### PR TITLE
add services item mongodb to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: ruby
 rvm: 2.1.2
 bundler_args: "--without development"
 before_script: "cp config/samples/* config/"
+services:
+  - mongodb


### PR DESCRIPTION
> MongoDB is not started on boot.

らしいので、`.travis.yml` の設定項目を追加してみました。
### Link
- [Travis CI: Databases and other services - MongoDB](http://docs.travis-ci.com/user/database-setup/#MongoDB)
