### PR TITLE
update README.md add inch ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SHIRASAGI is Contents Management System.
 [![Code Climate](https://codeclimate.com/github/shirasagi/shirasagi/badges/gpa.svg)](https://codeclimate.com/github/shirasagi/shirasagi)
 [![Coverage Status](https://coveralls.io/repos/shirasagi/shirasagi/badge.png)](https://coveralls.io/r/shirasagi/shirasagi)
 [![GitHub version](https://badge.fury.io/gh/shirasagi%2Fshirasagi.svg)](http://badge.fury.io/gh/shirasagi%2Fshirasagi)
+[![Inline docs](http://inch-ci.org/github/shirasagi/shirasagi.png?branch=master)](http://inch-ci.org/github/shirasagi/shirasagi)
 
 Platform
 --------


### PR DESCRIPTION
Inch によってコード内のドキュメント記述度を可視化します。

GitHub の設定からWebhook を設定することで、CI サービスとして機能させることが出来ます。
### Links
- [Inch CI - Documentation badges for Ruby projects - Show off your docs](http://inch-ci.org/)
- [How to configure a webhook for Inch CI](http://inch-ci.org/howto/webhook)
