### PR TITLE
remove database clearner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,9 +83,6 @@ group :development, :test do
   gem 'pry-doc'
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
-  # The latest version is 1.5.0 now, but getting the same error again.
-  # ref. https://github.com/DatabaseCleaner/database_cleaner/issues/390
-  gem 'database_cleaner'
   gem 'dotenv-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,6 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6.0)
-    database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     diffy (3.1.0)
@@ -435,7 +434,6 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   compass-rails
   coveralls
-  database_cleaner
   diffy
   dotenv-rails
   dynamic_form

--- a/spec/models/voice/file_spec.rb
+++ b/spec/models/voice/file_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Voice::File, http_server: true do
+describe Voice::File, http_server: true, dbscope: :example do
   http.default port: 33_190
   http.default doc_root: Rails.root.join("spec", "fixtures", "voice")
 
@@ -84,14 +84,13 @@ describe Voice::File, http_server: true do
   context 'when error is given, has_error is set automatically' do
     random_string = rand(0x100000000).to_s(36)
     let(:site) { cms_site }
-    let(:voice_file) { described_class.find_or_create_by_url("http://#{site.domain}/" + random_string) }
-    subject do
-      voice_file.error = "has error"
-      voice_file.save!
-      voice_file
-    end
+    subject { described_class.find_or_create_by_url("http://#{site.domain}/" + random_string) }
 
-    it { is_expected.not_to be_nil }
+    before do
+      subject.error = "has error"
+      subject.save!
+      subject
+    end
 
     describe "#has_error" do
       its(:error) { is_expected.to eq "has error" }
@@ -99,11 +98,10 @@ describe Voice::File, http_server: true do
     end
 
     describe "#search" do
-      count = nil
-      before(:all) do
-        count = described_class.search({ :has_error => 1 }).count
+      it do
+        expect(described_class.count).to be >= 1
+        expect(described_class.search({ :has_error => 1 }).count).to be >= 1
       end
-      it { expect(count).to be >= 1 }
     end
   end
 

--- a/spec/models/voice/synthesis_job_spec.rb
+++ b/spec/models/voice/synthesis_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Voice::SynthesisJob, http_server: true, dbscope: :example do
+describe Voice::SynthesisJob, http_server: true do
   http.default port: 33_190
   http.default doc_root: Rails.root.join("spec", "fixtures", "voice")
 
@@ -16,6 +16,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
 
       before do
         http.options real_path: "/test-001.html"
+      end
+
+      after :all do
+        clean_database
       end
 
       it { expect(@job).not_to be_nil }
@@ -53,6 +57,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
         http.options real_path: "/test-001.html"
       end
 
+      after :all do
+        clean_database
+      end
+
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -85,6 +93,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
         http.options real_path: "/test-001.html", status_code: 400
       end
 
+      after :all do
+        clean_database
+      end
+
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -113,6 +125,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
         http.options real_path: "/test-001.html", status_code: 404
       end
 
+      after :all do
+        clean_database
+      end
+
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -139,6 +155,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
 
       before do
         http.options real_path: "/test-001.html", status_code: 500
+      end
+
+      after :all do
+        clean_database
       end
 
       it { expect(@job).not_to be_nil }
@@ -170,6 +190,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
         http.options real_path: "/test-001.html", wait: @wait
       end
 
+      after(:all) do
+        clean_database
+      end
+
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -196,6 +220,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
 
       before do
         http.options real_path: "/test-001.html", last_modified: nil
+      end
+
+      after :all do
+        clean_database
       end
 
       it { expect(@job).not_to be_nil }
@@ -231,6 +259,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
         http.options real_path: "/test-001.html"
       end
 
+      after :all do
+        clean_database
+      end
+
       subject { Voice::File.find_or_create_by(site_id: site.id, url: @url) }
 
       it "creates voice file" do
@@ -256,6 +288,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
         http.options real_path: "/test-001.html", status_code: 404
       end
 
+      after :all do
+        clean_database
+      end
+
       subject { Voice::File.find_or_create_by(site_id: site.id, url: @url) }
 
       it "creates dows not voice file" do
@@ -275,6 +311,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
         http.options real_path: "/test-001.html", wait: @wait
       end
 
+      after :all do
+        clean_database
+      end
+
       subject { Voice::File.find_or_create_by(site_id: site.id, url: @url) }
 
       it "creates dows not voice file" do
@@ -285,6 +325,10 @@ describe Voice::SynthesisJob, http_server: true, dbscope: :example do
   end
 
   describe '#purge_pending_tasks' do
+    before do
+      clean_database
+    end
+
     context "when there is no tasks" do
       it do
         expect { described_class.purge_pending_tasks }.not_to raise_error

--- a/spec/models/voice/synthesis_job_spec.rb
+++ b/spec/models/voice/synthesis_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Voice::SynthesisJob, http_server: true do
+describe Voice::SynthesisJob, http_server: true, dbscope: :example do
   http.default port: 33_190
   http.default doc_root: Rails.root.join("spec", "fixtures", "voice")
 
