### PR TITLE
Uploader::File#ext を File.extname を使うようリファクタリング

### DIFF
--- a/app/models/uploader/file.rb
+++ b/app/models/uploader/file.rb
@@ -61,11 +61,7 @@ class Uploader::File
     end
 
     def ext
-      if !directory? && path =~ /\./
-        ".#{path.sub(/^.*\./, '')}"
-      else
-        ""
-      end
+      File.extname(path)
     end
 
     def directory?


### PR DESCRIPTION
拡張子を取得したいのであれば，Rubyに標準で`File.extname`というメソッドがあります．
## 参考

http://docs.ruby-lang.org/ja/2.1.0/class/File.html#S_EXTNAME
