### PR TITLE
add site_id in SS::File migration

### DIFF
--- a/lib/migrations/ss/20150521192401_fix_ss_files_site_id.rb
+++ b/lib/migrations/ss/20150521192401_fix_ss_files_site_id.rb
@@ -1,0 +1,23 @@
+class SS::Migration20150521192401
+  def change
+    Cms::Page.all.each do |page|
+      if page.site
+        page.files.each do |file|
+          file.set(site_id: page.site.id) unless file.site_id
+        end
+      end
+    end
+
+    Ads::Banner.all.each do |page|
+      if page.site && page.file
+        page.file.set(site_id: page.site.id) unless page.file.site_id
+      end
+    end
+
+    Facility::Image.all.each do |page|
+      if page.site && page.image
+        page.image.set(site_id: page.site.id) unless page.image.site_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
すでにアップされている添付ファイルにsite_idを付けるmigration
以下の添付ファイルが対象
* ページの添付ファイル
* バナーの画像
* 施設の画像