### PR TITLE
[refactor] Query tuning

### DIFF
--- a/app/controllers/cms/agents/parts/crumb_controller.rb
+++ b/app/controllers/cms/agents/parts/crumb_controller.rb
@@ -30,7 +30,7 @@ class Cms::Agents::Parts::CrumbController < ApplicationController
 
   private
     def find_node(path)
-      Cms::Node.site(@cur_site).in_path(path).order(depth: 1).each do |node|
+      Cms::Node.site(@cur_site).in_path(path).order(depth: -1).reverse.each do |node|
         next if @cur_node && @cur_node.depth >= node.depth
         @items << [node.name, node.url]
       end

--- a/app/controllers/concerns/cms/base_filter.rb
+++ b/app/controllers/concerns/cms/base_filter.rb
@@ -23,7 +23,8 @@ module Cms::BaseFilter
 
     def set_site
       @ss_mode = :cms
-      @cur_site = Cms::Site.find params[:site]
+      @cur_site = Cms::Site.where(id: params[:site]).first
+      raise "404" unless @cur_site
       @crumbs << [@cur_site.name, cms_contents_path]
     end
 

--- a/app/controllers/concerns/cms/public_filter/layout.rb
+++ b/app/controllers/concerns/cms/public_filter/layout.rb
@@ -62,10 +62,22 @@ module Cms::PublicFilter::Layout
       end
 
       # TODO: deprecated </ />
