### PR TITLE
Fix simplecov deprecation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,10 +20,10 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+])
 SimpleCov.start do
   add_filter 'spec/'
   add_filter 'vendor/bundle'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,10 +20,10 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-])
+]
 SimpleCov.start do
   add_filter 'spec/'
   add_filter 'vendor/bundle'


### PR DESCRIPTION
Fix the SimpleCov deprecation warning.

The warning message is below:

    /path/to/shirasagi/spec/spec_helper.rb:23:in `<top (required)>': [DEPRECATION]::[] is deprecated. Use ::new instead.

ref.

- https://github.com/colszowka/simplecov#using-multiple-formatters
- https://github.com/colszowka/simplecov/issues/428
- https://github.com/colszowka/simplecov/pull/432