### PR TITLE
Exclude /vendor/bundle/**/* on rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - Guardfile
     - bin/*
+    - vendor/bundle/**/*
 
 # Rails default check path
 Rails/DefaultScope:


### PR DESCRIPTION
`vendor/bundle`にgemをインストールするとRubocopがそのディレクトリも走査してしまうので無視させる．
