### PR TITLE
[ci skip] Fix Bundler gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ enabled=0
 # source /etc/profile
 # rvm install 2.2.2
 # rvm use 2.2.2 --default
-# gem install bundle
+# gem install bundler
 ```
 
 ## SHIRASAGI


### PR DESCRIPTION
✗ `gem install bundle`
✓ `gem install bundler`