### PR TITLE
[add] group keyword in list template

### DIFF
--- a/app/models/concerns/cms/addon/list.rb
+++ b/app/models/concerns/cms/addon/list.rb
@@ -107,6 +107,10 @@ module Cms::Addon::List
           I18n.l item.date
         elsif name =~ /^time\.(\w+)$/
           I18n.l item.date, format: $1.to_sym
+        elsif name == "group"
+          item.groups.first.try(:name)
+        elsif name == "groups"
+          item.groups.map(&:name).join(", ")
         else
           false
         end

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -522,6 +522,8 @@ ja:
           #{summary}　リンク先ページのSummaryが表示されます。
           #{current}　現在訪問しているページとURLが同一の場合、classにcurrentが付与されます。
           #{new}　リンク先のページ公開日時がNEWマーク期間の範囲内の場合、classにnewが付与されます。
+          #{group}　リンク先ページの所有グループが表示されます。
+          #{groups}　リンク先ページの全ての所有グループが表示されます。
 
           使用例：
           &lt;article class="#{class}">
@@ -639,6 +641,8 @@ ja:
           #{summary}　リンク先ページのSummaryが表示されます。
           #{current}　現在訪問しているページとURLが同一の場合、classにcurrentが付与されます。
           #{new}　リンク先のページ公開日時がNEWマーク期間の範囲内の場合、classにnewが付与されます。
+          #{group}　ルートグループが表示されます。
+          #{groups}　全てのグループが表示されます。
 
           使用例：
           &lt;article class="#{class}">


### PR DESCRIPTION
ループHTMLに管理グループを含めるPRです。
* `#{group}` 
先頭のグループ一つ `default_scope -> { order_by(order: 1, name: 1) }`

* `#{groups}` 
全てのグループ