### PR TITLE
Fix video dose not play in IE9 or later

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,7 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register 'video/mp4', :mp4
+Mime::Type.register 'video/webm', :webm
+Mime::Type.register 'video/ogg', :ogv


### PR DESCRIPTION
`.mp4` や `.webm`, `.ogv` をコンテンツに埋め込むと IE9/10/11 では、"無効なソース" と表示され正しく再生されない。原因は CMS コンテンツの静的ファイルが `send_file` によってレスポンスされる際、未定義の拡張子のため ContentType が `application/octet-stream` にセットされるため（`send_file` の `:type` オプションの初期値は `application/octet-stream`）。
http://blogs.msdn.com/b/thebeebs/archive/2011/07/20/html5-video-not-working-in-ie9-some-tips-to-debug.aspx

なお、Chrome/Firefox/Safari では `application/octet-stream` でも問題なく再生される。

動画を埋め込む場合 `<video>` タグで `.mp4` や `.webm`, `.ogv` を使うのが一般的だと思うので SHIRASAGI で対応しておいても良いと思います。