### PR TITLE
[add] destroy_all action

### DIFF
--- a/app/assets/javascripts/ss/lib/list_ui.coffee.erb
+++ b/app/assets/javascripts/ss/lib/list_ui.coffee.erb
@@ -16,14 +16,16 @@ class @SS_ListUI
       chk = $(this).prop('checked')
       $('.list-item input:checkbox').each ->
         $(this).prop('checked', chk)
+    $(".list-head .destroy-all").on "click", ->
+      token   = $(this).attr("data-token")
+      checked = $(".list-item input:checkbox:checked").map ->
+        $(this).val()
+      return false if checked.length == 0
+      return false unless confirm("<%= I18n.t("views.confirm.delete") %>")
 
-  @deleteitem: (id)->
-    $.ajax
-      type: "post"
-      url: location.pathname + "/" + id
-      async: false
-      data: "_method=delete"
-      success: (msg) ->
-        #
-      error: (msg, status) ->
-        alert(["== Error =="].concat(msg["statusText"]).join("\n"));
+      form = $("<form/>", action: "", method: "post")
+      form.append($("<input/>", name: "_method", value: "delete", type: "hidden" ))
+      form.append($("<input/>", name: "authenticity_token", value: token, type: "hidden" ))
+      for id in checked
+        form.append($("<input/>", name: "ids[]", value: id, type: "hidden"))
+      form.appendTo(document.body).submit()

--- a/app/assets/javascripts/ss/lib/list_ui.coffee.erb
+++ b/app/assets/javascripts/ss/lib/list_ui.coffee.erb
@@ -17,7 +17,7 @@ class @SS_ListUI
       $('.list-item input:checkbox').each ->
         $(this).prop('checked', chk)
     $(".list-head .destroy-all").on "click", ->
-      token   = $(this).attr("data-token")
+      token   = $('meta[name="csrf-token"]').attr('content')
       checked = $(".list-item input:checkbox:checked").map ->
         $(this).val()
       return false if checked.length == 0

--- a/app/controllers/concerns/cms/crud_filter.rb
+++ b/app/controllers/concerns/cms/crud_filter.rb
@@ -67,6 +67,12 @@ module Cms::CrudFilter
       render_destroy @item.destroy
     end
 
+    def destroy_all
+      raise "403" unless @items.first.allowed?(:delete, @cur_user, site: @cur_site, node: @cur_node)
+      @items.destroy_all
+      render_destroy true
+    end
+
     def lock
       if @item.acquire_lock(force: params[:force].present?)
         render

--- a/app/controllers/concerns/cms/crud_filter.rb
+++ b/app/controllers/concerns/cms/crud_filter.rb
@@ -68,9 +68,18 @@ module Cms::CrudFilter
     end
 
     def destroy_all
-      raise "403" unless @items.first.allowed?(:delete, @cur_user, site: @cur_site, node: @cur_node)
-      @items.destroy_all
-      render_destroy true
+      entries = @items.entries
+      @items = []
+
+      entries.each do |item|
+        if item.allowed?(:delete, @cur_user, site: @cur_site, node: @cur_node)
+          next if item.destroy
+        else
+          item.errors.add :base, :auth_error
+        end
+        @items << item
+      end
+      render_destroy_all (entries.size != @items.size)
     end
 
     def lock

--- a/app/controllers/concerns/ss/crud_filter.rb
+++ b/app/controllers/concerns/ss/crud_filter.rb
@@ -5,6 +5,7 @@ module SS::CrudFilter
     before_action :prepend_current_view_path
     before_action :append_view_paths
     before_action :set_item, only: [:show, :edit, :update, :delete, :destroy]
+    before_action :set_destroy_items, only: [:destroy_all]
   end
 
   private
@@ -23,6 +24,14 @@ module SS::CrudFilter
     def set_item
       @item = @model.find params[:id]
       @item.attributes = fix_params
+    end
+
+    def set_destroy_items
+      ids = params[:ids]
+      raise "400" unless ids
+      ids = ids.split(",") if ids.kind_of?(String)
+      ids = ids.map(&:to_i)
+      @items = @model.in(id: ids)
     end
 
     def fix_params
@@ -77,6 +86,11 @@ module SS::CrudFilter
 
     def destroy
       render_destroy @item.destroy
+    end
+
+    def destroy_all
+      @items.destroy_all
+      render_destroy true
     end
 
   private

--- a/app/controllers/concerns/ss/crud_filter.rb
+++ b/app/controllers/concerns/ss/crud_filter.rb
@@ -32,6 +32,7 @@ module SS::CrudFilter
       ids = ids.split(",") if ids.kind_of?(String)
       ids = ids.map(&:to_i)
       @items = @model.in(id: ids)
+      raise "400" unless @items.present?
     end
 
     def fix_params
@@ -90,7 +91,7 @@ module SS::CrudFilter
 
     def destroy_all
       @items.destroy_all
-      render_destroy true
+      render_destroy_all true
     end
 
   private
@@ -142,6 +143,17 @@ module SS::CrudFilter
           format.html { render render_opts }
           format.json { render json: @item.errors.full_messages, status: :unprocessable_entity }
         end
+      end
+    end
+
+    def render_destroy_all(result)
+      location = { action: :index }
+      notice = result ? { notice: t("views.notice.deleted") } : {}
+      errors = @items.map { |item| [item.id, item.errors.full_messages] }
+
+      respond_to do |format|
+        format.html { redirect_to location, notice }
+        format.json { head json: errors }
       end
     end
 end

