### PR TITLE
Fix ezine management view

### DIFF
--- a/app/controllers/ezine/members_controller.rb
+++ b/app/controllers/ezine/members_controller.rb
@@ -1,5 +1,6 @@
 class Ezine::MembersController < ApplicationController
   include Cms::BaseFilter
+  include Cms::CrudFilter
 
   model Ezine::Member
 
@@ -7,7 +8,7 @@ class Ezine::MembersController < ApplicationController
 
   private
     def fix_params
-      { cur_user: @cur_user, cur_site: @cur_site, cur_node: @cur_node }
+      { cur_user: @cur_user, cur_site: @cur_site, node_id: @cur_node.id }
     end
 
   public
@@ -18,5 +19,9 @@ class Ezine::MembersController < ApplicationController
         search(params[:s]).
         order_by(updated: -1).
         page(params[:page]).per(50)
+    end
+
+    def new
+      @item = Ezine::Member.new(site_id: @cur_site.id, node_id: @cur_node.id)
     end
 end

--- a/app/controllers/ezine/members_controller.rb
+++ b/app/controllers/ezine/members_controller.rb
@@ -15,6 +15,7 @@ class Ezine::MembersController < ApplicationController
       raise "403" unless @cur_node.allowed?(:read, @cur_user, site: @cur_site)
       @items = @model.site(@cur_site).
         where(node_id: @cur_node.id).
+        search(params[:s]).
         order_by(updated: -1).
         page(params[:page]).per(50)
     end

--- a/app/controllers/ezine/pages_controller.rb
+++ b/app/controllers/ezine/pages_controller.rb
@@ -76,10 +76,4 @@ class Ezine::PagesController < ApplicationController
         order_by(created: -1).
         page(params[:page]).per(50)
     end
-
-    def preview_text
-      load_pages
-      item = @items.find(params[:id])
-      render text: item.text.gsub(/\r\n|\r|\n/, "<br />")
-    end
 end

--- a/app/controllers/ezine/test_members_controller.rb
+++ b/app/controllers/ezine/test_members_controller.rb
@@ -16,6 +16,7 @@ class Ezine::TestMembersController < ApplicationController
       raise "403" unless @cur_node.allowed?(:read, @cur_user, site: @cur_site)
       @items = @model.site(@cur_site).
         where(node_id: @cur_node.id).
+        search(params[:s]).
         order_by(updated: -1).
         page(params[:page]).per(50)
     end

--- a/app/models/ezine/member.rb
+++ b/app/models/ezine/member.rb
@@ -1,6 +1,7 @@
 class Ezine::Member
   include SS::Document
   include SS::Reference::Site
+  include Ezine::MemberSearchable
 
   field :email, type: String, metadata: { from: :email }
   field :email_type, type: String

--- a/app/models/ezine/member.rb
+++ b/app/models/ezine/member.rb
@@ -1,16 +1,29 @@
 class Ezine::Member
   include SS::Document
+  include SS::Reference::User
   include SS::Reference::Site
+  include Cms::Permission
   include Ezine::MemberSearchable
 
   field :email, type: String, metadata: { from: :email }
   field :email_type, type: String
+  field :state, type: Boolean, default: true
+
+  permit_params :email, :email_type, :state
 
   belongs_to :node, class_name: "Cms::Node"
 
   validates :email, uniqueness: { scope: :node_id }, presence: true, email: true
 
   public
+    def email_type_options
+      [%w(テキスト版 text), %w(HTML版 html)]
+    end
+
+    def state_options
+      [%w(有効 true), %w(無効 false)]
+    end
+
     def test_member?
       false
     end

--- a/app/models/ezine/member.rb
+++ b/app/models/ezine/member.rb
@@ -14,6 +14,8 @@ class Ezine::Member
   belongs_to :node, class_name: "Cms::Node"
 
   validates :email, uniqueness: { scope: :node_id }, presence: true, email: true
+  validates :email_type, inclusion: { in: %w(text html) }
+  validates :state, inclusion: { in: [true, false] }
 
   public
     def email_type_options

--- a/app/models/ezine/member_searchable.rb
+++ b/app/models/ezine/member_searchable.rb
@@ -1,0 +1,15 @@
+module Ezine::MemberSearchable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def search(params)
+      criteria = self.where({})
+      return criteria if params.blank?
+
+      if params[:keyword].present?
+        criteria = criteria.keyword_in params[:keyword], :email
+      end
+      criteria
+    end
+  end
+end

