### PR TITLE
[WIP PR] Study and Fix Travis Ci's UnprocessableEntity Error.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,1 @@
-service_name: travis-pro
-repo_token: 6cLkZ9kEzRY6Ezs20tIYbpn8XzZI78JON
+service_name: travis-ci


### PR DESCRIPTION
Travis Ci で次のようなエラーが発生しています。

```
Coveralls encountered an exception:
RestClient::UnprocessableEntity
422 Unprocessable Entity
/home/travis/.rvm/gems/ruby-2.1.2/gems/rest-client-1.7.2/lib/restclient/abstract_response.rb:48:in `return!'
/home/travis/.rvm/gems/ruby-2.1.2/gems/rest-client-1.7.2/lib/restclient/request.rb:495:in `process_result'
/home/travis/.rvm/gems/ruby-2.1.2/gems/rest-client-1.7.2/lib/restclient/request.rb:421:in `block in transmit'
/home/travis/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/net/http.rb:853:in `start'
/home/travis/.rvm/gems/ruby-2.1.2/gems/rest-client-1.7.2/lib/restclient/request.rb:413:in `transmit'
/home/travis/.rvm/gems/ruby-2.1.2/gems/rest-client-1.7.2/lib/restclient/request.rb:176:in `execute'
/home/travis/.rvm/gems/ruby-2.1.2/gems/rest-client-1.7.2/lib/restclient/request.rb:41:in `execute'
/home/travis/.rvm/gems/ruby-2.1.2/gems/rest-client-1.7.2/lib/restclient.rb:69:in `post'
/home/travis/.rvm/gems/ruby-2.1.2/gems/coveralls-0.7.1/lib/coveralls/api.rb:24:in `post_json'
/home/travis/.rvm/gems/ruby-2.1.2/gems/coveralls-0.7.1/lib/coveralls/simplecov.rb:72:in `format'
/home/travis/.rvm/gems/ruby-2.1.2/gems/simplecov-0.9.0/lib/simplecov/result.rb:46:in `format!'
/home/travis/.rvm/gems/ruby-2.1.2/gems/simplecov-0.9.0/lib/simplecov/configuration.rb:158:in `block in at_exit'
/home/travis/.rvm/gems/ruby-2.1.2/gems/simplecov-0.9.0/lib/simplecov/defaults.rb:54:in `call'
/home/travis/.rvm/gems/ruby-2.1.2/gems/simplecov-0.9.0/lib/simplecov/defaults.rb:54:in `block in <top (required)>'
{"message":"Couldn't find a repository matching this job.","error":true}
```

これの解決方法は不明で、調査が必要です。
本 Pull Request は調査を進めながら、上記のエラーの修正を目的としています。