### PR TITLE
remove "e.kind_of?(fatal)" from Job::Service#system_error? because the NameError occurs

### DIFF
--- a/app/models/job/service.rb
+++ b/app/models/job/service.rb
@@ -110,7 +110,8 @@ class Job::Service
     end
 
     def system_error?(e)
-      e.kind_of?(NoMemoryError) || e.kind_of?(SignalException) || e.kind_of?(SystemExit) || e.kind_of?(fatal)
+      # e.kind_of?(NoMemoryError) || e.kind_of?(SignalException) || e.kind_of?(SystemExit) || e.kind_of?(fatal)
+      e.kind_of?(NoMemoryError) || e.kind_of?(SignalException) || e.kind_of?(SystemExit)
     end
 
     def create_job(task)

--- a/spec/models/voice/synthesis_job_spec.rb
+++ b/spec/models/voice/synthesis_job_spec.rb
@@ -89,7 +89,7 @@ describe Voice::SynthesisJob, http_server: true, doc_root: Rails.root.join("spec
       end
 
       it { expect(@job).not_to be_nil }
-      it { expect(system(@cmd)).to be false }
+      it { expect(system(@cmd)).to be_truthy }
 
       describe "job" do
         subject { Job::Task.find_by(name: 'job:voice_synthesis') rescue nil }
@@ -119,7 +119,7 @@ describe Voice::SynthesisJob, http_server: true, doc_root: Rails.root.join("spec
       end
 
       it { expect(@job).not_to be_nil }
-      it { expect(system(@cmd)).to be_falsey }
+      it { expect(system(@cmd)).to be_truthy }
 
       describe "job" do
         subject { Job::Task.find_by(name: 'job:voice_synthesis') rescue nil }
@@ -149,7 +149,7 @@ describe Voice::SynthesisJob, http_server: true, doc_root: Rails.root.join("spec
       end
 
       it { expect(@job).not_to be_nil }
-      it { expect(system(@cmd)).to be_falsey }
+      it { expect(system(@cmd)).to be_truthy }
 
       describe "job" do
         subject { Job::Task.find_by(name: 'job:voice_synthesis') rescue nil }
@@ -181,7 +181,7 @@ describe Voice::SynthesisJob, http_server: true, doc_root: Rails.root.join("spec
       end
 
       it { expect(@job).not_to be_nil }
-      it { expect(system(@cmd)).to be_falsey }
+      it { expect(system(@cmd)).to be_truthy }
 
       describe "job" do
         subject { Job::Task.find_by(name: 'job:voice_synthesis') rescue nil }


### PR DESCRIPTION
this error occurs:

    NameError: undefined local variable or method `fatal' for main:Object
