### PR TITLE
[skip ci] restore member.index

### DIFF
--- a/app/models/cms/member.rb
+++ b/app/models/cms/member.rb
@@ -3,7 +3,8 @@ class Cms::Member
 
   EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i.freeze
 
-  index({ site_id: 1, email: 1 }, { unique: true, sparse: true })
+  #TODO
+  #index({ site_id: 1, email: 1 }, { unique: true, sparse: true })
 
   class << self
     public


### PR DESCRIPTION
cms memberのindexに以下が追加されました。
`index({ site_id: 1, email: 1 }, { unique: true, sparse: true })`

しかし、oauthでログインするときはemailが空の場合が想定されており
テストが失敗します。

とりあえずbuildを直すために再度コメントアウトします。