### PR TITLE
[modify] show category hierarchy in 3 columns layout

### DIFF
--- a/app/assets/stylesheets/gws/share/_gws.scss
+++ b/app/assets/stylesheets/gws/share/_gws.scss
@@ -1,0 +1,5 @@
+.gws-share-files-index {
+  .index {
+    overflow: hidden;
+  }
+}

--- a/app/assets/stylesheets/gws/style.scss
+++ b/app/assets/stylesheets/gws/style.scss
@@ -1,6 +1,7 @@
 @import "ss/init";
 @import "board/gws";
 @import "schedule/gws";
+@import "share/gws";
 
 // Portal
 .portal-notice, .portal-reminder, .portal-board {
@@ -90,7 +91,7 @@ a.gws-category-label:hover {
     display: block;
   }
 }
-.gws-category-tree-view {
+.gws-category-tree-view, .index-category-tree-view {
   ul.depth0 {
     font-size: 115%;
   }
@@ -103,4 +104,10 @@ a.gws-category-label:hover {
     margin-bottom: 20px;
   }
 }
-
+.index-category-tree-view {
+  float: left;
+  width: 250px;
+  li.depth0 {
+    margin-bottom: 5px;
+  }
+}

--- a/app/views/gws/share/files/index.html.erb
+++ b/app/views/gws/share/files/index.html.erb
@@ -14,19 +14,27 @@ options = options_for_select(categories.to_options, params[:category].to_i)
 
 <% end %>
 
+<!--
 <div class="gws-category-navi-menu">
   <%= select_tag :category_id, options, include_blank: t('modules.gws/share') %>
 </div>
+-->
 
-<% @index_meta = proc do |item| %>
-  <span class="id">#<%= item.id %></span>
-  <span class="datetime"><%= item.updated.strftime("%Y/%m/%d %H:%M") %></span>
+<div class="gws-share-files-index">
+  <div class="index-category-tree-view">
+    <%= render partial: 'category0', locals: { categories: categories, css_class: 'list-items parent', depth: 0 } %>
+  </div>
+
+  <% @index_meta = proc do |item| %>
+    <span class="id">#<%= item.id %></span>
+    <span class="datetime"><%= item.updated.strftime("%Y/%m/%d %H:%M") %></span>
   <span class="gws-share-categories">
   <% item.categories.compact.each do |category| %>
     <%= link_to category.trailing_name, gws_share_category_files_path(category: category.id),
                 class: "gws-category-label", style: category_label_css(category) %>
   <% end %>
   </span>
-<% end %>
+  <% end %>
 
-<%= render file: "gws/crud/index" %>
+  <%= render file: "gws/crud/index" %>
+</div>


### PR DESCRIPTION
3 カラムレイアウトで、カテゴリーをツリー表示しました。

![image](https://cloud.githubusercontent.com/assets/3593466/14638172/098837aa-0671-11e6-9eb5-688a66afd366.png)