### PR TITLE
[fix] fallback to request.path when REQUEST_PATH env is not provided.

### DIFF
--- a/app/controllers/cms/preview_controller.rb
+++ b/app/controllers/cms/preview_controller.rb
@@ -55,7 +55,7 @@ class Cms::PreviewController < ApplicationController
     end
 
     def set_path_with_preview
-      @cur_path ||= request.env["REQUEST_PATH"]
+      @cur_path ||= request.env["REQUEST_PATH"] || request.path
       @cur_path.sub!(/^#{cms_preview_path}(\d+)?/, "")
       @cur_path = "index.html" if @cur_path.blank?
       @cur_path = URI.decode(@cur_path)

--- a/app/models/oauth/base.rb
+++ b/app/models/oauth/base.rb
@@ -2,12 +2,12 @@ require 'oauth2'
 
 module Oauth::Base
   def site
-    host = @env["HTTP_X_FORWARDED_HOST"] || @env["HTTP_HOST"]
+    host = @env["HTTP_X_FORWARDED_HOST"] || @env["HTTP_HOST"] || request.host_with_port
     @site ||= SS::Site.find_by_domain host
   end
 
   def node
-    path = request.env["REQUEST_PATH"]
+    path = request.env["REQUEST_PATH"] || request.path
     @node ||= Member::Node::Login.site(site).in_path(path).sort(depth: -1).first
   end
 


### PR DESCRIPTION
Raptor (Passenger 5.x) seems not to provide REQUEST_PATH env.