### PR TITLE
Show Ezine::Page body (html and text) on public view

### DIFF
--- a/app/models/ezine/addon.rb
+++ b/app/models/ezine/addon.rb
@@ -9,6 +9,7 @@ module Ezine::Addon
       included do
         field :html, type: String, default: ""
         field :text, type: String, default: ""
+        permit_params :html, :text
       end
     end
   end

--- a/app/models/ezine/addon.rb
+++ b/app/models/ezine/addon.rb
@@ -1,0 +1,15 @@
+module Ezine::Addon
+  module Page
+    module Body
+      extend SS::Addon
+      extend ActiveSupport::Concern
+
+      set_order 300
+
+      included do
+        field :html, type: String, default: ""
+        field :text, type: String, default: ""
+      end
+    end
+  end
+end

--- a/app/models/ezine/page.rb
+++ b/app/models/ezine/page.rb
@@ -6,8 +6,6 @@ class Ezine::Page
   field :results, type: Array, default: []
   field :completed, type: Boolean, default: false
 
-  permit_params :results
-
   before_save :seq_filename, if: ->{ basename.blank? }
 
   default_scope ->{ where(route: "ezine/page") }

--- a/app/models/ezine/page.rb
+++ b/app/models/ezine/page.rb
@@ -1,12 +1,11 @@
 class Ezine::Page
   include Cms::Page::Model
   include Cms::Addon::Release
+  include Ezine::Addon::Page::Body
 
   seqid :id
   field :route, type: String, default: ->{ "ezine/page" }
   field :name, type: String
-  field :html, type: String, default: ""
-  field :text, type: String, default: ""
   field :results, type: Array, default: []
   field :completed, type: Boolean, default: false
 

--- a/app/models/ezine/page.rb
+++ b/app/models/ezine/page.rb
@@ -3,13 +3,10 @@ class Ezine::Page
   include Cms::Addon::Release
   include Ezine::Addon::Page::Body
 
-  seqid :id
-  field :route, type: String, default: ->{ "ezine/page" }
-  field :name, type: String
   field :results, type: Array, default: []
   field :completed, type: Boolean, default: false
 
-  permit_params :id, :route, :name, :html, :text, :results
+  permit_params :results
 
   before_save :seq_filename, if: ->{ basename.blank? }
 

