### PR TITLE
Run coverage analysis only on TravisCI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
-require 'simplecov'
-require 'coveralls'
-Coveralls.wear!
+# Coverage analysis runs only on TravisCI
+# ref. http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+if ENV["CI"] == "true" && ENV["TRAVIS"] == "true"
+  require 'simplecov'
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
@@ -20,13 +24,16 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-]
-SimpleCov.start do
-  add_filter 'spec/'
-  add_filter 'vendor/bundle'
+# Coverage analysis runs only on TravisCI
+if ENV["CI"] == "true" && ENV["TRAVIS"] == "true"
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+  ]
+  SimpleCov.start do
+    add_filter 'spec/'
+    add_filter 'vendor/bundle'
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
カバレッジの計測絡みの処理に掛かる時間が，何度も繰り返し手元で `rspec spec/foo/bar_spec.rb` を実行しているとき(※)にちょっと鬱陶しい．

(※)
- テストの書き方を模索しているとき
- FactoryGirlの書き方を模索しているとき
- 実装がよく分からず試行錯誤しているとき

CoverallsやそれにまつわるSimpleCovの処理は，開発者の手元で何度も実行する必要は無いのではないか？CIをしてくれるサービス達に後から教えてもらうだけでもいいのではないか？と思っていたのと，自分がTravisCI上で動いているのかどうかを調べることが環境変数で出来ることが分かったので今回のPull Requestを作ってみました．

ref. http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables