### PR TITLE
add project and work files of IntelliJ IDEA & RubyMine to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 .DS_Store
 Thumbs.db
 ehthumbs.db
+
+# IntelliJ IDEA & RubyMine
+/*.iml
+/.idea/


### PR DESCRIPTION
IntelliJ IDEA と RubyMine のプロジェクトファイルとワークファイルを無視する設定を .gitignore に追加しました。

参考:
* https://www.gitignore.io/
* https://www.gitignore.io/api/intellij