--- a/app/models/ezine/page.rb
+++ b/app/models/ezine/page.rb
@@ -32,7 +32,7 @@ class Ezine::Page
     def members_to_deliver
       return [] if completed
       emails = Ezine::SentLog.where(page_id: id).map(&:email)
-      Ezine::Member.where(node_id: parent.id, email: {"$nin" => emails})
+      Ezine::Member.where(state: true, node_id: parent.id, email: {"$nin" => emails})
     end
 
     # Deliver a mail to a member.

--- a/app/models/ezine/test_member.rb
+++ b/app/models/ezine/test_member.rb
@@ -3,6 +3,7 @@ class Ezine::TestMember
   include SS::Reference::User
   include SS::Reference::Site
   include Cms::Permission
+  include Ezine::MemberSearchable
 
   field :email, type: String, metadata: { from: :email }
   field :email_type, type: String

--- a/app/views/ezine/members/_delete.html.erb
+++ b/app/views/ezine/members/_delete.html.erb
@@ -1,0 +1,1 @@
+<%= render "show" %>

--- a/app/views/ezine/members/_form.html.erb
+++ b/app/views/ezine/members/_form.html.erb
@@ -1,0 +1,14 @@
+<dl class="ezine-form see">
+  <dt><%= @model.t :email %></dt>
+  <dd><%= f.text_field :email %></dd>
+
+  <dt><%= @model.t :email_type %></dt>
+  <dd>
+  <% @item.email_type_options.each do |email_type| %>
+    <%= f.radio_button :email_type, email_type[1] %><%= email_type[0] %>
+  <% end %>
+  </dd>
+
+  <dt><%= @model.t :state %></dt>
+  <dd><%= f.check_box :state %><%= t("ezine.state.enable") %></dd>
+</dl>

--- a/app/views/ezine/members/_menu.html.erb
+++ b/app/views/ezine/members/_menu.html.erb
@@ -1,0 +1,28 @@
+<nav class="act-menu">
+  <% if params[:action] =~ /index/ %>
+    <% if @model.allowed?(:edit, @cur_user, site: @cur_site, node: @cur_node) %>
+      <%= link_to :new, action: :new %>
+    <% end %>
+  <% elsif params[:action] =~ /new|create/ %>
+    <%= link_to :back_to_index, action: :index %>
+  <% elsif params[:action] =~ /edit|update|delete/ %>
+    <% if @item.allowed?(:read, @cur_user, site: @cur_site, node: @cur_node) %>
+      <%= link_to :back_to_show, action: :show, id: @item %>
+    <% end %>
+    <%= link_to :back_to_index, action: :index %>
+  <% else %>
+    <% if @item.allowed?(:edit, @cur_user, site: @cur_site, node: @cur_node) %>
+      <%= link_to :edit, action: :edit, id: @item %>
+    <% end %>
+    <% if @item.allowed?(:delete, @cur_user, site: @cur_site, node: @cur_node) %>
+      <%= link_to :delete, action: :delete, id: @item %>
+    <% end %>
+    <%# <%= link_to :"cms.view_page", @item.url, target: :_blank if @item.public? %>
+
+    <%= link_to :back_to_index, action: :index %>
+  <% end %>
+</nav>
+
+<% if params[:action] =~ /new|edit|create|update/ %>
+<%= render file: "_addons_menu" %>
+<% end %>

--- a/app/views/ezine/members/_show.html.erb
+++ b/app/views/ezine/members/_show.html.erb
@@ -1,0 +1,10 @@
+<dl class="see">
+   <dt><%= @model.t :email %></dt>
+   <dd><%= @item.email %></dd>
+
+   <dt><%= @model.t :email_type %></dt>
+   <dd><%= @item.email_type %></dd>
+
+   <dt><%= @model.t :state %></dt>
+   <dd><%= @item.state ? t("ezine.state.enable") : t("ezine.state.disable") %></dd>
+</dl>

--- a/app/views/ezine/members/index.html.erb
+++ b/app/views/ezine/members/index.html.erb
@@ -3,8 +3,10 @@
 <table class="index">
   <thead>
     <tr>
+      <th style="width: 20px;"><input type="checkbox" /></th>
       <th><%= @model.t :email %></th>
       <th><%= @model.t :email_type %></th>
+      <th><%= @model.t :state %></th>
       <th class="datetime"><%= @model.t :updated %></th>
     </tr>
   </thead>
@@ -12,8 +14,17 @@
   <tbody>
     <% @items.each do |item| %>
     <tr>