--- a/app/controllers/uploader/files_controller.rb
+++ b/app/controllers/uploader/files_controller.rb
@@ -86,9 +86,20 @@ class Uploader::FilesController < ApplicationController
     def destroy
       raise "403" unless @cur_node.allowed?(:edit, @cur_user, site: @cur_site)
 
+      filenames = params[:ids]
       dirname = @item.dirname
-      @item.destroy
-      render_destroy true, location: "#{uploader_files_path}/#{dirname}"
+      if filenames
+        @items = []
+        filenames.each do |filename|
+          item = @model.file("#{@item.path.to_s}/#{filename}")
+          @items << item if item
+        end
+        @items.each(&:destroy)
+        render_destroy true, location: "#{uploader_files_path}/#{@item.filename}"
+      else
+        @item.destroy
+        render_destroy true, location: "#{uploader_files_path}/#{dirname}"
+      end
     end
 
   private

--- a/app/views/ss/crud/_list_head.html.erb
+++ b/app/views/ss/crud/_list_head.html.erb
@@ -2,7 +2,9 @@
   <label class="list-head-check"><input type="checkbox" /></label>
 
   <div class="list-head-action">
-    <button onclick="alert('TODO')"><%= t :"views.links.delete" %></button>
+    <button class="destroy-all" data-token="<%= form_authenticity_token %>">
+      <%= t :"views.links.delete" %>
+    </button>
   </div>
 
   <% @s = OpenStruct.new params[:s] %>

--- a/app/views/ss/crud/_list_head.html.erb
+++ b/app/views/ss/crud/_list_head.html.erb
@@ -2,9 +2,7 @@
   <label class="list-head-check"><input type="checkbox" /></label>
 
   <div class="list-head-action">
-    <button class="destroy-all" data-token="<%= form_authenticity_token %>">
-      <%= t :"views.links.delete" %>
-    </button>
+    <button class="destroy-all"><%= t :"views.links.delete" %></button>
   </div>
 
   <% @s = OpenStruct.new params[:s] %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -100,6 +100,7 @@ ja:
     format: ! '%{attribute}%{message}'
     messages:
       accepted: を受諾してください。
+      auth_error: 権限がありません。
       blank: を入力してください。
       present: は入力しないでください。
       confirmation: と%{attribute}の入力が一致しません。

--- a/config/routes/ads/routes.rb
+++ b/config/routes/ads/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   content "ads" do

--- a/config/routes/article/routes.rb
+++ b/config/routes/article/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :copy do

--- a/config/routes/category/routes.rb
+++ b/config/routes/category/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   content "category" do

--- a/config/routes/chorg/routes.rb
+++ b/config/routes/chorg/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   namespace("chorg_results", path: ".s:site/chorgs/revisions/:rid", module: "chorg", id: /\w+/) do

--- a/config/routes/cms/routes_end.rb
+++ b/config/routes/cms/routes_end.rb
@@ -2,6 +2,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, :on => :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :copy do

--- a/config/routes/event/routes.rb
+++ b/config/routes/event/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :crud do

--- a/config/routes/ezine/routes.rb
+++ b/config/routes/ezine/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   content "ezine" do

--- a/config/routes/facility/routes.rb
+++ b/config/routes/facility/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :download do

--- a/config/routes/faq/routes.rb
+++ b/config/routes/faq/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :copy do

--- a/config/routes/history/routes.rb
+++ b/config/routes/history/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   sys "history" do

--- a/config/routes/inquiry/routes.rb
+++ b/config/routes/inquiry/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :download do

--- a/config/routes/job/routes.rb
+++ b/config/routes/job/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   sys "job" do

--- a/config/routes/kana/routes.rb
+++ b/config/routes/kana/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   namespace("kana", as: "kana", path: ".s:site/kana", module: "kana") do

--- a/config/routes/key_visual/routes.rb
+++ b/config/routes/key_visual/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   content "key_visual" do

--- a/config/routes/ldap/routes.rb
+++ b/config/routes/ldap/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   namespace("ldap", as: "ldap", path: ".s:site/ldap", module: "ldap") do

--- a/config/routes/rss/routes.rb
+++ b/config/routes/rss/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :import do

--- a/config/routes/sitemap/routes.rb
+++ b/config/routes/sitemap/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :crud do

--- a/config/routes/sns/routes.rb
+++ b/config/routes/sns/routes.rb
@@ -2,6 +2,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, :on => :member
+    delete action: :destroy_all, :on => :collection
   end
 
   namespace "sns", path: ".u:user", user: /\d+/ do

--- a/config/routes/sys/routes.rb
+++ b/config/routes/sys/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, :on => :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :role do

--- a/config/routes/urgency/routes.rb
+++ b/config/routes/urgency/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   content "urgency" do

--- a/config/routes/voice/routes.rb
+++ b/config/routes/voice/routes.rb
@@ -4,6 +4,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
   end
 
   concern :file do

--- a/config/routes/workflow/routes.rb
+++ b/config/routes/workflow/routes.rb
@@ -2,6 +2,7 @@ SS::Application.routes.draw do
 
   concern :deletion do
     get :delete, on: :member
+    delete action: :destroy_all, :on => :collection
     post :request_update, on: :member
     post :approve_update, on: :member
     post :remand_update, on: :member


### PR DESCRIPTION
一括削除UIの為に `destroy_all` `action` を `crud` に追加しました。

ルーティングは以下が使えました。
<pre>
delete article/pages/:id    #destory
delete article/pages/        #destory_all
</pre>
※params[:ids]を参照します。
アップローダだけは同じアクションが使えなかったので別対応しています。