### PR TITLE
Update spring gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'simple_captcha2', require: 'simple_captcha'
 #gem "rails-dev-boost", git: "git://github.com/thedarkone/rails-dev-boost.git", group: :development
 
 group :development, :test do
-  gem 'spring'
+  gem 'spring', '~> 1.1.3'
   gem 'rspec'
   gem 'rspec-rails'
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,7 +242,7 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
-    spring (1.1.2)
+    spring (1.1.3)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -318,7 +318,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   simple_captcha2
-  spring
+  spring (~> 1.1.3)
   therubyracer (~> 0.10.2)
   thin
   turbolinks


### PR DESCRIPTION
gem Spirng の新しいバージョンが公開されていました。`1.1.2` から`1.1.3` に更新します。
### Link
- [Release v1.1.3 · rails/spring - GitHub](https://github.com/rails/spring/releases/tag/v1.1.3)
