### PR TITLE
Migration for #344

### DIFF
--- a/app/models/ss/migration.rb
+++ b/app/models/ss/migration.rb
@@ -1,4 +1,8 @@
 class SS::Migration
+  include Mongoid::Document
+
+  field :version, type: String
+
   DIR = Rails.root.join('lib/migrations')
 
   class << self
@@ -27,6 +31,18 @@ class SS::Migration
     #   #  '/foo/bar/lib/migrations/mod2/20150324000003_a.rb',]
     def filepaths
       ::Dir.glob(DIR.join('*/*')).sort_by { |i| File.basename i }
+    end
+
+    # Returns the latest applied migration version string.
+    # If there is no applied migration, it returns "00000000000000".
+    #
+    # @return [String] The latest applied migration version string or "00000000000000".
+    #
+    # @example
+    #   SS::Migration.latest_version #=> '20150330000000'
+    def latest_version
+      x = order(version: -1).limit(1).first
+      x.nil? ? '00000000000000' : x.version
     end
   end
 end

--- a/app/models/ss/migration.rb
+++ b/app/models/ss/migration.rb
@@ -57,5 +57,14 @@ class SS::Migration
     def take_timestamp(filepath)
       File.basename(filepath).split('_')[0]
     end
+
+    # Return the all filepath of migrations to apply.
+    #
+    # It is a sub array of *filepaths* method.
+    #
+    # @return [Array<String>] An array of filepath of migrations to apply.
+    def filepaths_to_apply
+      filepaths.select { |e| take_timestamp(e) > latest_version }
+    end
   end
 end

--- a/app/models/ss/migration.rb
+++ b/app/models/ss/migration.rb
@@ -44,5 +44,18 @@ class SS::Migration
       x = order(version: -1).limit(1).first
       x.nil? ? '00000000000000' : x.version
     end
+
+    # Take a timestamp from a filepath.
+    #
+    # @param [String] filepath
+    #
+    # @return [String] timestamp
+    #
+    # @example
+    #   SS::Migration.take_timestamp '/foo/bar/lib/migrations/mod1/20150330000000_a.rb'
+    #   #=> '20150330000000'
+    def take_timestamp(filepath)
+      File.basename(filepath).split('_')[0]
+    end
   end
 end

--- a/app/models/ss/migration.rb
+++ b/app/models/ss/migration.rb
@@ -6,6 +6,17 @@ class SS::Migration
   DIR = Rails.root.join('lib/migrations')
 
   class << self
+    # Do migration.
+    def migrate
+      filepaths_to_apply.each do |filepath|
+        timestamp = take_timestamp filepath
+        require filepath
+        "SS::Migration#{timestamp}".constantize.new.change
+        create version: timestamp
+        puts "Applied SS::Migration#{timestamp}"
+      end
+    end
+
     # Return the all filepaths in *RAILS_ROOT/lib/migrations/**.
     #
     # Returned array is sorted ascending by the filename.

--- a/app/models/ss/migration.rb
+++ b/app/models/ss/migration.rb
@@ -1,0 +1,32 @@
+class SS::Migration
+  DIR = Rails.root.join('lib/migrations')
+
+  class << self
+    # Return the all filepaths in *RAILS_ROOT/lib/migrations/**.
+    #
+    # Returned array is sorted ascending by the filename.
+    #
+    # @return [Array<String>] An array of sorted filepathe strings.
+    #
+    # @example It returns an array of filepath strings.
+    #   # Directory structure
+    #
+    #   # + /foo/bar/lib/migrations/
+    #   #   + mod1/
+    #   #     - 20150324000001_a.rb
+    #   #     - 20150324000002_a.rb
+    #   #   + mod2/
+    #   #     - 20150324000000_a.rb
+    #   #     - 20150324000003_a.rb
+    #
+    #   SS::Migration.filepaths
+    #   #=>
+    #   # ['/foo/bar/lib/migrations/mod2/20150324000000_a.rb',
+    #   #  '/foo/bar/lib/migrations/mod1/20150324000001_a.rb',
+    #   #  '/foo/bar/lib/migrations/mod1/20150324000002_a.rb',
+    #   #  '/foo/bar/lib/migrations/mod2/20150324000003_a.rb',]
+    def filepaths
+      ::Dir.glob(DIR.join('*/*')).sort_by { |i| File.basename i }
+    end
+  end
+end

