### PR TITLE
Add "BUNDLED_WITH" specification to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,3 +454,6 @@ DEPENDENCIES
   unicorn
   yard
   zipruby
+
+BUNDLED WITH
+   1.10.2


### PR DESCRIPTION
From version 1.10, this specification is added to the tail of Gemfile.lock.

ref. https://github.com/bundler/bundler/blob/master/CHANGELOG.md#1100pre2-2015-05-07