### PR TITLE
Refactor Ezine::Page#deliver_to argument

### DIFF
--- a/app/models/ezine/member.rb
+++ b/app/models/ezine/member.rb
@@ -8,4 +8,9 @@ class Ezine::Member
   belongs_to :node, class_name: "Cms::Node"
 
   validates :email, uniqueness: { scope: :node_id }, presence: true, email: true
+
+  public
+    def test_member?
+      false
+    end
 end

--- a/app/models/ezine/page.rb
+++ b/app/models/ezine/page.rb
@@ -44,21 +44,16 @@ class Ezine::Page
     # 成功しかつテスト配信でなければ配信ログを作成する。
     #
     # @param [Ezine::Member, Ezine::TestMember] member
-    # @param [true, false] is_test
-    #
-    #   Test delivery or not. (default: false)
-    #
-    #   テスト配信であるかどうか。(デフォルト: false)
     #
     # @raise [Object]
     #   An error object from `ActionMailer#deliver`
     #
     #   `ActionMailer#deliver` メソッドからのエラーオブジェクト
-    def deliver_to(member, is_test: false)
+    def deliver_to(member)
       Ezine::Mailer.page_mail(self, member).deliver
       Ezine::SentLog.create(
         node_id: parent.id, page_id: id, email: member.email
-      ) unless is_test
+      ) unless member.test_member?
     end
 
     # Do a test delivery.
@@ -66,7 +61,7 @@ class Ezine::Page
     # テスト配信を行う。
     def deliver_to_test_members
       Ezine::TestMember.all.each do |test_member|
-        deliver_to test_member, is_test: true
+        deliver_to test_member
       end
     end
 

--- a/app/models/ezine/test_member.rb
+++ b/app/models/ezine/test_member.rb
@@ -17,4 +17,8 @@ class Ezine::TestMember
     def email_type_options
       [%w(テキスト版 text), %w(HTML版 html)]
     end
+
+    def test_member?
+      true
+    end
 end


### PR DESCRIPTION
Refactor `Ezine::Page#deliver_to` argument specification.

## Comments from other developers

```
・コードレビュー：
　deliver_to メソッド、引数渡しで分岐している点を要検討
```

ref. https://www.facebook.com/groups/ssproj/permalink/821120054628656/

`is_test` という引数で判断はオブジェクト指向的にはどうなの？