### PR TITLE
add Travis-CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ SHIRASAGI
 
 SHIRASAGI is Contents Management System.
 
+[![Build Status](https://travis-ci.org/shirasagi/shirasagi.svg?branch=master)](https://travis-ci.org/shirasagi/shirasagi)
 [![Code Climate](https://codeclimate.com/github/shirasagi/shirasagi/badges/gpa.svg)](https://codeclimate.com/github/shirasagi/shirasagi)
 [![Coverage Status](https://coveralls.io/repos/shirasagi/shirasagi/badge.png)](https://coveralls.io/r/shirasagi/shirasagi)
 


### PR DESCRIPTION
Travis CI のビルドステータスを`README.md` に表示させます。