--- a/app/views/ezine/agents/addons/page/body/_form.html.erb
+++ b/app/views/ezine/agents/addons/page/body/_form.html.erb
@@ -1,0 +1,33 @@
+<%= coffee do %>
+  $ ->
+    $('.ezine-convert-button').click ->
+      if (typeof tinymce != 'undefined')
+        text = convert_html_to_text tinymce.get('item_html').getContent()
+      else if (typeof CKEDITOR != 'undefined')
+        text = convert_html_to_text CKEDITOR.instances.item_html.getData()
+      else
+        text = ""
+
+      $('.ezine-page-text').val(text)
+
+  convert_html_to_text = (html) ->
+    html = html.replace(/<("[^"]*"|'[^']*'|[^'">])*>/g,'')
+    html = html.replace(/&quot;|&#34;/g, '"')
+    html = html.replace(/&apos;|&#39;/g, '\'')
+    html = html.replace(/&lt;|&#60;/g, '\<')
+    html = html.replace(/&gt;|&#62;/g, '\>')
+    html = html.replace(/&nbsp;|&#160;/g, ' ')
+<% end %>
+
+<%= html_editor ".ezine-page-html", height: "400px" %>
+
+<dl class="see mod-ezine-page-body">
+  <dt><%= @model.t :html %></dt>
+  <dd><%= f.text_area :html, class: "ezine-page-html", style: "height:400px;" %></dd>
+
+  <dt>&nbsp;</dt>
+  <dd><%= button_tag t("ezine.button.convert_html_to_text"), { type: :button, class: "ezine-convert-button" } %></dd>
+
+  <dt><%= @model.t :text %></dt>
+  <dd><%= f.text_area :text, class: "ezine-page-text", style: "height:400px;" %></dd>
+</dl>

--- a/app/views/ezine/agents/addons/page/body/_show.html.erb
+++ b/app/views/ezine/agents/addons/page/body/_show.html.erb
@@ -1,0 +1,14 @@
+<dl class="see mod-ezine-page-body">
+  <dd class="wide">
+    <% if @item.send(:html).present? %>
+    <%= html_editor "#mod-ezine-page-body", height: "400px", readonly: true %>
+    <%= text_area_tag "mod-ezine-page-body", @item.html, style: "height: 400px;" %>
+    <% end %>
+  </dd>
+  <dd class="wide">
+    <% if @item.send(:text).present? %>
+    <%= text_area_tag "mod-ezine-page-body", @item.text, style: "height: 400px;" %>
+    <% end %>
+  </dd>
+</dl>
+

--- a/app/views/ezine/agents/addons/page/body/view/index.html.erb
+++ b/app/views/ezine/agents/addons/page/body/view/index.html.erb
@@ -1,0 +1,9 @@
+<% if @cur_page.html.present? %>
+<article class="body">
+  <% if SS.config.cms.html_editor == "wiki" %>
+  <%== ::Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(@cur_page.html) %>
+  <% else %>
+  <%== @cur_page.html %>
+  <% end %>
+</article>
+<% end %>

--- a/app/views/ezine/agents/pages/page/index.html.erb
+++ b/app/views/ezine/agents/pages/page/index.html.erb
@@ -1,1 +1,5 @@
+<header class="released">
+  <time datetime="<%= I18n.l @cur_page.date.to_date, format: :iso %>"><%= I18n.l @cur_page.date.to_date, format: :long %></time>
+</header>
+
 <%= render file: "cms/agents/pages/page/index" %>

--- a/app/views/ezine/pages/_form.html.erb
+++ b/app/views/ezine/pages/_form.html.erb
@@ -1,39 +1,7 @@
-<%= coffee do %>
-  $ ->
-    $('.ezine-convert-button').click ->
-      if (typeof tinymce != 'undefined')
-        text = convert_html_to_text tinymce.get('item_html').getContent()
-      else if (typeof CKEDITOR != 'undefined')
-        text = convert_html_to_text CKEDITOR.instances.item_html.getData()
-      else
-        text = ""
-
-      $('.ezine-page-text').val(text)
-
-  convert_html_to_text = (html) ->
-    html = html.replace(/<("[^"]*"|'[^']*'|[^'">])*>/g,'')
-    html = html.replace(/&quot;|&#34;/g, '"')
-    html = html.replace(/&apos;|&#39;/g, '\'')
-    html = html.replace(/&lt;|&#60;/g, '\<')
-    html = html.replace(/&gt;|&#62;/g, '\>')
-    html = html.replace(/&nbsp;|&#160;/g, ' ')
-<% end %>
-
-<%= html_editor ".ezine-page-html", height: "180px" %>
-
 <dl class="ezine-form see">
   <dt><%= @model.t :name %></dt>
   <dd><%= f.text_field :name %></dd>
 
   <dt><%= @model.t :layout_id %><%= @model.tt :layout_id %></dt>
   <dd><%= f.select :layout_id, ancestral_layouts(@item.parent), include_blank: " " %></dd>
-
-  <dt><%= @model.t :html %></dt>
-  <dd><%= f.text_area :html, class: "ezine-page-html", style: "height:180px;" %></dd>
-
-  <dt>&nbsp;</dt>
-  <dd><%= button_tag t("ezine.button.convert_html_to_text"), { type: :button, class: "ezine-convert-button" } %></dd>
-
-  <dt><%= @model.t :text %></dt>
-  <dd><%= f.text_area :text, class: "ezine-page-text" %></dd>
 </dl>

--- a/app/views/ezine/pages/_show.html.erb
+++ b/app/views/ezine/pages/_show.html.erb
@@ -1,4 +1,9 @@
 <dl class="see">
   <dt><%= @model.t :name %></dt>
   <dd><%= @item.send :name %></dd>
+
+  <% if @item.send(:layout_id).present? %>
+  <dt><%= @model.t :layout_id %></dt>
+  <dd><%= tryb{@item.layout.name} %></dd>
+  <% end %>
 </dl>

--- a/app/views/ezine/pages/_show.html.erb
+++ b/app/views/ezine/pages/_show.html.erb
@@ -1,10 +1,4 @@
 <dl class="see">
   <dt><%= @model.t :name %></dt>
   <dd><%= @item.send :name %></dd>
-
-  <dt><%= @model.t :html %></dt>
-  <dd><%= @item.send :html %></dd>
-
-  <dt><%= @model.t :text %></dt>
-  <dd><%= @item.send :text %></dd>
 </dl>

--- a/config/locales/ezine/ja.yml
+++ b/config/locales/ezine/ja.yml
@@ -27,6 +27,8 @@ ja:
 
   modules:
     ezine: メールマガジン
+    addons:
+      ezine/page/body: 本文
 
   cms:
     nodes:


### PR DESCRIPTION
#131 の

> ・記事詳細画面
> 　本文が表示されません。

に対応しつつ，`Ezine::Page` の body 的である部分，`html` フィールドと `text` フィールドを `Ezine::Addon::Page::Body` に切り出し，view も分割しました．