### PR TITLE
fix unicorn startup file

### DIFF
--- a/bin/unicorn.sh
+++ b/bin/unicorn.sh
@@ -17,8 +17,12 @@ for APP in ${APPS[@]}; do
   start()
   {
     if [ -e $PID ]; then
-      echo "$NAME already started"
-      exit 1
+      if ! ps `cat ${PID}`|grep "unicorn master">/dev/null 2>&1; then
+        rm -f ${PID}
+      else
+        echo "$NAME already started"
+        exit 1
+      fi
     fi
     echo "start $NAME"
     cd $APP


### PR DESCRIPTION
bin/unicorn.shでユニコーン起動時に、tmp/pids/unicorn.pid が残っている場合に起動しない現象に対応。
unicorn.pidが存在する場合、ファイルに記録されているpidのunicorn masterプロセスを確認し、
プロセスが存在しない場合は、同ファイルを削除し起動を行う対応としました。
