### PR TITLE
user title order

### DIFF
--- a/app/controllers/gws/schedule/group_plans_controller.rb
+++ b/app/controllers/gws/schedule/group_plans_controller.rb
@@ -12,6 +12,6 @@ class Gws::Schedule::GroupPlansController < ApplicationController
 
   public
     def index
-      @items = @group.users
+      @items = @group.users.order_by("title_orders.#{@cur_site.id}" => 1, name: 1).compact
     end
 end

--- a/app/controllers/gws/users_controller.rb
+++ b/app/controllers/gws/users_controller.rb
@@ -17,6 +17,16 @@ class Gws::UsersController < ApplicationController
     end
 
   public
+    def index
+      #raise "403" unless @model.allowed?(:read, @cur_user, site: @cur_site)
+
+      @items = @model.site(@cur_site).
+        allow(:read, @cur_user, site: @cur_site).
+        search(params[:s]).
+        order_by("title_orders.#{@cur_site.id}" => 1, name: 1).
+        page(params[:page]).per(50)
+    end
+
     def update
       other_group_ids = Gws::Group.nin(id: Gws::Group.site(@cur_site).pluck(:id)).in(id: @item.group_ids).pluck(:id)
       other_role_ids = Gws::Role.nin(id: Gws::Role.site(@cur_site).pluck(:id)).in(id: @item.gws_role_ids).pluck(:id)

--- a/app/models/concerns/ss/model/user.rb
+++ b/app/models/concerns/ss/model/user.rb
@@ -3,9 +3,10 @@ module SS::Model::User
   extend SS::Translation
   include SS::Document
   include SS::Fields::Normalizer
+  include SS::Reference::UserTitles
   include Ldap::Addon::User
 
-  attr_accessor :cur_user, :in_password, :self_edit
+  attr_accessor :cur_site, :cur_user, :in_password, :self_edit
 
   TYPE_SNS = "sns".freeze
   TYPE_LDAP = "ldap".freeze
@@ -37,7 +38,6 @@ module SS::Model::User
     field :initial_password_warning, type: Integer
 
     embeds_ids :groups, class_name: "SS::Group"
-    embeds_ids :titles, class_name: "SS::UserTitle"
 
     permit_params :name, :uid, :email, :password, :tel, :type, :login_roles, :remark, group_ids: []
     permit_params :in_password
@@ -124,10 +124,6 @@ module SS::Model::User
     end
   end
 
-  def title(group)
-    titles.where(group_id: cur_site.id).first
-  end
-
   def enabled?
     now = Time.zone.now
     return false if account_start_date.present? && account_start_date > now
@@ -147,10 +143,6 @@ module SS::Model::User
       return false unless login_roles.include?(LOGIN_ROLE_DBPASSWD)
       return false if password.blank?
       password == SS::Crypt.crypt(in_passwd)
-    end
-
-    def set_title_ids
-      #
     end
 
     def validate_type

--- a/app/models/concerns/ss/model/user_title.rb
+++ b/app/models/concerns/ss/model/user_title.rb
@@ -16,6 +16,7 @@ module SS::Model::UserTitle
     permit_params :name, :order
 
     validates :name, presence: true, length: { maximum: 40 }