--- a/lib/migrations/ezine/20150408081234_enable_member_state.rb
+++ b/lib/migrations/ezine/20150408081234_enable_member_state.rb
@@ -1,0 +1,7 @@
+class SS::Migration20150408081234
+  def change
+    Ezine::Member.where(state: nil).each do |member|
+      member.update state: 'enabled'
+    end
+  end
+end

--- a/lib/migrations/ezine/20150423044546_update_results.rb
+++ b/lib/migrations/ezine/20150423044546_update_results.rb
@@ -2,6 +2,7 @@ class SS::Migration20150423044546
   def change
     Ezine::Page.all.each do |page|
       results = page[:results]
+      next if results.nil?
       next if results.empty?
       next if results.first.instance_of? Ezine::Result
 

--- a/lib/migrations/ezine/20150423044546_update_results.rb
+++ b/lib/migrations/ezine/20150423044546_update_results.rb
@@ -1,0 +1,20 @@
+class SS::Migration20150423044546
+  def change
+    Ezine::Page.all.each do |page|
+      results = page[:results]
+      next if results.empty?
+      next if results.first.instance_of? Ezine::Result
+
+      page.unset :results
+      results
+        .group_by.with_index { |e, i| i / 3 }.values
+        .each do |result|
+          page.results.create(
+            started: result[0],
+            delivered: result[1],
+            count: result[2]
+          )
+        end
+    end
+  end
+end

--- a/lib/tasks/ss/migrate.rake
+++ b/lib/tasks/ss/migrate.rake
@@ -1,0 +1,5 @@
+namespace :ss do
+  task :migrate => :environment do
+    SS::Migration.migrate
+  end
+end

--- a/spec/factories/ezine/member.rb
+++ b/spec/factories/ezine/member.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :ezine_member, class: Ezine::Member do
+    sequence(:email) { |n| "#{n}@example.jp" }
+    email_type "text"
+    state "enabled"
+    site_id { cms_site.id }
+  end
+end

--- a/spec/factories/ezine/page.rb
+++ b/spec/factories/ezine/page.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :ezine_page, class: Ezine::Page do
+    site_id { cms_site.id }
+    user_id { cms_user.id }
+    name 'title'
+    filename 'magazine/1'
+    test_delivered nil
+    completed false
+  end
+end

--- a/spec/factories/ss/migrations.rb
+++ b/spec/factories/ss/migrations.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :ss_migration, class: SS::Migration do
+  end
+end

--- a/spec/lib/ss/migrations/20150408081234_enable_member_state_spec.rb
+++ b/spec/lib/ss/migrations/20150408081234_enable_member_state_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require Rails.root.join('lib/migrations/ezine/20150408081234_enable_member_state.rb')
+
+RSpec.describe SS::Migration20150408081234, dbscope: :example do
+  before do
+    member = create :ezine_member
+    member.unset :state
+  end
+
+  it do
+    expect { described_class.new.change }
+      .to change { Ezine::Member.enabled.count }.by 1
+  end
+end

--- a/spec/lib/ss/migrations/20150423044546_update_results_spec.rb
+++ b/spec/lib/ss/migrations/20150423044546_update_results_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require Rails.root.join('lib/migrations/ezine/20150423044546_update_results.rb')
+
+RSpec.describe SS::Migration20150423044546, dbscope: :example do
+  let(:started) { Time.zone.now }
+  let(:delivered) { started + 1 }
+
+  before do
+    x = create :ezine_page
+    @id = x.id
+    x[:results] = [started, delivered, 1]
+    x.save
+  end
+
+  let(:page) { Ezine::Page.find @id }
+
+  it { expect(page[:results]).to be_kind_of Array }
+
+  context "after migration" do
+    before { described_class.new.change }
+
+    let(:result) { page.results.first }
+
+    it { expect(result.started).to eq_as_time started }
+    it { expect(result.delivered).to eq_as_time delivered }
+  end
+end

