### PR TITLE
Fix timestamp initialization

### DIFF
--- a/app/models/concerns/ss/document.rb
+++ b/app/models/concerns/ss/document.rb
@@ -10,8 +10,8 @@ module SS::Document
     class_variable_set(:@@_permit_params, [])
     class_variable_set(:@@_text_index_fields, [])
 
-    field :created, type: DateTime, default: -> { Time.zone.now }
-    field :updated, type: DateTime, default: -> { Time.zone.now }
+    field :created, type: DateTime, default: -> { @now ||= Time.zone.now }
+    field :updated, type: DateTime, default: -> { @now ||= Time.zone.now }
     field :text_index, type: String
 
     validate :validate_updated, if: -> { in_updated.present? }

--- a/spec/models/ss/document_spec.rb
+++ b/spec/models/ss/document_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+class Klass
+  include SS::Document
+end
+
+RSpec.describe Klass, type: :model, dbscope: :example do
+  it do
+    Timecop.scale(1_000_000_000)
+    object = Klass.new
+    expect(object.created == object.updated).to be_truthy
+    Timecop.return
+  end
+end


### PR DESCRIPTION
`SS::Document` の `created` と `updated` が原理的にズレる．ごく僅かなのと丸められるのとで気にされてなかったのだと思われるが，一致して欲しいという要求が出てきそうなので修正したい．

失敗例:

```text
     7: RSpec.describe Klass, type: :model, dbscope: :example do
     8:   it do
     9:     Timecop.scale(1_000_000_000)
    10:     object = Klass.new
    11:     binding.pry
 => 12:     expect(object.created == object.updated).to be_truthy
    13:     Timecop.return
    14:   end
    15: end

[1] pry(#<RSpec::ExampleGroups::Klass>)> object.created
=> Thu, 21 May 2015 23:15:58 +0900
[2] pry(#<RSpec::ExampleGroups::Klass>)> object.updated
=> Sat, 30 May 2015 17:33:57 +0900
[3] pry(#<RSpec::ExampleGroups::Klass>)> continue

  1) Klass should be truthy
     Failure/Error: expect(object.created == object.updated).to be_truthy
       expected: truthy value
            got: false
     # ./spec/models/ss/document_spec.rb:12:in `block (2 levels) in <top (required)>'

 1/1 |======================================================= 100 =======================================================>| Time: 00:00:15

Finished in 16.14 seconds (files took 9.33 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/models/ss/document_spec.rb:8 # Klass should be truthy
```