-      <td><%= item.email %></td>
+      <td>
+        <input type="checkbox" name="ids[]" value="<%= item.id %>" />
+        <nav class="tap-menu">
+          <%= link_to :show, action: :show, id: item if @cur_node.allowed?(:read, @cur_user, site: @cur_site) %>
+          <%= link_to :edit, action: :edit, id: item if @cur_node.allowed?(:edit, @cur_user, site: @cur_site) %>
+          <%= link_to :delete, action: :delete, id: item if @cur_node.allowed?(:edit, @cur_user, site: @cur_site) %>
+        </nav>
+      </td>
+      <td><%= link_to item.email, { action: :show, id: item } %></td>
       <td><%= item.email_type %></td>
+      <td><%= item.state ? t("ezine.state.enable") : t("ezine.state.disable") %></td>
       <td><%= item.updated.strftime("%Y/%m/%d %H:%M") %></td>
     </tr>
     <% end %>

--- a/app/views/ezine/members/index.html.erb
+++ b/app/views/ezine/members/index.html.erb
@@ -1,3 +1,5 @@
+<%= render file: "app/views/ss/crud/_search" %>
+
 <table class="index">
   <thead>
     <tr>

--- a/app/views/ezine/pages/index.html.erb
+++ b/app/views/ezine/pages/index.html.erb
@@ -3,6 +3,7 @@
     <tr>
       <th style="width: 20px;"><input type="checkbox" /></th>
       <th><%= @model.t :name %></th>
+      <th><%= @model.t :results %></th>
       <th class="datetime"><%= @model.t :updated %></th>
     </tr>
   </thead>
@@ -19,6 +20,7 @@
         </nav>
       </td>
       <td><%= link_to item.name, { action: :show, id: item }, class: "icon-page" %></td>
+      <td><%= item.results[0].strftime("%Y/%m/%d %H:%M") unless item.results[0].nil? %></td>
       <td><%= item.updated.strftime("%Y/%m/%d %H:%M") %></td>
     </tr>
     <% end %>

--- a/app/views/ezine/test_members/index.html.erb
+++ b/app/views/ezine/test_members/index.html.erb
@@ -1,3 +1,5 @@
+<%= render file: "app/views/ss/crud/_search" %>
+
 <table class="index">
   <thead>
     <tr>

--- a/config/locales/ezine/ja.yml
+++ b/config/locales/ezine/ja.yml
@@ -46,6 +46,7 @@ ja:
         name: 記事タイトル
         html: 本文（HTML版）
         text: 本文（テキスト版）
+        results: 配信開始日時
       ezine/member:
         email: メールアドレス
         email_type: 配信形式

--- a/config/locales/ezine/ja.yml
+++ b/config/locales/ezine/ja.yml
@@ -18,6 +18,9 @@ ja:
     notice:
       delivered: 配信を開始しました
       delivered_test: テスト配信を完了しました
+    state:
+      enable: 配信する
+      disable: 配信しない
 
   modules:
     ezine: メールマガジン
@@ -50,6 +53,7 @@ ja:
       ezine/member:
         email: メールアドレス
         email_type: 配信形式
+        state: 配信状態
       ezine/test_member:
         email: メールアドレス
         email_type: 配信形式

--- a/config/locales/ezine/ja.yml
+++ b/config/locales/ezine/ja.yml
@@ -4,8 +4,6 @@ ja:
     member: メルマガ読者
     test_member: テスト読者
     entry: 登録履歴
-    preview_html: HTML版プレビュー
-    preview_text: テキスト版プレビュー
     deliver_test: テスト配信
     deliver: 本配信
     sent_log: 配信ログ

--- a/config/routes/ezine/routes.rb
+++ b/config/routes/ezine/routes.rb
@@ -12,7 +12,6 @@ SS::Application.routes.draw do
       get :delivery_confirmation, on: :member
       get :delivery_test_confirmation, on: :member
       get :sent_logs, on: :member
-      get :preview_text, on: :member
       post :delivery, on: :member
       post :delivery_test, on: :member
     end


### PR DESCRIPTION
* Add search function to `Ezine::Member` and `Ezine::Testmember`
* Remove `preview_text` method
* Add deliver start time in `ezine/pages/index`
* Modify `Ezine::Member` to editable
* Add `state` field
* Add its views and locales
* Fix `Ezine::Page#members_to_deliver`
* Add validations of `email_type` and `state`

For #195 following issues.

> 管理画面からメルマガ読者を削除（無効）にできるようにしてください。
> エラーメールなどを確認して削除したいのと、管理者が削除したことがわかるよ
> うにしたいです。
> 削除するため、検索機能をつけてください。

and

> 本配信の履歴がわかるようにしてください。
> 一覧で、いつ配信したかわかるようにしてください。


