### PR TITLE
add public side rspec support.

### DIFF
--- a/app/controllers/concerns/cms/public_filter.rb
+++ b/app/controllers/concerns/cms/public_filter.rb
@@ -42,13 +42,13 @@ module Cms::PublicFilter
 
   private
     def set_site
-      host = request.env["HTTP_X_FORWARDED_HOST"] || request.env["HTTP_HOST"]
+      host = request.env["HTTP_X_FORWARDED_HOST"] || request.env["HTTP_HOST"] || request.host_with_port
       @cur_site ||= SS::Site.find_by_domain host
       raise "404" if !@cur_site
     end
 
     def set_request_path
-      @cur_path ||= request.env["REQUEST_PATH"]
+      @cur_path ||= request.env["REQUEST_PATH"] || request.path
       cur_path = @cur_path.dup
 
       filter_methods = self.class.private_instance_methods.select { |m| m =~ /^set_request_path_with_/ }


### PR DESCRIPTION
rspec では、HTTP_HOST のような固定的な env なら設定可能ですが、
動的に変化するような REQUEST_PATH を設定するのは難しいです。

例えば、メンバーページにログインするよう処理をテストする場合、
リダイレクトが何回か発生します。リダイレクトのたびに REQUEST_PATH を
変更する必要がありますが、rspec 側だけでは、なかなか容易に対応できません。

Cms::PublicFilter 側のサポートが必要です。
