### PR TITLE
ezine: checking sent_log for multiple execution

### DIFF
--- a/app/models/ezine/task.rb
+++ b/app/models/ezine/task.rb
@@ -50,6 +50,10 @@ class Ezine::Task
         members.each.with_index do |member, index|
           interval_sleep index
           begin
+            # checking SentLog more strictly for multiple execution
+            sent_log = Ezine::SentLog.where(page_id: page.id, email: member.email).first
+            raise "already delivered to #{member.email}" if sent_log
+
             task.log "To: " + member.email
             page.deliver_to member
             success_count += 1


### PR DESCRIPTION
多重実行されてしまった時の為、
`page.members_to_deliver.each do ... end` の中でも `Ezine::SentLog` のチェックをするよう修正