### PR TITLE
Add test_delivered to Ezine::Page

### DIFF
--- a/app/models/ezine/page.rb
+++ b/app/models/ezine/page.rb
@@ -4,6 +4,7 @@ class Ezine::Page
   include Cms::Addon::ReleasePlan
   include Ezine::Addon::Page::Body
 
+  field :test_delivered, type: DateTime
   field :results, type: Array, default: []
   field :completed, type: Boolean, default: false
 
@@ -63,6 +64,7 @@ class Ezine::Page
       Ezine::TestMember.where(node_id: parent.id).each do |test_member|
         deliver_to test_member
       end
+      update test_delivered: Time.now
     end
 
   private

--- a/app/views/ezine/pages/index.html.erb
+++ b/app/views/ezine/pages/index.html.erb
@@ -3,6 +3,7 @@
     <tr>
       <th style="width: 20px;"><input type="checkbox" /></th>
       <th><%= @model.t :name %></th>
+      <th><%= @model.t :test_delivered %></th>
       <th><%= @model.t :results %></th>
       <th class="datetime"><%= @model.t :updated %></th>
     </tr>
@@ -20,6 +21,7 @@
         </nav>
       </td>
       <td><%= link_to item.name, { action: :show, id: item }, class: "icon-page" %></td>
+      <td><%= item.test_delivered.strftime("%Y/%m/%d %H:%M") unless item.test_delivered.nil? %></td>
       <td><%= item.results[0].strftime("%Y/%m/%d %H:%M") unless item.results[0].nil? %></td>
       <td><%= item.updated.strftime("%Y/%m/%d %H:%M") %></td>
     </tr>

--- a/config/locales/ezine/ja.yml
+++ b/config/locales/ezine/ja.yml
@@ -49,6 +49,7 @@ ja:
         name: 記事タイトル
         html: 本文（HTML版）
         text: 本文（テキスト版）
+        test_delivered: テスト配信完了日時
         results: 配信開始日時
       ezine/member:
         email: メールアドレス


### PR DESCRIPTION
To show test delivery log datetime in management views.

For the below issue of #195.

> テスト配信の履歴がわかるようにしてください。