### PR TITLE
スケジュールの prev と next が正しく表示されない問題の修正

### DIFF
--- a/app/assets/stylesheets/gws/style.scss
+++ b/app/assets/stylesheets/gws/style.scss
@@ -1,6 +1,3 @@
-//= require fullcalendar
-//= require fullcalendar-scheduler/scheduler.min.css
-
 @import "ss/init";
 @import "ss/lib";
 @import "ss/pc_mb";

--- a/app/assets/stylesheets/ss/style.scss
+++ b/app/assets/stylesheets/ss/style.scss
@@ -2,6 +2,7 @@
  *= require jquery.datetimepicker
  *= require jquery.multi-select
  *= require fullcalendar
+ *= require fullcalendar-scheduler/scheduler.min.css
  */
 
 // base

--- a/app/assets/stylesheets/ss/style.scss
+++ b/app/assets/stylesheets/ss/style.scss
@@ -22,3 +22,8 @@
 @import "kana/ss";
 @import "ldap/ss";
 @import "workflow/ss";
+
+// fix fullcalendar issue: https://github.com/fullcalendar/fullcalendar/issues/2852
+.fc-icon:after {
+  margin: 0 0; color: black
+}


### PR DESCRIPTION
Win10 Edge で prev と next が正しく表示されない問題は、以下の Issue に登録されたまま未解決です。
https://github.com/fullcalendar/fullcalendar/issues/2852

※2015/12/19 のコメントにあるように
※.fc-icon:after {margin: 0 0; color: black}
※とすると直ると思います。