### PR TITLE
[fix] thumb file's site_id

### DIFF
--- a/app/models/concerns/ss/relation/thumb.rb
+++ b/app/models/concerns/ss/relation/thumb.rb
@@ -68,7 +68,9 @@ module SS::Relation::Thumb
       thumbs_resizing.each do |name, size|
         file = thumbs_was.delete(size)
         if file
-          file.update_attributes(filename: filename, state: state) if state_changed? || filename_changed?
+          if state_changed? || filename_changed? || site_id_changed?
+            file.update_attributes(filename: filename, state: state, site_id: site_id)
+          end
           file.set(image_size_name: name) if name != file.image_size_name
         else
           file = SS::ThumbFile.new


### PR DESCRIPTION
画像保存時にsite_idが追加されたら、サムネイル画像にもsite_idを付けるように修正
site_idがないため書き出されていませんでした。
関連：https://github.com/shirasagi/shirasagi/commit/f274430421eea9755ff2513fd2e284dbf083ba29
