### PR TITLE
Tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ ehthumbs.db
 # IntelliJ IDEA & RubyMine
 /*.iml
 /.idea/
+
+# Local Guardfile
+/Guardfile.local

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ ehthumbs.db
 
 # Local Guardfile
 /Guardfile.local
+
+# Dotenv
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :development, :test do
   # The latest version is 1.5.0 now, but getting the same error again.
   # ref. https://github.com/DatabaseCleaner/database_cleaner/issues/390
   gem 'database_cleaner', '1.4.1'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -80,23 +80,9 @@ group :development, :test do
   gem 'pry-doc'
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
-
-  # DatabaseCleaner
-  #
-  # ref.
-  #   https://github.com/DatabaseCleaner/database_cleaner
-  #   http://stackoverflow.com/questions/6583618/clean-out-or-reset-test-database-with-rspec-and-mongoid-on-rails-3
-  #
-  # Version 1.4.0 is latest now, but that version contaions an error.
-  #
-  # Error message:
-  #   DatabaseCleaner::UnknownStrategySpecified:
-  #          The 'truncation' strategy does not exist for the mongoid ORM!  Available strategies: truncation
-  #
-  # ref.
-  #   https://github.com/DatabaseCleaner/database_cleaner/issues/322
-  #   https://github.com/DatabaseCleaner/database_cleaner/issues/299
-  gem 'database_cleaner', '1.3.0'
+  # The latest version is 1.5.0 now, but getting the same error again.
+  # ref. https://github.com/DatabaseCleaner/database_cleaner/issues/390
+  gem 'database_cleaner', '1.4.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,4 +515,4 @@ DEPENDENCIES
   zipruby
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       simplecov (~> 0.10.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
-    database_cleaner (1.3.0)
+    database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     diffy (3.0.7)
@@ -454,7 +454,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   compass-rails
   coveralls
-  database_cleaner (= 1.3.0)
+  database_cleaner (= 1.4.1)
   diffy
   dynamic_form
   factory_girl_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
     docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.0.2)
+    dotenv-rails (2.0.2)
+      dotenv (= 2.0.2)
+      railties (~> 4.0)
     dynamic_form (1.1.4)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -456,6 +460,7 @@ DEPENDENCIES
   coveralls
   database_cleaner (= 1.4.1)
   diffy
+  dotenv-rails
   dynamic_form
   factory_girl_rails
   fullcalendar.io-rails

--- a/Guardfile
+++ b/Guardfile
@@ -44,3 +44,10 @@ guard 'brakeman', :run_on_start => true do
   watch(%r{^lib/.+\.rb$})
   watch('Gemfile')
 end
+
+# Load local Guardfile
+local_guardfile_path = File.expand_path('../Guardfile.local', __FILE__)
+if File.exist? local_guardfile_path
+  self.instance_eval(File.open(local_guardfile_path).read)
+end
+# ref. https://github.com/openmensa/openmensa/blob/ac3b063edfd3639091d2b4025a292feea7814ec9/Guardfile#L34-L38

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,6 @@ Rails.application.configure do
 
   # Logger
   config.logger = Logger.new("#{Rails.root}/log/development.log")
-  config.log_level = :warn
+  config.log_level = ENV['DEVELOPMENT_LOG_LEVEL'] || :warn
   # config.log_level = :debug
 end


### PR DESCRIPTION
- Bump up Bundler version to 1.10.6
  - `BUNDLED_WITH` is modified
- Bump up database_cleaner version to 1.4.1
  - 1.5.0 is the latest but the version rebirths the bug on 1.4.0
- Enable to switch development environment log level value by the environment variable
  - Use `DEVELOPMENT_LOG_LEVEL`
- Use dotenv gem to manage environment variables simply