@@ -16,11 +16,6 @@ describe Voice::SynthesisJob, http_server: true do
 
       before do
         http.options real_path: "/test-001.html"
-      end
-
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
       end
 
       it { expect(@job).not_to be_nil }
@@ -58,11 +53,6 @@ describe Voice::SynthesisJob, http_server: true do
         http.options real_path: "/test-001.html"
       end
 
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
-      end
-
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -95,11 +85,6 @@ describe Voice::SynthesisJob, http_server: true do
         http.options real_path: "/test-001.html", status_code: 400
       end
 
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
-      end
-
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -128,11 +113,6 @@ describe Voice::SynthesisJob, http_server: true do
         http.options real_path: "/test-001.html", status_code: 404
       end
 
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
-      end
-
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -159,11 +139,6 @@ describe Voice::SynthesisJob, http_server: true do
 
       before do
         http.options real_path: "/test-001.html", status_code: 500
-      end
-
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
       end
 
       it { expect(@job).not_to be_nil }
@@ -195,11 +170,6 @@ describe Voice::SynthesisJob, http_server: true do
         http.options real_path: "/test-001.html", wait: @wait
       end
 
-      after(:all) do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
-      end
-
       it { expect(@job).not_to be_nil }
       it { expect(system(@cmd)).to be_truthy }
 
@@ -226,11 +196,6 @@ describe Voice::SynthesisJob, http_server: true do
 
       before do
         http.options real_path: "/test-001.html", last_modified: nil
-      end
-
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
       end
 
       it { expect(@job).not_to be_nil }
@@ -266,11 +231,6 @@ describe Voice::SynthesisJob, http_server: true do
         http.options real_path: "/test-001.html"
       end
 
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
-      end
-
       subject { Voice::File.find_or_create_by(site_id: site.id, url: @url) }
 
       it "creates voice file" do
@@ -296,11 +256,6 @@ describe Voice::SynthesisJob, http_server: true do
         http.options real_path: "/test-001.html", status_code: 404
       end
 
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
-      end
-
       subject { Voice::File.find_or_create_by(site_id: site.id, url: @url) }
 
       it "creates dows not voice file" do
@@ -320,11 +275,6 @@ describe Voice::SynthesisJob, http_server: true do
         http.options real_path: "/test-001.html", wait: @wait
       end
 
-      after :all do
-        DatabaseCleaner.clean
-        DatabaseCleaner.start
-      end
-
       subject { Voice::File.find_or_create_by(site_id: site.id, url: @url) }
 
       it "creates dows not voice file" do
@@ -335,11 +285,6 @@ describe Voice::SynthesisJob, http_server: true do
   end
 
   describe '#purge_pending_tasks' do
-    before do
-      DatabaseCleaner.clean
-      DatabaseCleaner.start
-    end
-
     context "when there is no tasks" do
       it do
         expect { described_class.purge_pending_tasks }.not_to raise_error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,6 @@ require 'rspec/rails'
 #require 'rspec/autorun'
 require 'capybara/rspec'
 require 'capybara/rails'
-require 'database_cleaner'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -106,14 +105,10 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
+    # load all models
+    ::Rails.application.eager_load!
     # `rake db:drop`
     ::Mongoid::Clients.default.database.drop
-    # `rake db:create_indexes`
-    ::Rails.application.eager_load!
-    ::Mongoid::Tasks::Database.create_indexes
-
-    #
-    DatabaseCleaner[:mongoid].strategy = :truncation
   end
 
   config.add_setting :default_dbscope, default: :context

--- a/spec/support/ss/database_cleaner_support.rb
+++ b/spec/support/ss/database_cleaner_support.rb
@@ -6,11 +6,10 @@ module SS
 
       obj.prepend_before(dbscope) do
         Rails.logger.debug "start database cleaner at #{inspect}"
-        DatabaseCleaner.start
       end
       obj.after(dbscope) do
         Rails.logger.debug "clean database at #{inspect}"
-        DatabaseCleaner.clean
+        ::Mongoid::Clients.default.database.drop
       end
     end
   end

--- a/spec/support/ss/database_cleaner_support.rb
+++ b/spec/support/ss/database_cleaner_support.rb
@@ -11,6 +11,15 @@ module SS
         Rails.logger.debug "clean database at #{inspect}"
         ::Mongoid::Clients.default.database.drop
       end
+
+      obj.class_eval do
+        define_singleton_method(:clean_database) do
+          ::Mongoid::Clients.default.database.drop
+        end
+        define_method(:clean_database) do
+          ::Mongoid::Clients.default.database.drop
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
MongoDB 3.2 + WiredTiger (Default Storage Engine on MongoDB 3.2) + DatabaseCleaner の組み合わせがうまく動作しないことが分かりました。
https://github.com/DatabaseCleaner/database_cleaner/issues/392

DatabaseCleaner は、前にも MongoDB との相性が悪くうまく動作しないことが何度かありましたので、
DatabaseCleaner の使用をやめて、自前で Database Cleaner 相当のことを処理することにしました。

DatabaseCleaner では、全てのコレクションを削除していましたが、本プルリクではデータベースを drop するようにしたので、テストが少し早くなったと思います。