-      html = body.gsub(/(<\/|\{\{) part ".+?" (\/>|\}\})/) do |m|
+      parts = {}
+      body = body.gsub(/(<\/|\{\{) part ".+?" (\/>|\}\})/) do |m|
         path = m.sub(/(?:<\/|\{\{) part "(.+)?" (?:\/>|\}\})/, '\\1') + ".part.html"
         path = path[0] == "/" ? path.sub(/^\//, "") : @cur_layout.dirname(path)
-        render_layout_part(path)
+        parts[path] = nil
+        "{{ part \"#{path}\" }}"
+      end
+
+      criteria = Cms::Part.site(@cur_site).and_public.any_in(filename: parts.keys)
+      criteria = criteria.where(mobile_view: "show") if filters.include?(:mobile)
+      criteria.each { |part| parts[part.filename] = part }
+
+      html = body.gsub(/(<\/|\{\{) part ".+?" (\/>|\}\})/) do |m|
+        path = m.sub(/(?:<\/|\{\{) part "(.+)?" (?:\/>|\}\})/, '\\1')
+        part = parts[path]
+        part ? render_layout_part(part) : ''
       end
 
       if notice
@@ -79,12 +91,7 @@ module Cms::PublicFilter::Layout
       html
     end
 
-    def render_layout_part(path)
-      part = Cms::Part.site(@cur_site).and_public
-      part = part.where(mobile_view: "show") if filters.include?(:mobile)
-      part = part.filename(path).first
-      return unless part
-
+    def render_layout_part(part)
       if part.ajax_view == "enabled" && !filters.include?(:mobile) && !@preview
         part.ajax_html
       else

--- a/app/controllers/concerns/cms/public_filter/node.rb
+++ b/app/controllers/concerns/cms/public_filter/node.rb
@@ -4,7 +4,7 @@ module Cms::PublicFilter::Node
 
   private
     def find_node(path)
-      node = Cms::Node.site(@cur_site).in_path(path).sort(depth: -1).first
+      node = Cms::Node.site(@cur_site).in_path(path).sort(depth: -1).to_a.first
       return unless node
       @preview || node.public? ? node.becomes_with_route : nil
     end

--- a/app/models/concerns/cms/content.rb
+++ b/app/models/concerns/cms/content.rb
@@ -49,7 +49,7 @@ module Cms::Content
   module ClassMethods
     def split_path(path)
       last = nil
-      dirs = path.split('/').map {|n| last = last ? "#{last}/#{n}" : n }
+      dirs = path.split('/').map { |n| last = last ? "#{last}/#{n}" : n }
     end
 
     def search(params)

--- a/app/models/concerns/cms/model/node.rb
+++ b/app/models/concerns/cms/model/node.rb
@@ -27,8 +27,12 @@ module Cms::Model::Node
     after_destroy :remove_directory
     after_destroy :destroy_children
 
-    scope :root, ->{ where(depth: 1) }
-    scope :in_path, ->(path) { where :filename.in => Cms::Node.split_path(path.sub(/^\//, "")) }
+    scope :root, ->{ where depth: 1 }
+    scope :in_path, ->(path) {
+      paths = Cms::Node.split_path(path.sub(/^\//, ""))
+      paths.pop if paths.last =~ /\./
+      where :filename.in => paths
+    }
   end
 
   def becomes_with_route(name = nil)

--- a/app/views/gws/main/_links.html.erb
+++ b/app/views/gws/main/_links.html.erb
@@ -1,6 +1,6 @@
 <%
 
-links = Gws::Link.site(@cur_site).and_public.target_to(@cur_user)
+links = Gws::Link.site(@cur_site).and_public.target_to(@cur_user).to_a
 return if links.blank?
 
 %>


### PR DESCRIPTION
DBの問い合わせ回数を減らしてみた。

## Model.find と Model.(belongs_to) の Query が異なる

~~~
(find) collection=ss_sites selector={"_id"=>1} flags=[] limit=0 skip=0 batch_size=nil fields=nil runtime: 0.4343ms
(belongs_to) collection=ss_sites selector={"$query"=>{"_id"=>1}, "$orderby"=>{:_id=>1}} flags=[] limit=-1 skip=0 batch_size=nil fields=nil runtime: 0.4906ms
~~~

常に呼ばれるところなので Query を統一した。

~~~
@cur_site = Cms::Site.find params[:site]
@cur_site = Cms::Site.where(id: params[:site]).first # and unless condition
~~~

## Criteria.present? で count が発行される

~~~
collection=gws_links selector={"$query"=>{"site_id"=>1, "state"=>"public", "$or"=>[{"target"=>nil}, {"target"=>"all"}, {"$and"=>[{"target"=>"group"}, {"group_ids"=>{"$in"=>[3]}}]}]}, "$orderby"=>{"released"=>-1}} flags=[] limit=-1 skip=0 batch_size=nil fields={:_id=>1} runtime: 0.5305ms
collection=gws_links selector={"$query"=>{"site_id"=>1, "state"=>"public", "$or"=>[{"target"=>nil}, {"target"=>"all"}, {"$and"=>[{"target"=>"group"}, {"group_ids"=>{"$in"=>[3]}}]}]}, "$orderby"=>{"released"=>-1}} flags=[] limit=0 skip=0 batch_size=nil fields=nil runtime: 1.3481ms
~~~

頻繁に使うところなので to_a で一旦取得した。
~~~
<% items = Model.where().to_a %>
<% if items.present? %>
  <% items.each do |item| %>
~~~

## 公開画面フォルダー検索

~~~
collection=cms_nodes selector={"$query"=>{"site_id"=>1, "filename"=>{"$in"=>["docs", "docs/index.html"]}}, "$orderby"=>{"depth"=>-1}} flags=[] limit=-1 skip=0 batch_size=nil fields=nil runtime: 0.5830ms
collection=cms_nodes selector={"$query"=>{"site_id"=>1, "filename"=>{"$in"=>["docs", "docs/index.html"]}}, "$orderby"=>{"depth"=>1}} flags=[] limit=0 skip=0 batch_size=nil fields=nil runtime: 0.6666ms
~~~

フォルダーなので検索条件から basename を除外した。
パンくずパーツで QueryCache を効かせた。
~~~
 collection=cms_nodes selector={"$query"=>{"site_id"=>1, "filename"=>{"$in"=>["docs"]}}, "$orderby"=>{"depth"=>-1}} flags=[] limit=0 skip=0 batch_size=nil fields=nil runtime: 0.4192ms
~~~

## パーツレンダリング

~~~
collection=cms_parts selector={"$query"=>{"site_id"=>1, "state"=>"public", "filename"=>"head.part.html"}, "$orderby"=>{:_id=>1}} flags=[] limit=-1 skip=0 batch_size=nil fields=nil runtime: 0.3757ms
collection=cms_parts selector={"$query"=>{"site_id"=>1, "state"=>"public", "filename"=>"navi.part.html"}, "$orderby"=>{:_id=>1}} flags=[] limit=-1 skip=0 batch_size=nil fields=nil runtime: 0.5654ms
collection=cms_parts selector={"$query"=>{"site_id"=>1, "state"=>"public", "filename"=>"crumbs.part.html"}, "$orderby"=>{:_id=>1}} flags=[] limit=-1 skip=0 batch_size=nil fields=nil runtime: 0.5894ms
collection=cms_parts selector={"$query"=>{"site_id"=>1, "state"=>"public", "filename"=>"foot.part.html"}, "$orderby"=>{:_id=>1}} flags=[] limit=-1 skip=0 batch_size=nil fields=nil runtime: 0.7705ms
~~~

使用されているパーツの検索を１発にまとめた
~~~
collection=cms_parts selector={"site_id"=>1, "state"=>"public", "filename"=>{"$in"=>["head.part.html", "navi.part.html", "crumbs.part.html", "foot.part.html"]}} flags=[] limit=0 skip=0 batch_size=nil fields=nil runtime: 0.6391ms
~~~


