### PR TITLE
Fix for Ruby 2.2.0

### DIFF
--- a/config/initializers/ss/rb_config.rb
+++ b/config/initializers/ss/rb_config.rb
@@ -1,3 +1,3 @@
 #> Use RbConfig instead of obsolete and deprecated Config.
-Object.send :remove_const, :Config
+Object.send :remove_const, :Config if defined? Object::Config
 Config = RbConfig


### PR DESCRIPTION
Remove `Config` constant only when it is defined.

Fix the following error

```
config/initializers/ss/rb_config.rb:2:in `remove_const': constant Object::Config not defined (NameError)
```

Ruby 2.2.0 で動かそうとした場合に発生するエラーに対処するためだけのコードです．テストをTravisCI先生に見てもらいたいのでPR作ってみます．

## Reference

http://stackoverflow.com/questions/10171978/check-if-a-constant-is-already-defined