### PR TITLE
fix: link to root in preview

### DIFF
--- a/app/controllers/cms/preview_controller.rb
+++ b/app/controllers/cms/preview_controller.rb
@@ -44,7 +44,7 @@ class Cms::PreviewController < ApplicationController
         url = m.match(/.*?="(.*?)"/)[1]
         if url =~ /^\/(assets|assets-dev)\//
           m
-        elsif url =~ /^\/[^\/]/
+        elsif url =~ /^\/(?!\/)/
           m.sub(/="/, "=\"#{preview_url}")
         else
           m


### PR DESCRIPTION
プレビュー表示にてサイトトップのリンクが公開画面になってしまう #243