### PR TITLE
[fix] every 5th monday schedule plan

### DIFF
--- a/app/models/gws/schedule/repeat_plan.rb
+++ b/app/models/gws/schedule/repeat_plan.rb
@@ -108,9 +108,10 @@ class Gws::Schedule::RepeatPlan
       dates = []
       dates << repeat_start
 
-      dates.each do |date|
-        date += interval.month
-        dates << date if date <= repeat_end
+      1.upto(1_024) do |i|
+        date = (interval * i).months.since(repeat_start)
+        break if date > repeat_end
+        dates << date
       end
       dates
     end
@@ -175,8 +176,10 @@ class Gws::Schedule::RepeatPlan
     #                             条件が不正な場合は近い日が返る
     #                             例えば 4 月に第 5 月曜日が存在しなかった場合、第 4 月曜日を返す。
     def get_date_by_nearest_ordinal_week(year, month, week, wday)
-      while week >= 0 && (ret = get_date_by_ordinal_week(year, month, week, wday)).nil?
-        week = week - 1
+      while week > 0
+        ret = get_date_by_ordinal_week(year, month, week, wday)
+        break if ret.present?
+        week -= 1
       end
       ret
     end

--- a/spec/features/gws/schedule/plans/repeated_spec.rb
+++ b/spec/features/gws/schedule/plans/repeated_spec.rb
@@ -5,21 +5,22 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example do
     let(:site) { gws_site }
     let(:index_path) { gws_schedule_plans_path site }
     let(:name) { unique_id }
-    let(:repeat_start_text) { "2016/04/15" }
-    let(:repeat_start) { Date.parse(repeat_start_text) }
-    let(:repeat_end_text) { "2017/04/15" }
-    let(:repeat_end) { Date.parse(repeat_end_text) }
-    let(:start_at_text) { "#{repeat_start_text} 19:15" }
-    let(:start_at) { Time.zone.parse(start_at_text) }
-    let(:end_at_text) { "#{repeat_start_text} 19:30" }
-    let(:end_at) { Time.zone.parse(end_at_text) }
-    let(:repeat_type) { "daily" }
-    let(:repeat_type_label) { I18n.t("gws/schedule.options.repeat_type.#{repeat_type}") }
-    let(:interval) { 3 }
 
     before { login_gws_user }
 
     context "every day" do
+      let(:repeat_start_text) { "2016/04/15" }
+      let(:repeat_start) { Date.parse(repeat_start_text) }
+      let(:repeat_end_text) { "2017/04/15" }
+      let(:repeat_end) { Date.parse(repeat_end_text) }
+      let(:start_at_text) { "#{repeat_start_text} 19:15" }
+      let(:start_at) { Time.zone.parse(start_at_text) }
+      let(:end_at_text) { "#{repeat_start_text} 19:30" }
+      let(:end_at) { Time.zone.parse(end_at_text) }
+      let(:repeat_type) { "daily" }
+      let(:repeat_type_label) { I18n.t("gws/schedule.options.repeat_type.#{repeat_type}") }
+      let(:interval) { 3 }
+
       it do
         visit index_path
         click_on "予定を作成"
@@ -66,6 +67,79 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example do
 
         # gws_reminders
         expect(Gws::Reminder.count).to eq 122
