### PR TITLE
[modify]add unicorn worker killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 # gem 'bcrypt', '~> 3.1.7'
 gem "unicorn"
+gem "unicorn-worker-killer"
 # gem 'capistrano-rails', group: :development
 # gem "debugger", group: [:development, :test]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
+    get_process_mem (0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     guard (2.13.0)
@@ -435,6 +436,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.3)
+      get_process_mem (~> 0)
+      unicorn (~> 4)
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -513,6 +517,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   ungarbled
   unicorn
+  unicorn-worker-killer
   yard
   zipruby
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,13 @@
 # This file is used by Rack-based servers to start the application.
 
+# Unicorn self-process killer
+require 'unicorn/worker_killer'
+
+# Max requests per worker
+use Unicorn::WorkerKiller::MaxRequests, 3072, 4096
+
+# Max memory size (RSS) per worker
+use Unicorn::WorkerKiller::Oom, (384*(1024**2)), (448*(1024**2))
+
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application


### PR DESCRIPTION
worker再起動のトリガーとなるリクエスト回数の範囲（3072-4096）はunicorn-worker-killerの初期値です。
一方、メモリ範囲(384MB-448MB)はシラサギ本番稼働中のworkerのメモリ占有平均が約258MBの為、
1.5倍程度の使用量から+64MBを再起動対象となるメモリ占有範囲としています。