### PR TITLE
[delete] trans sid support

### DIFF
--- a/app/controllers/concerns/mobile/public_filter.rb
+++ b/app/controllers/concerns/mobile/public_filter.rb
@@ -31,24 +31,7 @@ module Mobile::PublicFilter
 
       # links
       location = @cur_site.mobile_location.gsub(/^\/|\/$/, "")
-      body.gsub!(/href="\/(?!#{location}\/)(?!fs\/)(.*?)"/) do
-        path_with_query = $1
-        uri = URI.parse(path_with_query)
-        embeds = apply_trans_sid?
-        embeds = false unless embeds && same_host?(uri)
-        if embeds
-          key = CGI::escapeHTML(session_key)
-          val = CGI::escapeHTML(mobile_session_id)
-          if uri.query
-            uri.query = "#{uri.query}&#{key}=#{val}" unless uri.query.include?("#{key}=#{val}")
-          else
-            uri.query = "#{key}=#{val}"
-          end
-          path_with_query = uri.to_s
-        end
-
-        "href=\"/#{location}/#{path_with_query}\""
-      end
+      body.gsub!(/href="\/(?!#{location}\/)(?!fs\/)/, "href=\"/#{location}/")
       body.gsub!(/<span .*?id="ss-(small|medium|large|kana|pc|mb)".*?>.*?<\/span>/, "")
 
       # tags
@@ -88,16 +71,5 @@ module Mobile::PublicFilter
       return true unless domain = uri.host
       domain = "#{domain}:#{uri.port}" if uri.port
       @cur_site.domains.include?(domain)
-    end
-
-    def apply_trans_sid?
-      applies = false
-      case @cur_site.trans_sid.to_sym
-      when :always
-        applies = true
-      when :mobile
-        applies = mobile_path?
-      end
-      applies
     end
 end

--- a/app/controllers/concerns/mobile/public_filter.rb
+++ b/app/controllers/concerns/mobile/public_filter.rb
@@ -56,17 +56,6 @@ module Mobile::PublicFilter
       response.body = body.to_s
     end
 
-    def session_key
-      unless key = Rails.application.config.session_options.merge(request.session_options || {})[:key]
-        key = ActionDispatch::Session::AbstractStore::DEFAULT_OPTIONS[:key]
-      end
-      key
-    end
-
-    def mobile_session_id
-      request.session_options[:id] || request.session.id
-    end
-
     def same_host?(uri)
       return true unless domain = uri.host
       domain = "#{domain}:#{uri.port}" if uri.port

--- a/app/controllers/concerns/ss/trans_sid_filter.rb
+++ b/app/controllers/concerns/ss/trans_sid_filter.rb
@@ -1,28 +1,10 @@
 module SS::TransSidFilter
   extend ActiveSupport::Concern
 
-  included do
-    if defined?(Jpmobile)
-      before_action :set_trans_sid
-      trans_sid :none
-    end
-  end
-
   private
     def mobile_path?
       filters = request.env["ss.filters"]
       return false if filters.blank?
       filters.include?(:mobile)
-    end
-
-    def set_trans_sid
-      case @cur_site.trans_sid.to_sym
-      when :always
-        self.trans_sid_mode = :always
-      when :mobile
-        if mobile_path?
-          self.trans_sid_mode = :mobile
-        end
-      end
     end
 end

--- a/app/models/concerns/ss/addon/mobile_setting.rb
+++ b/app/models/concerns/ss/addon/mobile_setting.rb
@@ -7,11 +7,9 @@ module SS::Addon
       field :mobile_state, type: String
       field :mobile_location, type: String
       field :mobile_css, type: SS::Extensions::Words
-      field :trans_sid, type: String
-      permit_params :mobile_state, :mobile_location, :mobile_css, :trans_sid
+      permit_params :mobile_state, :mobile_location, :mobile_css
       before_validation :normalize_mobile_location
       validates :mobile_state, inclusion: { in: %w(disabled enabled) }, if: ->{ mobile_state.present? }
-      validates :trans_sid, inclusion: { in: %w(none mobile always) }, if: ->{ trans_sid.present? }
     end
 
     private
@@ -44,11 +42,6 @@ module SS::Addon
         [css]
       end
 
