### PR TITLE
Fix sending mail fails

### DIFF
--- a/config/samples/mail.yml
+++ b/config/samples/mail.yml
@@ -1,4 +1,4 @@
-production:
+production: &production
   # smtp or sendmail
   delivery_method: sendmail
 


### PR DESCRIPTION
原因は samples/mail.yml の `*production` エイリアスに対応するアンカーが存在しないため。
app/mailers/application_mailer.rb#L6 の YAML.load_file でエラーとなるが、
begin .. rescue によって例外が破棄されてしまうため、結果 mail.yml がロードされない。
この状態でメールを送信すると以下のようなエラーが発生する。

```
Errno::ECONNREFUSED (Connection refused - connect(2) for "localhost" port 25):
  app/controllers/workflow/pages_controller.rb:59:in `block in request_update'
  app/controllers/workflow/pages_controller.rb:55:in `each'
  app/controllers/workflow/pages_controller.rb:55:in `request_update'
```

環境は nginx + unicorn, Ruby 2.1.2, SHIRASAGI v0.5.0, CentOS6.5 x86_64.