+        Gws::Reminder.first.tap do |item|
+          expect(item.name).to eq name
+          expect(item.url_lazy).not_to be_nil
+          expect(item.date).to eq start_at
+          expect(item.model).to eq 'gws/schedule/plan'
+          expect(item.item_id).not_to be_nil
+          expect(item.read_at).not_to be_nil
+          # expect(item.updated_fields).to eq ["groups_hash"]
+        end
+      end
+    end
+
+    context "set every month plan on 5th monday" do
+      let(:repeat_start_text) { "2016/05/30" }
+      let(:repeat_start) { Date.parse(repeat_start_text) }
+      let(:repeat_end_text) { "2017/05/29" }
+      let(:repeat_end) { Date.parse(repeat_end_text) }
+      let(:start_at_text) { "#{repeat_start_text} 13:00" }
+      let(:start_at) { Time.zone.parse(start_at_text) }
+      let(:end_at_text) { "#{repeat_start_text} 14:00" }
+      let(:end_at) { Time.zone.parse(end_at_text) }
+      let(:repeat_type) { "monthly" }
+      let(:repeat_type_label) { I18n.t("gws/schedule.options.repeat_type.#{repeat_type}") }
+      let(:repeat_base) { "wday" }
+      let(:interval) { 1 }
+
+      it do
+        visit index_path
+        click_on "予定を作成"
+
+        within "form#item-form" do
+          fill_in "item[name]", with: name
+          fill_in "item[start_at]", with: start_at_text
+          fill_in "item[end_at]", with: end_at_text
+          select repeat_type_label, from: "item[repeat_type]"
+          select interval.to_s, from: "item[interval]"
+          choose "item_repeat_base_#{repeat_base}"
+          fill_in "item[repeat_start]", with: repeat_start_text
+          fill_in "item[repeat_end]", with: repeat_end_text
+
+          click_on "保存"
+        end
+
+        expect(page).to have_css("aside#notice div", text: "保存しました。")
+
+        # gws_schedule_repeat_plans
+        expect(Gws::Schedule::RepeatPlan.count).to eq 1
+        Gws::Schedule::RepeatPlan.first.tap do |item|
+          expect(item.repeat_type).to eq repeat_type
+          expect(item.interval).to eq interval
+          expect(item.repeat_start).to eq repeat_start
+          expect(item.repeat_end).to eq repeat_end
+          expect(item.repeat_base).to eq 'wday'
+          expect(item.wdays).to eq []
+        end
+
+        # gws_schedule_plans
+        expect(Gws::Schedule::Plan.count).to eq 13
+        Gws::Schedule::Plan.first.tap do |item|
+          expect(item.state).to eq 'public'
+          expect(item.name).to eq name
+          expect(item.start_on).to be_nil
+          expect(item.end_on).to be_nil
+          expect(item.start_at).to eq start_at
+          expect(item.end_at).to eq end_at
+          expect(item.allday).to be_nil
+          expect(item.repeat_plan_id).not_to be_nil
+          expect(item.text).to be_nil
+          expect(item.target).to eq 'all'
+        end
+
+        # gws_reminders
+        expect(Gws::Reminder.count).to eq 13
         Gws::Reminder.first.tap do |item|
           expect(item.name).to eq name
           expect(item.url_lazy).not_to be_nil

--- a/spec/models/gws/schedule/repeat_plan_spec.rb
+++ b/spec/models/gws/schedule/repeat_plan_spec.rb
@@ -9,6 +9,50 @@ RSpec.describe Gws::Schedule::RepeatPlan, type: :model, dbscope: :example, tmpdi
   let(:friday) { 5 }
   let(:saturday) { 6 }
 
+  describe "#monthly_dates_by_date" do
+    context "with 2016/05/01～2017/5/01" do
+      let(:repeat_start) { Date.new(2016, 5, 1) }
+      let(:repeat_end) { Date.new(2017, 5, 1) }
+      let(:interval) { 1 }
+      let(:item) { described_class.new(repeat_start: repeat_start, repeat_end: repeat_end, interval: 1) }
+      subject { item.send(:monthly_dates_by_date) }
+
+      it { is_expected.to include(Date.new(2016, 5, 1)) }
+      it { is_expected.to include(Date.new(2016, 6, 1)) }
+      it { is_expected.to include(Date.new(2016, 7, 1)) }
+      it { is_expected.to include(Date.new(2016, 8, 1)) }
+      it { is_expected.to include(Date.new(2016, 9, 1)) }
+      it { is_expected.to include(Date.new(2016, 10, 1)) }
+      it { is_expected.to include(Date.new(2016, 11, 1)) }
+      it { is_expected.to include(Date.new(2016, 12, 1)) }
+      it { is_expected.to include(Date.new(2017, 1, 1)) }
+      it { is_expected.to include(Date.new(2017, 2, 1)) }
+      it { is_expected.to include(Date.new(2017, 3, 1)) }
+      it { is_expected.to include(Date.new(2017, 4, 1)) }
+    end
+
+    context "with 2016/05/31～2017/5/31" do
+      let(:repeat_start) { Date.new(2016, 5, 31) }
+      let(:repeat_end) { Date.new(2017, 5, 31) }
+      let(:interval) { 1 }
+      let(:item) { described_class.new(repeat_start: repeat_start, repeat_end: repeat_end, interval: 1) }
+      subject { item.send(:monthly_dates_by_date) }
+
+      it { is_expected.to include(Date.new(2016, 5, 31)) }
+      it { is_expected.to include(Date.new(2016, 6, 30)) }
+      it { is_expected.to include(Date.new(2016, 7, 31)) }
+      it { is_expected.to include(Date.new(2016, 8, 31)) }
+      it { is_expected.to include(Date.new(2016, 9, 30)) }
+      it { is_expected.to include(Date.new(2016, 10, 31)) }
+      it { is_expected.to include(Date.new(2016, 11, 30)) }
+      it { is_expected.to include(Date.new(2016, 12, 31)) }
+      it { is_expected.to include(Date.new(2017, 1, 31)) }
+      it { is_expected.to include(Date.new(2017, 2, 28)) }
+      it { is_expected.to include(Date.new(2017, 3, 31)) }
+      it { is_expected.to include(Date.new(2017, 4, 30)) }
+    end
+  end
+
   describe "#get_week_number_of_month" do
     context "with 2016/01/01" do
       subject { described_class.new.send(:get_week_number_of_month, Date.new(2016, 1, 1)) }
