### PR TITLE
refactor helper rspec

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,17 +1,14 @@
 require 'spec_helper'
 
-describe ApplicationHelper do
-  include ActionView::Helpers
-  include ApplicationHelper
-
+describe ApplicationHelper, type: :helper do
   describe ".mail_to_entity" do
     context "when only email address is given" do
-      subject { mail_to_entity("test@example.jp") }
+      subject { helper.mail_to_entity("test@example.jp") }
       it { is_expected.to eq '<a href="mailto:test&#64;example&#46;jp">test&#64;example&#46;jp</a>' }
     end
 
     context "when email address and name is given" do
-      subject { mail_to_entity("test@example.jp", "テスト") }
+      subject { helper.mail_to_entity("test@example.jp", "テスト") }
       it { is_expected.to eq '<a href="mailto:test&#64;example&#46;jp">テスト</a>' }
     end
   end

--- a/spec/helpers/event/event_helper_spec.rb
+++ b/spec/helpers/event/event_helper_spec.rb
@@ -1,45 +1,41 @@
 require 'spec_helper'
 require 'timecop'
 
-include Event::EventHelper
+describe Event::EventHelper, type: :helper do
 
-def date_when(date_opts = {})
-  return Date.current if date_opts.empty?
-  Date.current.change(date_opts)
-end
-
-describe Event::EventHelper do
+  def date_when(date_opts = {})
+    return Date.current if date_opts.empty?
+    Date.current.change(date_opts)
+  end
 
   before { Timecop.freeze(date_when(year: 2014, month: 9, day: 14)) }
-
-  subject { Event::EventHelper }
 
   context '#within_one_year?' do
     it 'given current date returns true' do
       date = Date.current # 2014/09/14
-      expect(subject.within_one_year?(date)).to eq true
+      expect(helper.within_one_year?(date)).to eq true
     end
 
     # start_date
     it 'given 2013/12/31 returns true' do
       date = date_when(year: 2013, month: 12, day: 31)
-      expect(subject.within_one_year?(date)).to eq true
+      expect(helper.within_one_year?(date)).to eq true
     end
 
     it 'given 2012/12/30 returns false' do
       date = date_when(year: 2012, month: 12, day: 30)
-      expect(subject.within_one_year?(date)).to eq false
+      expect(helper.within_one_year?(date)).to eq false
     end
 
     # close_date
     it 'given 2015/09/01 returns true' do
       date = date_when(year: 2015, month: 9, day: 1)
-      expect(subject.within_one_year?(date)).to eq true
+      expect(helper.within_one_year?(date)).to eq true
     end
 
     it 'given 2015/09/02 returns false' do
       date = date_when(year: 2015, month: 10, day: 2)
-      expect(subject.within_one_year?(date)).to eq false
+      expect(helper.within_one_year?(date)).to eq false
     end
   end
 


### PR DESCRIPTION
refactor helper rspec by specifying `type: :helper` which enables rspec-rails's extensions.