--- a/spec/lib/ss/migrations/20150423044546_update_results_spec.rb
+++ b/spec/lib/ss/migrations/20150423044546_update_results_spec.rb
@@ -2,26 +2,55 @@ require 'spec_helper'
 require Rails.root.join('lib/migrations/ezine/20150423044546_update_results.rb')
 
 RSpec.describe SS::Migration20150423044546, dbscope: :example do
-  let(:started) { Time.zone.now }
-  let(:delivered) { started + 1 }
+  context "1 result" do
+    let(:started) { Time.zone.now }
+    let(:delivered) { started + 1 }
 
-  before do
-    x = create :ezine_page
-    @id = x.id
-    x[:results] = [started, delivered, 1]
-    x.save
+    before do
+      x = create :ezine_page
+      @id = x.id
+      x[:results] = [started, delivered, 1]
+      x.save
+    end
+
+    let(:page) { Ezine::Page.find @id }
+
+    it { expect(page[:results]).to be_kind_of Array }
+
+    context "after migration" do
+      before { described_class.new.change }
+
+      let(:result) { page.results.first }
+
+      it { expect(result.started).to eq_as_time started }
+      it { expect(result.delivered).to eq_as_time delivered }
+    end
   end
 
-  let(:page) { Ezine::Page.find @id }
+  context "2 results" do
+    let(:started1) { Time.zone.now }
+    let(:delivered1) { started1 + 1 }
+    let(:started2) { delivered1 + 1 }
+    let(:delivered2) { started2 + 1 }
 
-  it { expect(page[:results]).to be_kind_of Array }
+    before do
+      x = create :ezine_page
+      @id = x.id
+      x[:results] = [started1, delivered1, 1, started2, delivered2, 2]
+      x.save
+      described_class.new.change
+    end
 
-  context "after migration" do
-    before { described_class.new.change }
+    let(:page) { Ezine::Page.find @id }
+    let(:result1) { page.results[0] }
+    let(:result2) { page.results[1] }
 
-    let(:result) { page.results.first }
-
-    it { expect(result.started).to eq_as_time started }
-    it { expect(result.delivered).to eq_as_time delivered }
+    it { expect(page.results.count).to eq 2 }
+    it { expect(result1.started).to eq_as_time started1 }
+    it { expect(result1.delivered).to eq_as_time delivered1 }
+    it { expect(result1.count).to eq_as_time 1 }
+    it { expect(result2.started).to eq_as_time started2 }
+    it { expect(result2.delivered).to eq_as_time delivered2 }
+    it { expect(result2.count).to eq_as_time 2 }
   end
 end

--- a/spec/models/ss/migration_spec.rb
+++ b/spec/models/ss/migration_spec.rb
@@ -49,4 +49,35 @@ RSpec.describe SS::Migration, type: :model, dbscope: :example do
       /.*\/mod2\/20150324000003_a\.rb$/,
     ] }
   end
+
+  describe '.latest_version' do
+    subject { described_class.latest_version }
+
+    context 'no version exists' do
+      it { is_expected.to eq '00000000000000' }
+    end
+
+    context '1 version exists' do
+      before { create :ss_migration, version: '20150324000001' }
+      it { is_expected.to eq '20150324000001' }
+    end
+
+    context '2 versions exist' do
+      before do
+        create :ss_migration, version: '20150324000000'
+        create :ss_migration, version: '20150324000001'
+      end
+
+      it { is_expected.to eq '20150324000001' }
+    end
+
+    context '2 reversed ordered versions exist' do
+      before do
+        create :ss_migration, version: '20150324000001'
+        create :ss_migration, version: '20150324000000'
+      end
+
+      it { is_expected.to eq '20150324000001' }
+    end
+  end
 end