@@ -86,7 +130,7 @@ RSpec.describe Gws::Schedule::RepeatPlan, type: :model, dbscope: :example, tmpdi
 
     context "5th monday of April" do
       subject { described_class.new.send(:get_date_by_nearest_ordinal_week, 2016, 4, 5, monday) }
-      it { is_expected.to  eq Date.new(2016, 4, 25) }
+      it { is_expected.to eq Date.new(2016, 4, 25) }
     end
   end
 end

--- a/spec/models/gws/schedule/repeat_plan_spec.rb
+++ b/spec/models/gws/schedule/repeat_plan_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+RSpec.describe Gws::Schedule::RepeatPlan, type: :model, dbscope: :example, tmpdir: true do
+  let(:sunday) { 0 }
+  let(:monday) { 1 }
+  let(:tuesday) { 2 }
+  let(:wednesday) { 3 }
+  let(:thursday) { 4 }
+  let(:friday) { 5 }
+  let(:saturday) { 6 }
+
+  describe "#get_week_number_of_month" do
+    context "with 2016/01/01" do
+      subject { described_class.new.send(:get_week_number_of_month, Date.new(2016, 1, 1)) }
+      it { is_expected.to eq 1 }
+    end
+
+    context "with 2016/01/31" do
+      subject { described_class.new.send(:get_week_number_of_month, Date.new(2016, 1, 31)) }
+      it { is_expected.to eq 5 }
+    end
+
+    context "with 2016/02/29" do
+      subject { described_class.new.send(:get_week_number_of_month, Date.new(2016, 2, 29)) }
+      it { is_expected.to eq 5 }
+    end
+  end
+
+  describe "#get_date_by_ordinal_week" do
+    context "first sunday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 1, sunday) }
+      it { is_expected.to eq Date.new(2016, 1, 3) }
+    end
+
+    context "first monday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 1, monday) }
+      it { is_expected.to eq Date.new(2016, 1, 4) }
+    end
+
+    context "first tuesday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 1, tuesday) }
+      it { is_expected.to eq Date.new(2016, 1, 5) }
+    end
+
+    context "first wednesday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 1, wednesday) }
+      it { is_expected.to eq Date.new(2016, 1, 6) }
+    end
+
+    context "first thursday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 1, thursday) }
+      it { is_expected.to eq Date.new(2016, 1, 7) }
+    end
+
+    context "first friday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 1, friday) }
+      it { is_expected.to eq Date.new(2016, 1, 1) }
+    end
+
+    context "first saturday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 1, saturday) }
+      it { is_expected.to eq Date.new(2016, 1, 2) }
+    end
+
+    context "5th friday of January" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 1, 5, friday) }
+      it { is_expected.to eq Date.new(2016, 1, 29) }
+    end
+
+    context "5th monday of April" do
+      subject { described_class.new.send(:get_date_by_ordinal_week, 2016, 4, 5, monday) }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#get_date_by_nearest_ordinal_week" do
+    context "first sunday of January" do
+      subject { described_class.new.send(:get_date_by_nearest_ordinal_week, 2016, 1, 1, sunday) }
+      it { is_expected.to eq Date.new(2016, 1, 3) }
+    end
+
+    context "5th friday of January" do
+      subject { described_class.new.send(:get_date_by_nearest_ordinal_week, 2016, 1, 5, friday) }
+      it { is_expected.to eq Date.new(2016, 1, 29) }
+    end
+
+    context "5th monday of April" do
+      subject { described_class.new.send(:get_date_by_nearest_ordinal_week, 2016, 4, 5, monday) }
+      it { is_expected.to  eq Date.new(2016, 4, 25) }
+    end
+  end
+end


### PR DESCRIPTION
毎月第5月曜日（火曜日等でも可）にスケジュールを設定すると、内部エラーになっていたのを修正。
第5月曜日の存在しない月は、第4月曜日にスケジュールを設定するようにした。