### PR TITLE
rubocop: add exclude rule, bin directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   RunRailsCops: true
   Exclude:
     - Guardfile
+    - bin/*
 
 # Rails default check path
 Rails/DefaultScope:


### PR DESCRIPTION
Guard + RuboCop での利用時にbin ディレクトリまで検査対象になっていたので、それを除外します。