--- a/spec/models/ss/migration_spec.rb
+++ b/spec/models/ss/migration_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'fileutils'
+
+RSpec.describe SS::Migration, type: :model, dbscope: :example do
+  def mkdir(dirname)
+    FileUtils.mkdir_p dirname
+  end
+
+  def touch(filepath)
+    File.open Rails.root.join(filepath), 'w'
+  end
+
+  def rm_rf(dirpath)
+    FileUtils.rm_rf Rails.root.join(dirpath)
+  end
+
+  before(:all) { mkdir 'tmp/lib/migrations' }
+
+  after(:all)  { rm_rf 'tmp/lib' }
+
+  describe 'DIR constant' do
+    it { expect(described_class::DIR.to_s).to match(/.*\/lib\/migrations$/) }
+  end
+
+  describe '.filepaths' do
+    before do
+      mkdir 'tmp/lib/migrations/mod1'
+      mkdir 'tmp/lib/migrations/mod2'
+      touch 'tmp/lib/migrations/mod2/20150324000000_a.rb'
+      touch 'tmp/lib/migrations/mod1/20150324000001_a.rb'
+      touch 'tmp/lib/migrations/mod1/20150324000002_a.rb'
+      touch 'tmp/lib/migrations/mod2/20150324000003_a.rb'
+      SS::Migration::DIR = Rails.root.join 'tmp/lib/migrations'
+    end
+
+    after do
+      rm_rf 'tmp/lib/migrations/mod1'
+      rm_rf 'tmp/lib/migrations/mod2'
+    end
+
+    it { expect(described_class.filepaths).to match [
+      /.*\/mod2\/20150324000000_a\.rb$/,
+      /.*\/mod1\/20150324000001_a\.rb$/,
+      /.*\/mod1\/20150324000002_a\.rb$/,
+      /.*\/mod2\/20150324000003_a\.rb$/,
+    ] }
+  end
+end

--- a/spec/models/ss/migration_spec.rb
+++ b/spec/models/ss/migration_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe SS::Migration, type: :model, dbscope: :example do
       touch 'tmp/lib/migrations/mod1/20150324000001_a.rb'
       touch 'tmp/lib/migrations/mod1/20150324000002_a.rb'
       touch 'tmp/lib/migrations/mod2/20150324000003_a.rb'
+      # ref.
+      #   http://docs.ruby-lang.org/ja/2.2.0/method/Module/i/remove_const.html
+      #   http://docs.ruby-lang.org/ja/2.2.0/class/Module.html#I_CLASS_EVAL
+      SS::Migration.class_eval { remove_const :DIR }
       SS::Migration::DIR = Rails.root.join 'tmp/lib/migrations'
     end
 

--- a/spec/models/ss/migration_spec.rb
+++ b/spec/models/ss/migration_spec.rb
@@ -80,4 +80,9 @@ RSpec.describe SS::Migration, type: :model, dbscope: :example do
       it { is_expected.to eq '20150324000001' }
     end
   end
+
+  describe '.take_timestamp' do
+    subject { described_class.take_timestamp '/a/b/20150330000000_c_d.rb' }
+    it { is_expected.to eq '20150330000000' }
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,3 +104,13 @@ end
 def unique_id
   Time.zone.now.to_f.to_s.delete('.').to_i.to_s(36)
 end
+
+# ref.
+#   https://www.relishapp.com/rspec/rspec-expectations/v/2-5/docs/built-in-matchers/be-within-matcher
+#   http://qiita.com/kozy4324/items/9a6530736be7e92954bc
+RSpec::Matchers.define :eq_as_time do |expected_time|
+  match do |actual_time|
+    expect(actual_time.to_f).to be_within(0.001).of(expected_time.to_f)
+  end
+end
+# TODO: Should this code be written here? Another more correctly place?


### PR DESCRIPTION
`rake ss:migrate` 出来るようにしました．

ezine関連のタスクを2つ，サンプルとして実装している状態であるとします．

1つは `Ezine::Member` の `state` フィールドを `enabled` にするもの．

もう1つは `Ezine::Page` の `results` フィールドを単なる `Array` から `embeds_many` に変更するもの．