### PR TITLE
[fix] overwitten render method in SS::CrudFilter

### DIFF
--- a/app/controllers/concerns/ss/crud_filter.rb
+++ b/app/controllers/concerns/ss/crud_filter.rb
@@ -17,7 +17,7 @@ module SS::CrudFilter
     end
 
     def render(*args)
-      args.size == 0 ? super(file: params[:action]) : super
+      args.size == 0 ? super(file: params[:action]) : super(*args)
     end
 
     def set_item


### PR DESCRIPTION
この修正の妥当性をどなたか確認していただけますか？

あと，修正の際はコミットコメントの先頭は`[modify]`の方が良かったりしますか？