+    validates :order, presence: true
     validates :group_id, presence: true
 
     scope :search, ->(params) {

--- a/app/models/concerns/ss/model/user_title.rb
+++ b/app/models/concerns/ss/model/user_title.rb
@@ -19,6 +19,8 @@ module SS::Model::UserTitle
     validates :order, presence: true
     validates :group_id, presence: true
 
+    index({ group_id: 1, order: 1})
+
     scope :search, ->(params) {
       criteria = where({})
       return criteria if params.blank?

--- a/app/models/concerns/ss/reference/user_titles.rb
+++ b/app/models/concerns/ss/reference/user_titles.rb
@@ -1,0 +1,67 @@
+module SS::Reference
+  module UserTitles
+    extend ActiveSupport::Concern
+    extend SS::Translation
+
+    included do
+      embeds_ids :titles, class_name: "SS::UserTitle"
+      field :title_orders, type: Hash
+      before_save :update_title_order
+    end
+
+    class_methods do
+      def update_all_title_orders(title)
+        self.where(title_ids: title.id).each do |item|
+          item.send(:set_title_order, title)
+          item.save
+        end
+      end
+    end
+
+    def title
+      return nil if cur_site.blank?
+      titles.where(group_id: cur_site.id).first
+    end
+
+    def update_title_order(title = nil)
+      title ||= self.title
+
+      if title.present?
+        set_title_order(title)
+      else
+        remove_title_order
+      end
+    end
+
+    private
+      # def set_title_ids
+      #   #
+      # end
+
+      def set_title_order(title)
+        orders = self.title_orders
+        orders = {} if orders.nil?
+
+        return if orders[title.group_id.to_s] == title.order
+
+        # hash key must be string
+        orders[title.group_id.to_s] = title.order
+
+        # overwrite with new hash instance
+        self.title_orders = orders.deep_dup
+      end
+
+      def remove_title_order
+        return if cur_site.blank?
+
+        orders = self.title_orders
+        return if orders.blank?
+        return unless orders.key?(cur_site.id.to_s)
+
+        orders.delete(cur_site.id.to_s)
+
+        # overwrite with new hash instance
+        self.title_orders = orders.deep_dup
+      end
+  end
+end

--- a/app/models/gws/user.rb
+++ b/app/models/gws/user.rb
@@ -8,7 +8,7 @@ class Gws::User
 
   cattr_reader(:group_class) { Gws::Group }
 
-  attr_accessor :cur_site, :in_title_id
+  attr_accessor :in_title_id
 
   embeds_ids :groups, class_name: "Gws::Group"
 

--- a/app/models/gws/user.rb
+++ b/app/models/gws/user.rb
@@ -17,6 +17,9 @@ class Gws::User
   before_validation :set_title_ids, if: ->{ in_title_id }
   validate :validate_groups
 
+  # reset default order
+  self.default_scoping = nil if default_scopable?
+
   scope :site, ->(site) { self.in(group_ids: Gws::Group.site(site).pluck(:id)) }
 
   def title_id_options

--- a/app/models/gws/user_title.rb
+++ b/app/models/gws/user_title.rb
@@ -7,11 +7,17 @@ class Gws::UserTitle
   attr_accessor :cur_user, :cur_site
 
   before_validation :set_group_id, if: ->{ cur_site.present? }
+  after_save :update_users_title_order
 
   scope :site, ->(site) { where group_id: site.id }
 
   private
     def set_group_id
       self.group_id = cur_site.id
+    end
+
+    def update_users_title_order
+      return if self.order_was.nil?
+      Gws::User.update_all_title_orders(self)
     end
 end

--- a/app/models/gws/user_title.rb
+++ b/app/models/gws/user_title.rb
@@ -9,6 +9,7 @@ class Gws::UserTitle
   before_validation :set_group_id, if: ->{ cur_site.present? }
   after_save :update_users_title_order
 
+  default_scope -> { order_by(order: 1) }
   scope :site, ->(site) { where group_id: site.id }
 
   private

--- a/app/views/gws/users/_form.html.erb
+++ b/app/views/gws/users/_form.html.erb
@@ -29,7 +29,7 @@ $("#random-password").click(function() {
   <dd><%= f.text_field :tel %></dd>
 
   <dt><%= @model.t :title_ids %><%= @model.tt :title_ids %></dt>
-  <dd><%= f.select :in_title_id, @item.title_id_options, selected: tryb { @item.title(@cur_site).id }, include_blank: "" %></dd>
+  <dd><%= f.select :in_title_id, @item.title_id_options, selected: tryb { @item.title.id }, include_blank: "" %></dd>
 
   <dt><%= @model.t :type %><%= @model.tt :type %></dt>
   <dd><%= f.select :type, @model.type_options %></dd>

--- a/app/views/gws/users/_show.html.erb
+++ b/app/views/gws/users/_show.html.erb
@@ -8,15 +8,11 @@
   <dt><%= @model.t :email %></dt>
   <dd><%= @item.send :email %></dd>
 
-  <% if @item.tel.present? %>
   <dt><%= @model.t :tel %></dt>
   <dd><%= @item.send :tel %></dd>
-  <% end %>
 
-  <% if title = @item.title %>
   <dt><%= @model.t :title_ids %></dt>
-  <dd><%= title.name %></dd>
-  <% end %>
+  <dd><%= tryb { @item.title.name } %></dd>
 
   <dt><%= @model.t :type %></dt>
   <dd><%= @item.send :type %></dd>

--- a/app/views/gws/users/_show.html.erb
+++ b/app/views/gws/users/_show.html.erb
@@ -13,7 +13,7 @@
   <dd><%= @item.send :tel %></dd>
   <% end %>
 
-  <% if title = @item.title(@cur_site) %>
+  <% if title = @item.title %>
   <dt><%= @model.t :title_ids %></dt>
   <dd><%= title.name %></dd>
   <% end %>

--- a/app/views/gws/users/index.html.erb
+++ b/app/views/gws/users/index.html.erb
@@ -1,13 +1,18 @@
 <% @index_meta = proc do |item| %>
+  <% item.cur_site = @cur_site %>
   <span class="id">#<%= item.uid.presence || item.id %></span>
   <span class="datetime"><%= item.updated.strftime("%Y/%m/%d %H:%M") %></span>
 
   <% if item.email.present? %>
-  <span><%= mail_to item.email %></span>
+  <span class="email"><%= mail_to item.email %></span>
   <% end %>
 
   <% if item.tel.present? %>
-  <span><%= item.tel %></span>
+  <span class="tel"><%= item.tel %></span>
+  <% end %>
+
+  <% if item.title.present? %>
+  <span class="user-title"><%= item.title.name %></span>
   <% end %>
 <% end %>
 

--- a/spec/factories/chorg/changesets.rb
+++ b/spec/factories/chorg/changesets.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :add_changeset, class: Chorg::Changeset do
     type Chorg::Changeset::TYPE_ADD
-    destinations { [ { name: "シラサギ市/新設グループ_#{unique_id}" }.stringify_keys ] }
+    destinations { [ { name: "組織変更/新設グループ_#{unique_id}" }.stringify_keys ] }
   end
 
   factory :move_changeset, class: Chorg::Changeset do
@@ -12,7 +12,7 @@ FactoryGirl.define do
     type Chorg::Changeset::TYPE_MOVE
     sources { [ { id: source.id, name: source.name }.stringify_keys ] }
     destinations do
-      [ { name: "シラサギ市/新設グループ_#{unique_id}",
+      [ { name: "組織変更/新設グループ_#{unique_id}",
           order: "",
           contact_email: "mb4pjr0czv@example.jp",
           contact_tel: "03-8471-8438",
@@ -29,7 +29,7 @@ FactoryGirl.define do
     type Chorg::Changeset::TYPE_MOVE
     sources { [ { id: source.id, name: source.name }.stringify_keys ] }
     destinations do
-      [ { name: "シラサギ市/新設グループ_#{unique_id}",
+      [ { name: "組織変更/新設グループ_#{unique_id}",
           order: "",
           contact_email: "",
           contact_tel: "",
@@ -46,7 +46,7 @@ FactoryGirl.define do
 
     type Chorg::Changeset::TYPE_UNIFY
     destinations do
-      [ { name: "シラサギ市/新設グループ_#{unique_id}",
+      [ { name: "組織変更/新設グループ_#{unique_id}",
           order: "",
           contact_email: "mb4pjr0czv@example.jp",
           contact_tel: "03-8471-8438",

--- a/spec/factories/chorg/revisions.rb
+++ b/spec/factories/chorg/revisions.rb
@@ -4,11 +4,11 @@ FactoryGirl.define do
   end
 
   factory :revision_root_group, parent: :cms_group do
-    name { "シラサギ市" }
+    name { "組織変更" }
   end
 
   factory :revision_new_group, parent: :cms_group do
-    name { "シラサギ市/グループ#{unique_id}" }
+    name { "組織変更/グループ#{unique_id}" }
     contact_email { "#{unique_id}@example.jp" }
     contact_tel "03-4389-8714"
     contact_fax "03-4389-8715"

--- a/spec/factories/gws/user_titles.rb
+++ b/spec/factories/gws/user_titles.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  trait :gws_user_title_base do
+    cur_site { gws_site }
+    cur_user { gws_user }
+
+    name { "title-#{unique_id}" }
+  end
+
+  trait :gws_user_title_random_order do
+    order { rand(10000) }
+  end
+
+  factory :gws_user_title, class: Gws::UserTitle, traits: [:gws_user_title_base, :gws_user_title_random_order] do
+  end
+end

--- a/spec/factories/gws/users.rb
+++ b/spec/factories/gws/users.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  trait :gws_user_base do
+    transient do
+      cur_group gws_site
+    end
+
+    cur_site { gws_site }
+    cur_user { gws_user }
+
+    group_ids { [ cur_group.id ] }
+    name { "name-#{unique_id}" }
+    uid { "uid-#{unique_id}" }
+    email { "#{uid}@example.jp" }
+    in_password "pass"
+  end
+
+  factory :gws_user, class: Gws::User, traits: [:gws_user_base] do
+  end
+end

--- a/spec/factories/sys/groups.rb
+++ b/spec/factories/sys/groups.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :sys_group, class: Sys::Group do
+    name { unique_id }
+  end
+end

--- a/spec/features/cms/groups_spec.rb
+++ b/spec/features/cms/groups_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
-describe "cms_groups" do
-  subject(:site) { cms_site }
-  subject(:item) { Cms::Group.last }
-  subject(:index_path) { cms_groups_path site.id }
-  subject(:new_path) { new_cms_group_path site.id }
-  subject(:show_path) { cms_group_path site.id, item }
-  subject(:edit_path) { edit_cms_group_path site.id, item }
-  subject(:delete_path) { delete_cms_group_path site.id, item }
-  subject(:import_path) { import_cms_groups_path site.id }
+describe "cms_groups", type: :feature, dbscope: :example do
+  let(:site) { cms_site }
+  let(:item) { cms_group }
+  let(:index_path) { cms_groups_path site.id }
+  let(:new_path) { new_cms_group_path site.id }
+  let(:show_path) { cms_group_path site.id, item }
+  let(:edit_path) { edit_cms_group_path site.id, item }
+  let(:delete_path) { delete_cms_group_path site.id, item }
+  let(:import_path) { import_cms_groups_path site.id }
 
   it "without login" do
     visit index_path

--- a/spec/features/sys/db_spec.rb
+++ b/spec/features/sys/db_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe "sys_db" do
-  subject(:index_path) { sys_db_colls_path }
+describe "sys_db", type: :feature, dbscope: :example do
+  let(:index_path) { sys_db_colls_path }
 
   it "without login" do
     visit index_path

--- a/spec/features/sys/groups_spec.rb
+++ b/spec/features/sys/groups_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "sys_groups" do
-  subject(:item) { Sys::Group.last }
-  subject(:index_path) { sys_groups_path }
-  subject(:new_path) { new_sys_group_path }
-  subject(:show_path) { sys_group_path item }
-  subject(:edit_path) { edit_sys_group_path item }
-  subject(:delete_path) { delete_sys_group_path item }
+describe "sys_groups", type: :feature, dbscope: :example do
+  let(:item) { create(:sys_group) }
+  let(:index_path) { sys_groups_path }
+  let(:new_path) { new_sys_group_path }
+  let(:show_path) { sys_group_path item }
+  let(:edit_path) { edit_sys_group_path item }
+  let(:delete_path) { delete_sys_group_path item }
 
   it "without login" do
     visit index_path

--- a/spec/features/sys/info_spec.rb
+++ b/spec/features/sys/info_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe "sys_info" do
-  subject(:index_path) { sys_info_path }
+describe "sys_info", type: :feature, dbscope: :example do
+  let(:index_path) { sys_info_path }
 
   it "without login" do
     visit index_path

--- a/spec/features/sys/roles_spec.rb
+++ b/spec/features/sys/roles_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "sys_users" do
-  subject(:item) { Sys::Role.last }
-  subject(:index_path) { sys_roles_path }
-  subject(:new_path) { new_sys_role_path }
-  subject(:show_path) { sys_role_path item }
-  subject(:edit_path) { edit_sys_role_path item }
-  subject(:delete_path) { delete_sys_role_path item }
+describe "sys_users", type: :feature, dbscope: :example do
+  let(:item) { create(:sys_role) }
+  let(:index_path) { sys_roles_path }
+  let(:new_path) { new_sys_role_path }
+  let(:show_path) { sys_role_path item }
+  let(:edit_path) { edit_sys_role_path item }
+  let(:delete_path) { delete_sys_role_path item }
 
   it "without login" do
     visit index_path

--- a/spec/features/sys/sites_spec.rb
+++ b/spec/features/sys/sites_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "sys_users" do
-  subject(:item) { SS::Site.last }
-  subject(:index_path) { sys_sites_path }
-  subject(:new_path) { new_sys_site_path }
-  subject(:show_path) { sys_site_path item }
-  subject(:edit_path) { edit_sys_site_path item }
-  subject(:delete_path) { delete_sys_site_path item }
+describe "sys_users", type: :feature, dbscope: :example do
+  let(:item) { create(:sys_site) }
+  let(:index_path) { sys_sites_path }
+  let(:new_path) { new_sys_site_path }
+  let(:show_path) { sys_site_path item }
+  let(:edit_path) { edit_sys_site_path item }
+  let(:delete_path) { delete_sys_site_path item }
 
   it "without login" do
     visit index_path

--- a/spec/features/sys/test_spec.rb
+++ b/spec/features/sys/test_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "sys_test" do
+describe "sys_test", type: :feature, dbscope: :example do
   subject(:index_path) { sys_test_path }
 
   it "without login" do

--- a/spec/features/sys/users_spec.rb
+++ b/spec/features/sys/users_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe "sys_users" do
-  subject(:item) { create :sys_user_sample }
-  subject(:index_path) { sys_users_path }
-  subject(:new_path) { new_sys_user_path }
-  subject(:show_path) { sys_user_path item }
-  subject(:edit_path) { edit_sys_user_path item }
-  subject(:delete_path) { delete_sys_user_path item }
+describe "sys_users", type: :feature, dbscope: :example do
+  let(:item) { create :sys_user_sample }
+  let(:index_path) { sys_users_path }
+  let(:new_path) { new_sys_user_path }
+  let(:show_path) { sys_user_path item }
+  let(:edit_path) { edit_sys_user_path item }
+  let(:delete_path) { delete_sys_user_path item }
 
   it "without login" do
     visit index_path

--- a/spec/models/chorg/substituter_spec.rb
+++ b/spec/models/chorg/substituter_spec.rb
@@ -64,11 +64,11 @@ describe Chorg::Substituter::StringSubstituter do
       end
 
       context "with group hierarchy" do
-        let(:from) { "シラサギ市/企画政策部/企画政策部 広報課" }
-        let(:to) { "シラサギ市/企画政策部/企画政策部 政策課" }
+        let(:from) { "組織変更/企画政策部/企画政策部 広報課" }
+        let(:to) { "組織変更/企画政策部/企画政策部 政策課" }
         subject { described_class.new(from, to) }
-        it { expect(subject.call("シラサギ市/企画政策部/企画政策部 広報課")).to eq "シラサギ市/企画政策部/企画政策部 政策課" }
-        it { expect(subject.call("シラサギ市/危機管理部/危機管理部 管理課")).to eq "シラサギ市/危機管理部/危機管理部 管理課" }
+        it { expect(subject.call("組織変更/企画政策部/企画政策部 広報課")).to eq "組織変更/企画政策部/企画政策部 政策課" }
+        it { expect(subject.call("組織変更/危機管理部/危機管理部 管理課")).to eq "組織変更/危機管理部/危機管理部 管理課" }
         it { expect(subject.call("企画政策部 広報課")).to eq "企画政策部 広報課" }
         it { expect(subject.call("危機管理部 管理課")).to eq "危機管理部 管理課" }
       end
@@ -78,7 +78,7 @@ describe Chorg::Substituter::StringSubstituter do
   describe "#<=>" do
     let(:substituer1) { described_class.new("kmsrgxit7k@example.jp", "tfszbhe91d@example.jp") }
     let(:substituer2) { described_class.new("kmsrgxit7k", "tfszbhe91d") }
-    let(:substituer3) { described_class.new("シラサギ市/企画政策部/企画政策部 長生き課", "シラサギ市/健康管理部/健康管理部 地域連携課") }
+    let(:substituer3) { described_class.new("組織変更/企画政策部/企画政策部 長生き課", "組織変更/健康管理部/健康管理部 地域連携課") }
     let(:substituer4) { described_class.new("企画政策部 長生き課", "健康管理部 地域連携課") }
     let(:substituer5) { Chorg::Substituter::IdSubstituter.new(30_016, []) }
 
@@ -101,18 +101,18 @@ end
 describe Chorg::Substituter do
   context "with simple substitution" do
     let(:from) do
-      { id: 30_016, name: "シラサギ市/企画政策部/企画政策部 長生き課",
+      { id: 30_016, name: "組織変更/企画政策部/企画政策部 長生き課",
         contact_email: "kmsrgxit7k@example.jp", release_date: Time.zone.now }
     end
     let(:to) do
-      { id: 31_016, name: "シラサギ市/健康管理部/健康管理部 地域連携課",
+      { id: 31_016, name: "組織変更/健康管理部/健康管理部 地域連携課",
         contact_email: "1b3ubagfds@example.jp", release_date: Time.zone.now }
     end
     subject { described_class.collect(from, to) }
 
     describe "#call" do
       it { expect(subject.call(30_016)).to eq 31_016 }
-      it { expect(subject.call("シラサギ市/企画政策部/企画政策部 長生き課")).to eq "シラサギ市/健康管理部/健康管理部 地域連携課" }
+      it { expect(subject.call("組織変更/企画政策部/企画政策部 長生き課")).to eq "組織変更/健康管理部/健康管理部 地域連携課" }
       it { expect(subject.call("企画政策部 長生き課")).to eq "健康管理部 地域連携課" }
       it { expect(subject.call("kmsrgxit7k@example.jp")).to eq "1b3ubagfds@example.jp" }
 
@@ -126,23 +126,23 @@ describe Chorg::Substituter do
   end
 
   context "with multiple substitutions" do
-    let(:from1) { { id: 30_015, name: "シラサギ市/企画政策部" } }
+    let(:from1) { { id: 30_015, name: "組織変更/企画政策部" } }
     let(:from2) do
-      { id: 30_016, name: "シラサギ市/企画政策部/企画政策部 長生き課",
+      { id: 30_016, name: "組織変更/企画政策部/企画政策部 長生き課",
         contact_email: "kmsrgxit7k@example.jp", release_date: Time.zone.now }
     end
-    let(:to1) { { id: 31_015, name: "シラサギ市/健康管理部" } }
+    let(:to1) { { id: 31_015, name: "組織変更/健康管理部" } }
     let(:to2) do
-      { id: 31_016, name: "シラサギ市/健康管理部/健康管理部 地域連携課",
+      { id: 31_016, name: "組織変更/健康管理部/健康管理部 地域連携課",
         contact_email: "1b3ubagfds@example.jp", release_date: Time.zone.now }
     end
     subject { described_class.collect(from1, to1).collect(from2, to2) }
 
     it { expect(subject.call(30_015)).to eq 31_015 }
     it { expect(subject.call(30_016)).to eq 31_016 }
-    it { expect(subject.call("シラサギ市/企画政策部")).to eq "シラサギ市/健康管理部" }
+    it { expect(subject.call("組織変更/企画政策部")).to eq "組織変更/健康管理部" }
     it { expect(subject.call("企画政策部")).to eq "健康管理部" }
-    it { expect(subject.call("シラサギ市/企画政策部/企画政策部 長生き課")).to eq "シラサギ市/健康管理部/健康管理部 地域連携課" }
+    it { expect(subject.call("組織変更/企画政策部/企画政策部 長生き課")).to eq "組織変更/健康管理部/健康管理部 地域連携課" }
     it { expect(subject.call("企画政策部 長生き課")).to eq "健康管理部 地域連携課" }
     it { expect(subject.call("kmsrgxit7k@example.jp")).to eq "1b3ubagfds@example.jp" }
 
@@ -167,7 +167,7 @@ describe Chorg::Substituter do
 
   describe "does not substitute to nil" do
     let(:from) do
-      { id: 30_016, name: "シラサギ市/企画政策部/企画政策部 長生き課",
+      { id: 30_016, name: "組織変更/企画政策部/企画政策部 長生き課",
         contact_email: "kmsrgxit7k@example.jp", release_date: Time.zone.now }
     end
     let(:to) { { id: 31_016 } }
@@ -175,7 +175,7 @@ describe Chorg::Substituter do
 
     describe "#call" do
       it { expect(subject.call(30_016)).to eq 31_016 }
-      it { expect(subject.call("シラサギ市/企画政策部/企画政策部 長生き課")).to eq "シラサギ市/企画政策部/企画政策部 長生き課" }
+      it { expect(subject.call("組織変更/企画政策部/企画政策部 長生き課")).to eq "組織変更/企画政策部/企画政策部 長生き課" }
       it { expect(subject.call("企画政策部 長生き課")).to eq "企画政策部 長生き課" }
       it { expect(subject.call("kmsrgxit7k@example.jp")).to eq "kmsrgxit7k@example.jp" }
     end

--- a/spec/models/gws/user_title_spec.rb
+++ b/spec/models/gws/user_title_spec.rb
@@ -50,7 +50,7 @@ describe Gws::UserTitle, type: :model, dbscope: :example do
       user1.save
 
       expect(user1.title_ids).to eq []
-      expect(user1.title_orders[title1.group_id.to_s]).to be_nil
+      expect(user1.title_orders[title1.group_id.to_s]).to eq 10_000_000
     end
   end
 end

--- a/spec/models/gws/user_title_spec.rb
+++ b/spec/models/gws/user_title_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Gws::UserTitle, type: :model, dbscope: :example do
+  let(:model) { described_class }
+
+  describe "validation" do
+    it { expect(model.new.save).to be_falsey }
+  end
+
+  describe "factory" do
+    subject { create :gws_user_title }
+    its(:name) { is_expected.not_to be_nil }
+    its(:order) { is_expected.not_to be_nil }
+    its(:valid?) { is_expected.to be_truthy }
+  end
+
+  describe "title and its order" do
+    let(:title1) { create :gws_user_title }
+    let(:title2) { create :gws_user_title, order: title1.order + 10 }
+    let!(:user1) { create :gws_user, in_title_id: title1.id }
+    let!(:user2) { create :gws_user, in_title_id: title2.id }
+
+    it "initial title order" do
+      user1.reload
+      user2.reload
+      expect(user1.title_orders[title1.group_id.to_s]).to eq title1.order
+      expect(user2.title_orders[title2.group_id.to_s]).to eq title2.order
+    end
+
+    it "change title's order" do
+      title1.order = title1.order - 10
+      expect(title1.save).to be_truthy
+
+      user1.reload
+      user2.reload
+      expect(user1.title_orders[title1.group_id.to_s]).to eq title1.order
+      expect(user2.title_orders[title2.group_id.to_s]).to eq title2.order
+    end
+
+    it "change user's title" do
+      user1.in_title_id = title2.id
+      user1.save
+
+      expect(user1.title_orders[title1.group_id.to_s]).not_to eq title1.order
+      expect(user1.title_orders[title2.group_id.to_s]).to eq title2.order
+    end
+
+    it "remove user's title" do
+      user1.in_title_id = ""
+      user1.save
+
+      expect(user1.title_ids).to eq []
+      expect(user1.title_orders[title1.group_id.to_s]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
役職順表示に対応しました。
課題がいくつかあります。

* 平社員（＝役職なし）が役職order を持てないため、1千万を既定でセットするようにしました。
  * 全 Gws::User の再保存が必要です。
* 役職順にソートできるようになりましたが、index を使用した効率のよいソート方法が不明で、MongoDB にメモリでソートしてもらっている状態です。ユーザー数が数千を超えると、うまくソートできるのかどうか...。