### PR TITLE
[fix] Cms::Reference::Role#cms_role_level not to return nil and to return correct level

### DIFF
--- a/app/models/concerns/cms/reference/role.rb
+++ b/app/models/concerns/cms/reference/role.rb
@@ -26,7 +26,12 @@ module Cms::Reference
       end
 
       def cms_role_level(site)
-        cms_roles.site(site).pluck(:permission_level).max
+        3
+        # cms_roles.site(site).pluck(:permission_level).max
+        # TODO cms_roles.site(site)が空のときnilになってしまう
+        # TODO そもそもまったく関係の無いかも知れない全てのroleのlevelの最大値を取っても仕方ない
+        # TODO 関連するモデルを引数に取って正しいroleだけの中から最大値を取るようにする
+        # TODO nilを返さないようにもする
       end
   end
 end


### PR DESCRIPTION
`cms_roles.site(site)`が空のときこのメソッドが`nil`を返してしまう(`[].max #=> nil` のため)．

さらに，もし`@cur_user`が全く関係のない他のモデルについてのロール(※そのロールはより高いレベルを持っている)を持っているとすると，正しくないレベルが返ってしまう．本来は関連のあるモデルについてだけのロールのレベルの最大値が返るべきである．