-      def trans_sid
-        return 'none' unless value = self.attributes["trans_sid"]
-        value
-      end
-
       def mobile_disabled?
         !mobile_enabled?
       end
@@ -59,10 +52,6 @@ module SS::Addon
 
       def mobile_state_options
         %w(disabled enabled).map { |m| [ I18n.t("views.options.state.#{m}"), m ] }.to_a
-      end
-
-      def trans_sid_options
-        %w(none mobile always).map { |m| [ I18n.t("views.options.trans_sid.#{m}"), m ] }.to_a
       end
   end
 end

--- a/app/views/ss/agents/addons/mobile_setting/_form.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_form.html.erb
@@ -7,7 +7,4 @@
 
   <dt><%= @model.t :mobile_css %><%= @model.tt :mobile_css %></dt>
   <dd><%= f.text_area :mobile_css, value: @item.mobile_css == @item.default_mobile_css ? nil : @item.mobile_css.join("\n") %></dd>
-
-  <dt><%= @model.t :trans_sid %><%= @model.tt :trans_sid %></dt>
-  <dd><%= f.select :trans_sid, @item.trans_sid_options %></dd>
 </dl>

--- a/app/views/ss/agents/addons/mobile_setting/_show.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_show.html.erb
@@ -7,7 +7,4 @@
 
   <dt><%= @model.t :mobile_css %></dt>
   <dd><%= br(@item.mobile_css.join("\n")) %></dd>
-
-  <dt><%= @model.t :trans_sid %></dt>
-  <dd><%= @item.label :trans_sid %></dd>
 </dl>

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -103,10 +103,6 @@ ja:
         768x1024: 768x1024(XGA縦)
         1280x720: 1280x720(HD横)
         720x1280: 720x1280(HD縦)
-      trans_sid:
-        none: 無効
-        mobile: モバイルのみ
-        always: いつも
     state:
       public: 公開中
       closed: 非公開
@@ -228,7 +224,6 @@ ja:
         mobile_state: 状態
         mobile_location: ロケーション
         mobile_css: CSS
-        trans_sid: Trans SID
       ss/max_file_size:
         name: 名前
         extensions: 拡張子

--- a/spec/models/cms/site_spec.rb
+++ b/spec/models/cms/site_spec.rb
@@ -17,7 +17,6 @@ describe Cms::Site do
     it { expect(item.mobile_state).to eq 'enabled' }
     it { expect(item.mobile_location).to eq '/mobile' }
     it { expect(item.mobile_css).to eq ['%{assets_prefix}/cms/mobile.css'] }
-    it { expect(item.trans_sid).to eq 'none' }
     it { expect(item.mobile_disabled?).to be_falsey }
     it { expect(item.mobile_enabled?).to be_truthy }
   end

--- a/spec/models/ss/site_spec.rb
+++ b/spec/models/ss/site_spec.rb
@@ -18,7 +18,6 @@ describe SS::Site do
     it { expect(subject.mobile_state).to eq 'enabled' }
     it { expect(subject.mobile_location).to eq '/mobile' }
     it { expect(subject.mobile_css).to eq ['%{assets_prefix}/cms/mobile.css'] }
-    it { expect(subject.trans_sid).to eq 'none' }
     it { expect(subject.mobile_disabled?).to be_falsey }
     it { expect(subject.mobile_enabled?).to be_truthy }
   end
@@ -34,7 +33,6 @@ describe SS::Site do
       it { expect(subject.mobile_state).to eq 'enabled' }
       it { expect(subject.mobile_location).to eq '/mobile' }
       it { expect(subject.mobile_css).to eq ['%{assets_prefix}/cms/mobile.css'] }
-      it { expect(subject.trans_sid).to eq 'none' }
       it { expect(subject.mobile_disabled?).to be_falsey }
       it { expect(subject.mobile_enabled?).to be_truthy }
     end


### PR DESCRIPTION
別案件で Trans SID の仕組みを導入してみたが、うまく動作しないので削除。

* 固定ページで Trans SID が動作しない。
* 書き出されたページで Trans SID が動作しない。

Trans SID 自体 IPA の『安全なウェブサイトの作り方』でも非推奨であり、
現状、中途半端に動作する機能となっているので Trans SID を削除する。