### PR TITLE
[modify] kana/dictionary_spec for removing the warning

### DIFF
--- a/spec/models/kana/dictionary_spec.rb
+++ b/spec/models/kana/dictionary_spec.rb
@@ -91,7 +91,7 @@ describe Kana::Dictionary do
       end
 
       it "fails to save" do
-        expect { item.save! }.to raise_error
+        expect { item.save! }.to raise_error Mongoid::Errors::Validations
       end
     end
 


### PR DESCRIPTION
The warning message is below:

    WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /somewhere/shirasagi/spec/models/kana/dictionary_spec.rb:95:in `block (4 levels) in <top (required)>'.