### PR TITLE
unabled select group

### DIFF
--- a/app/assets/javascripts/gws/schedule/lib/calendar.coffee.erb
+++ b/app/assets/javascripts/gws/schedule/lib/calendar.coffee.erb
@@ -1,9 +1,9 @@
 class @Gws_Schedule_Calendar
   @render: (selector, opts = {})->
     params = @defaultParams(opts)
-    $.extend params, @editableParams(opts) if opts['restUrl']
-    $.extend params, @tapMenuParams(opts) if opts['restUrl']
-    $.extend params, opts
+    $.extend true, params, @editableParams(opts) if opts['restUrl']
+    $.extend true, params, @tapMenuParams(opts) if opts['restUrl']
+    $.extend true, params, opts
     $(selector).fullCalendar(params)
 
     $(document).click (ev) ->

--- a/app/assets/javascripts/gws/schedule/lib/multiple_calendar.coffee.erb
+++ b/app/assets/javascripts/gws/schedule/lib/multiple_calendar.coffee.erb
@@ -28,7 +28,7 @@ class @Gws_Schedule_Multiple_Calendar
     eventSources: []
     eventAfterAllRender: (view)->
       if view.name == 'basicWeek'
-        view.el.find(".fc-body").html("")
+        view.el.find(".fc-body").hide()
 
   @contentParams: (opts) ->
     eventRender: (event, element, view)->

--- a/app/assets/javascripts/gws/schedule/lib/multiple_calendar.coffee.erb
+++ b/app/assets/javascripts/gws/schedule/lib/multiple_calendar.coffee.erb
@@ -1,11 +1,11 @@
 class @Gws_Schedule_Multiple_Calendar
   @render: (selector, opts = {})->
     params = Gws_Schedule_Calendar.defaultParams(opts)
-    $.extend params, Gws_Schedule_Calendar.editableParams(opts) if opts['restUrl']
-    $.extend params, Gws_Schedule_Calendar.tapMenuParams(opts) if opts['restUrl']
-    $.extend params, @defaultParams(opts)
-    $.extend params, @contentParams(opts)
-    $.extend params, opts
+    $.extend true, params, Gws_Schedule_Calendar.editableParams(opts) if opts['restUrl']
+    $.extend true, params, Gws_Schedule_Calendar.tapMenuParams(opts) if opts['restUrl']
+    $.extend true, params, @defaultParams(opts)
+    $.extend true, params, @contentParams(opts)
+    $.extend true, params, opts
     $(selector).fullCalendar(params)
 
     $(document).click (ev) ->
@@ -39,9 +39,9 @@ class @Gws_Schedule_Multiple_Calendar
 
   @renderController: (selector, opts = {}) ->
     params = Gws_Schedule_Calendar.defaultParams(opts)
-    $.extend params, @defaultParams(opts)
-    $.extend params, @controllerParams(opts)
-    $.extend params, opts
+    $.extend true, params, @defaultParams(opts)
+    $.extend true, params, @controllerParams(opts)
+    $.extend true, params, opts
 
     $(selector).fullCalendar(params)
 

--- a/app/assets/javascripts/ss/lib/dropdown.coffee
+++ b/app/assets/javascripts/ss/lib/dropdown.coffee
@@ -1,0 +1,49 @@
+class @SS_DropDown
+  @render: ->
+    $("button.dropdown").each ->
+      dropdown = new SS_DropDown(this, { target: $(this).siblings(".dropdown-target")[0] })
+      SS_DropDown.dropdown = dropdown unless SS_DropDown.dropdown
+
+  @openDropdown: ->
+    SS_DropDown.dropdown.openDropdown() if SS_DropDown.dropdown
+
+  @closeDropdown: ->
+    SS_DropDown.dropdown.closeDropdown() if SS_DropDown.dropdown
+
+  @toggleDropdown: ->
+    SS_DropDown.dropdown.toggleDropdown() if SS_DropDown.dropdown
+
+  constructor: (elem, options) ->
+    @elem = $(elem)
+    @options = options
+    @target = $(@options.target)
+    @bindEvents()
+
+  bindEvents: ->
+    @elem.on "click", (e) =>
+      @toggleDropdown()
+      @cancelEvent(e)
+
+    # focusout
+    $(document).on "click", (e) =>
+      if e.target != @elem && e.target != @target
+        @closeDropdown()
+
+    @elem.on "keydown", (e) =>
+      if e.keyCode == 27  # ESC
+        @closeDropdown()
+        @cancelEvent(e)
+
+  openDropdown: ->
+    @target.show()
+
+  closeDropdown: ->
+    @target.hide()
+
+  toggleDropdown: ->
+    @target.toggle()
+
+  cancelEvent: (e) ->
+    e.preventDefault()
+    e.stopPropagation()
+    false

--- a/app/assets/javascripts/ss/lib/dropdown.coffee
+++ b/app/assets/javascripts/ss/lib/dropdown.coffee
@@ -1,17 +1,18 @@
-class @SS_DropDown
+class @SS_Dropdown
   @render: ->
     $("button.dropdown").each ->
-      dropdown = new SS_DropDown(this, { target: $(this).siblings(".dropdown-target")[0] })
-      SS_DropDown.dropdown = dropdown unless SS_DropDown.dropdown
+      target = $(this).parent().find(".dropdown-container")[0]
+      dropdown = new SS_Dropdown(this, { target: target })
+      SS_Dropdown.dropdown = dropdown unless SS_Dropdown.dropdown
 
   @openDropdown: ->
-    SS_DropDown.dropdown.openDropdown() if SS_DropDown.dropdown
+    SS_Dropdown.dropdown.openDropdown() if SS_Dropdown.dropdown
 
   @closeDropdown: ->
-    SS_DropDown.dropdown.closeDropdown() if SS_DropDown.dropdown
+    SS_Dropdown.dropdown.closeDropdown() if SS_Dropdown.dropdown
 
   @toggleDropdown: ->
-    SS_DropDown.dropdown.toggleDropdown() if SS_DropDown.dropdown
+    SS_Dropdown.dropdown.toggleDropdown() if SS_Dropdown.dropdown
 
   constructor: (elem, options) ->
     @elem = $(elem)

--- a/app/assets/javascripts/ss/lib/tree_ui.coffee
+++ b/app/assets/javascripts/ss/lib/tree_ui.coffee
@@ -8,7 +8,7 @@ class @SS_TreeUI
       root.push(parseInt($(this).attr("data-depth")))
     root = Math.min.apply(null, root)
     root = parseInt(root)
-    return if isNaN(root) || root <= 0
+    return if isNaN(root) || root < 0
 
     $(tree).find("tbody tr").each ->
       td = $(this).find(".expandable")

--- a/app/assets/javascripts/ss/script.coffee.erb
+++ b/app/assets/javascripts/ss/script.coffee.erb
@@ -119,7 +119,7 @@ class @SS
         alert(["== Error =="].concat(data.responseJSON).join("\n"));
     }
     elem.on "submit", (e) ->
-      $(this).ajaxSubmit $.extend(defaults, params)
+      $(this).ajaxSubmit $.extend(true, defaults, params)
       e.preventDefault();
 
   @ajax:(elem, params = {}) ->
@@ -134,7 +134,7 @@ class @SS
         error: (data, status) ->
           alert("== Error ==");
       }
-      $.ajax $.extend(defaults, params)
+      $.ajax $.extend(true, defaults, params)
       e.preventDefault();
       return false
 
@@ -154,7 +154,7 @@ class @SS
         error: (data, status) ->
           alert(["== Error =="].concat(data.responseJSON).join("\n"));
       }
-      $.ajax $.extend(defaults, params)
+      $.ajax $.extend(true, defaults, params)
       e.preventDefault();
       return false
 

--- a/app/assets/javascripts/ss/script.coffee.erb
+++ b/app/assets/javascripts/ss/script.coffee.erb
@@ -12,6 +12,7 @@
 //= require ss/lib/mobile
 //= require ss/lib/search_ui
 //= require ss/lib/tooltips
+//= require ss/lib/dropdown
 //= require cms/lib/editor
 //= require cms/lib/form
 //= require cms/lib/edit_lock

--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1235,7 +1235,7 @@ table.index {
     width: 15px;
   }
 }
-table.pulldown-index {
+.dropdown-container {
   display: none;
   position: absolute;
   width: 70%;
@@ -1243,6 +1243,8 @@ table.pulldown-index {
   border: 1px solid #bbb;
   font-weight: normal;
   z-index: 10;
+  max-height: 250px;
+  overflow: auto;
   @include box-shadow(0 1px 10px #bbb);
 }
 .ads-total table.index {

--- a/app/controllers/gws/apis/users_controller.rb
+++ b/app/controllers/gws/apis/users_controller.rb
@@ -4,11 +4,13 @@ class Gws::Apis::UsersController < ApplicationController
   model Gws::User
 
   before_action :set_group
+  before_action :set_custom_group
 
   private
     def set_group
       if params[:s].present? && params[:s][:group].present?
-        @group = @cur_site.descendants.active.find(params[:s][:group])
+        @group = @cur_site.descendants.active.find(params[:s][:group]) rescue nil
+        @group ||= @cur_site
       else
         @group = @cur_user.groups.active.in_group(@cur_site).first
       end
@@ -16,16 +18,29 @@ class Gws::Apis::UsersController < ApplicationController
       @groups = @cur_site.descendants.active
     end
 
+    def set_custom_group
+      @custom_groups = Gws::CustomGroup.site(@cur_site)
+
+      if params[:s].present? && params[:s][:custom_group].present?
+        @custom_group = Gws::CustomGroup.site(@cur_site).find(params[:s][:custom_group]) rescue nil
+      end
+    end
+
     def group_ids
-      @cur_site.descendants.active.in_group(@group).pluck(:id)
+      @group_ids ||= @cur_site.descendants.active.in_group(@group).pluck(:id)
     end
 
   public
     def index
       @multi = params[:single].blank?
 
-      @items = @model.site(@cur_site).
-        active.
+      if @custom_group.present?
+        criteria = @custom_group.members
+      else
+        criteria = @model.site(@cur_site)
+      end
+
+      @items = criteria.active.
         in(group_ids: group_ids).
         search(params[:s]).
         order_by_title(@cur_site).

--- a/app/controllers/gws/schedule/facilities_controller.rb
+++ b/app/controllers/gws/schedule/facilities_controller.rb
@@ -15,7 +15,11 @@ class Gws::Schedule::FacilitiesController < ApplicationController
         @category = Gws::Facility::Category.site(@cur_site).find(@category) rescue nil
       end
 
-      @category ||= @categories.find { |c| c.id.present? }
+      @category ||= begin
+        c = @categories.find { |c| c.id.present? }
+        c = Gws::Facility::Category.site(@cur_site).find(c.id) rescue nil
+        c
+      end
     end
 
   public

--- a/app/controllers/workflow/search_approvers_controller.rb
+++ b/app/controllers/workflow/search_approvers_controller.rb
@@ -9,9 +9,8 @@ class Workflow::SearchApproversController < ApplicationController
     def set_group
       if params[:s].present? && params[:s][:group].present?
         @group = Cms::Group.site(@cur_site).active.find(params[:s][:group])
-      else
-        @group = @cur_user.groups.active.first
       end
+      @group ||= @cur_user.groups.active.first
 
       @groups = Cms::Group.site(@cur_site).active
     end

--- a/app/views/gws/apis/facilities/index.html.erb
+++ b/app/views/gws/apis/facilities/index.html.erb
@@ -2,7 +2,7 @@
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.categories");
 
-  SS_DropDown.render();
+  SS_Dropdown.render();
 
   $("form.search .select-category").on("click", function(e) {
     $("#ajax-box #s_group").val($(e.target).data("id"));
@@ -23,26 +23,28 @@
       <dd>
         <button class="dropdown btn" type="button"><%= tryb { @group.name } || @model.t(:category_id) %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.try(:id)) %>
-        <table class="index categories pulldown-index dropdown-target">
-          <tbody>
-          <tr data-depth="1">
-            <td class="expandable">
-              <%= link_to @model.t(:category_id), "#", class: "select-category" %>
-            </td>
-          </tr>
-          <% @groups.each do |item| %>
-            <tr data-depth="<%= item.depth + 1 %>" class="<%= item.children? ? "toggle" : nil %>">
+        <div class="dropdown-container">
+          <table class="index categories">
+            <tbody>
+            <tr data-depth="1">
               <td class="expandable">
-                <% if item.id.present? %>
-                  <%= link_to item.name, "#", class: "select-category", data: { id: item.id } %>
-                <% else %>
-                  <%= item.name %>
-                <% end %>
+                <%= link_to @model.t(:category_id), "#", class: "select-category" %>
               </td>
             </tr>
-          <% end %>
-          </tbody>
-        </table>
+            <% @groups.each do |item| %>
+              <tr data-depth="<%= item.depth + 1 %>" class="<%= item.children? ? "toggle" : nil %>">
+                <td class="expandable">
+                  <% if item.id.present? %>
+                    <%= link_to item.name, "#", class: "select-category", data: { id: item.id } %>
+                  <% else %>
+                    <%= item.name %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
       </dd>
 
       <dt><%= @model.t :name %></dt>

--- a/app/views/gws/apis/facilities/index.html.erb
+++ b/app/views/gws/apis/facilities/index.html.erb
@@ -2,21 +2,15 @@
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.categories");
 
-  $("form.search .dropdown").on("click", function(e) {
-    $("form.search .index.categories").toggle();
-
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
+  SS_DropDown.render();
 
   $("form.search .select-category").on("click", function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    $("form.search .index.categories").hide();
     $("#ajax-box #s_group").val($(e.target).data("id"));
     SS_SearchUI.selectItems()
     $("#ajax-box form.search").submit()
+
+    e.preventDefault();
+    e.stopPropagation();
     return false;
   });
 <% end %>
@@ -29,15 +23,15 @@
       <dd>
         <button class="dropdown btn" type="button"><%= tryb { @group.name } || @model.t(:category_id) %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.try(:id)) %>
-        <table class="index categories pulldown-index">
+        <table class="index categories pulldown-index dropdown-target">
           <tbody>
-          <tr data-depth="1" class="toggle">
+          <tr data-depth="1">
             <td class="expandable">
               <%= link_to @model.t(:category_id), "#", class: "select-category" %>
             </td>
           </tr>
           <% @groups.each do |item| %>
-            <tr data-depth="<%= item.depth + 1 %>" class="toggle">
+            <tr data-depth="<%= item.depth + 1 %>" class="<%= item.children? ? "toggle" : nil %>">
               <td class="expandable">
                 <% if item.id.present? %>
                   <%= link_to item.name, "#", class: "select-category", data: { id: item.id } %>

--- a/app/views/gws/apis/users/_custom_group_dropdown.html.erb
+++ b/app/views/gws/apis/users/_custom_group_dropdown.html.erb
@@ -1,0 +1,9 @@
+<%= jquery do %>
+  $("form.search #s_custom_group").on("change", function(e) {
+    SS_SearchUI.selectItems()
+    $("#ajax-box form.search").submit()
+  });
+<% end %>
+
+<dt><%= t("mongoid.models.gws/custom_group") %></dt>
+<dd><%= select_tag "s[custom_group]", options_for_select(@custom_groups.map { |g| [ g.name, g.id ] }, @custom_group.try(:id)), include_blank: t("mongoid.models.gws/custom_group") %></dd>

--- a/app/views/gws/apis/users/_group_dropdown.html.erb
+++ b/app/views/gws/apis/users/_group_dropdown.html.erb
@@ -1,0 +1,37 @@
+<%= jquery do %>
+  SS_TreeUI.render("form.search .index.groups");
+  SS_Dropdown.render();
+
+  $("form.search .index.groups .select-group").on("click", function(e) {
+    $("#ajax-box #s_group").val($(e.target).data("id"));
+    SS_SearchUI.selectItems()
+    $("#ajax-box form.search").submit()
+
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+  });
+<% end %>
+<dt><%= t("mongoid.models.gws/group") %></dt>
+<dd>
+  <button class="dropdown btn"><%= @group.name %> <span class="caret">&#x25BC;</span></button>
+  <%= hidden_field_tag("s[group]", @group.id) %>
+  <div class="dropdown-container">
+    <table class="index groups">
+      <tbody>
+      <tr data-depth="0" class="toggle">
+        <td class="expandable">
+          <%= link_to @cur_site.name, "#", class: "select-group", data: { id: @cur_site.id } %>
+        </td>
+      </tr>
+      <% @groups.each do |item| %>
+        <tr data-depth="<%= item.name.count("/") + @cur_site.name.count("/") %>" class="toggle">
+          <td class="expandable">
+            <%= link_to item.trailing_name, "#", class: "select-group", data: { id: item.id } %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</dd>

--- a/app/views/gws/apis/users/index.html.erb
+++ b/app/views/gws/apis/users/index.html.erb
@@ -1,16 +1,12 @@
 <%= jquery do %>
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.groups");
-  $("form.search .dropdown").on("click", function(e) {
-    $("form.search .index.groups").toggle();
+  SS_DropDown.render();
 
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
   $("form.search .index.groups .select-group").on("click", function(e) {
     e.preventDefault();
     e.stopPropagation();
+    dropdown.closeDropdown();
     $("#ajax-box #s_group").val($(e.target).data("id"));
     SS_SearchUI.selectItems()
     $("#ajax-box form.search").submit()
@@ -26,7 +22,7 @@
       <dd>
         <button class="dropdown btn"><%= @group.name %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.id) %>
-        <table class="index groups pulldown-index">
+        <table class="index groups pulldown-index dropdown-target">
           <tbody>
           <% @groups.each do |item| %>
             <tr data-depth="<%= item.name.count("/") + @cur_site.name.count("/") %>" class="toggle">

--- a/app/views/gws/apis/users/index.html.erb
+++ b/app/views/gws/apis/users/index.html.erb
@@ -1,39 +1,13 @@
 <%= jquery do %>
   SS_SearchUI.modal();
-  SS_TreeUI.render("form.search .index.groups");
-  SS_DropDown.render();
-
-  $("form.search .index.groups .select-group").on("click", function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    dropdown.closeDropdown();
-    $("#ajax-box #s_group").val($(e.target).data("id"));
-    SS_SearchUI.selectItems()
-    $("#ajax-box form.search").submit()
-    return false;
-  });
 <% end %>
 
 <div style="margin-bottom: 20px; padding: 10px; border: 1px solid #ddd;">
   <%= form_for :s, url: { action: :index }, html: { method: "GET", class: :search } do |f| %>
     <%= hidden_field_tag :single, params[:single] %>
     <dl class="see">
-      <dt><%= t("mongoid.models.gws/group") %></dt>
-      <dd>
-        <button class="dropdown btn"><%= @group.name %> <span class="caret">&#x25BC;</span></button>
-        <%= hidden_field_tag("s[group]", @group.id) %>
-        <table class="index groups pulldown-index dropdown-target">
-          <tbody>
-          <% @groups.each do |item| %>
-            <tr data-depth="<%= item.name.count("/") + @cur_site.name.count("/") %>" class="toggle">
-              <td class="expandable">
-                <%= link_to item.trailing_name, "#", class: "select-group", data: { id: item.id } %>
-              </td>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
-      </dd>
+      <%= render partial: "group_dropdown", locals: { f: f } %>
+      <%= render partial: "custom_group_dropdown", locals: { f: f } %>
       <dt><%= t "mongoid.models.gws/user" %></dt>
       <dd>
         <%= f.text_field :keyword, value: params[:s].try(:[], :keyword) %>

--- a/app/views/gws/board/apis/categories/index.html.erb
+++ b/app/views/gws/board/apis/categories/index.html.erb
@@ -1,22 +1,15 @@
 <%= jquery do %>
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.categories");
-
-  $("form.search .dropdown").on("click", function(e) {
-    $("form.search .index.categories").toggle();
-
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
+  SS_DropDown.render();
 
   $("form.search .select-category").on("click", function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    $("form.search .index.categories").hide();
     $("#ajax-box #s_group").val($(e.target).data("id"));
     SS_SearchUI.selectItems()
     $("#ajax-box form.search").submit()
+
+    e.preventDefault();
+    e.stopPropagation();
     return false;
   });
 <% end %>
@@ -27,18 +20,18 @@
     <dl class="see">
       <dt><%= t("gws.apis.categories.parent_id") %></dt>
       <dd>
-        <button class="dropdown btn" type="button"><%= tryb { @group.name } || t("gws.apis.categories.parent_id") %> <span class="caret">&#x25BC;</span></button>
+        <button class="dropdown btn" type="button"><%= tryb { @group.name } || t("mongoid.models.gws/board/category") %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.try(:id)) %>
-        <table class="index categories pulldown-index">
+        <table class="index categories pulldown-index dropdown-target">
           <tbody>
-          <tr data-depth="1" class="toggle">
+          <tr data-depth="0" class="toggle">
             <td class="expandable">
-              <%= link_to t("gws.apis.categories.parent_id"), "#", class: "select-category", data: { id: "" } %>
+              <%= link_to t("mongoid.models.gws/board/category"), "#", class: "select-category", data: { id: "" } %>
             </td>
           </tr>
           <% @groups.each do |group| %>
             <% next if !group.children? && group.depth > 0 %>
-            <tr data-depth="<%= group.depth + 1 %>" class="toggle">
+            <tr data-depth="<%= group.depth + 1 %>" class="<%= group.children? ? "toggle" : nil %>">
               <td class="expandable">
                 <% if group.id.present? %>
                   <%= link_to group.name, "#", class: "select-category", data: { id: group.id } %>

--- a/app/views/gws/board/apis/categories/index.html.erb
+++ b/app/views/gws/board/apis/categories/index.html.erb
@@ -1,7 +1,7 @@
 <%= jquery do %>
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.categories");
-  SS_DropDown.render();
+  SS_Dropdown.render();
 
   $("form.search .select-category").on("click", function(e) {
     $("#ajax-box #s_group").val($(e.target).data("id"));
@@ -22,27 +22,29 @@
       <dd>
         <button class="dropdown btn" type="button"><%= tryb { @group.name } || t("mongoid.models.gws/board/category") %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.try(:id)) %>
-        <table class="index categories pulldown-index dropdown-target">
-          <tbody>
-          <tr data-depth="0" class="toggle">
-            <td class="expandable">
-              <%= link_to t("mongoid.models.gws/board/category"), "#", class: "select-category", data: { id: "" } %>
-            </td>
-          </tr>
-          <% @groups.each do |group| %>
-            <% next if !group.children? && group.depth > 0 %>
-            <tr data-depth="<%= group.depth + 1 %>" class="<%= group.children? ? "toggle" : nil %>">
+        <div class="dropdown-container">
+          <table class="index categories">
+            <tbody>
+            <tr data-depth="0" class="toggle">
               <td class="expandable">
-                <% if group.id.present? %>
-                  <%= link_to group.name, "#", class: "select-category", data: { id: group.id } %>
-                <% else %>
-                  <%= group.name %>
-                <% end %>
+                <%= link_to t("mongoid.models.gws/board/category"), "#", class: "select-category", data: { id: "" } %>
               </td>
             </tr>
-          <% end %>
-          </tbody>
-        </table>
+            <% @groups.each do |group| %>
+              <% next if !group.children? && group.depth > 0 %>
+              <tr data-depth="<%= group.depth + 1 %>" class="<%= group.children? ? "toggle" : nil %>">
+                <td class="expandable">
+                  <% if group.id.present? %>
+                    <%= link_to group.name, "#", class: "select-category", data: { id: group.id } %>
+                  <% else %>
+                    <%= group.name %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
       </dd>
 
       <dt><%= @model.t :name %></dt>

--- a/app/views/gws/board/topics/index.html.erb
+++ b/app/views/gws/board/topics/index.html.erb
@@ -7,39 +7,32 @@ end
 %>
 <%= jquery do %>
   SS_TreeUI.render(".gws-category-navi-menu .index.categories");
-
-  $(".gws-category-navi-menu .dropdown").on("click", function(e) {
-    $(".gws-category-navi-menu .index.categories").toggle();
-
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
+  SS_DropDown.render();
 
   $(".gws-category-navi-menu .select-category").on("click", function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    $(".gws-category-navi-menu .index.categories").hide();
-
     var id = $(e.target).data("id");
     if (id) location.href = '<%= gws_board_category_topics_path(category: 'ID') %>'.replace('ID', id);
     else location.href = '<%= gws_board_topics_path %>';
 
+    e.preventDefault();
+    e.stopPropagation();
     return false;
   });
+
+  $(".gws-category-navi-menu .index.categories tbody tr[data-depth='0'] img").click();
 <% end %>
 
 <div class="gws-category-navi-menu">
   <button class="dropdown btn" type="button"><%= tryb { category.name } || t('modules.gws/board') %> <span class="caret">&#x25BC;</span></button>
-  <table class="index categories pulldown-index">
+  <table class="index categories pulldown-index dropdown-target">
     <tbody>
-    <tr data-depth="1" class="toggle">
+    <tr data-depth="0" class="toggle">
       <td class="expandable">
         <%= link_to t('modules.gws/board'), "#", class: "select-category" %>
       </td>
     </tr>
     <% categories.flatten.each do |category| %>
-      <tr data-depth="<%= category.depth + 1 %>" class="toggle">
+      <tr data-depth="<%= category.depth + 1 %>" class="<%= category.children? ? "toggle" : nil %>">
         <td class="expandable">
           <% if category.id.present? %>
             <%= link_to category.name, "#", class: "select-category", data: { id: category.id } %>

--- a/app/views/gws/board/topics/index.html.erb
+++ b/app/views/gws/board/topics/index.html.erb
@@ -7,7 +7,7 @@ end
 %>
 <%= jquery do %>
   SS_TreeUI.render(".gws-category-navi-menu .index.categories");
-  SS_DropDown.render();
+  SS_Dropdown.render();
 
   $(".gws-category-navi-menu .select-category").on("click", function(e) {
     var id = $(e.target).data("id");
@@ -24,26 +24,28 @@ end
 
 <div class="gws-category-navi-menu">
   <button class="dropdown btn" type="button"><%= tryb { category.name } || t('modules.gws/board') %> <span class="caret">&#x25BC;</span></button>
-  <table class="index categories pulldown-index dropdown-target">
-    <tbody>
-    <tr data-depth="0" class="toggle">
-      <td class="expandable">
-        <%= link_to t('modules.gws/board'), "#", class: "select-category" %>
-      </td>
-    </tr>
-    <% categories.flatten.each do |category| %>
-      <tr data-depth="<%= category.depth + 1 %>" class="<%= category.children? ? "toggle" : nil %>">
+  <div class="dropdown-container">
+    <table class="index categories">
+      <tbody>
+      <tr data-depth="0" class="toggle">
         <td class="expandable">
-          <% if category.id.present? %>
-            <%= link_to category.name, "#", class: "select-category", data: { id: category.id } %>
-          <% else %>
-            <%= category.name %>
-          <% end %>
+          <%= link_to t('modules.gws/board'), "#", class: "select-category" %>
         </td>
       </tr>
-    <% end %>
-    </tbody>
-  </table>
+      <% categories.flatten.each do |category| %>
+        <tr data-depth="<%= category.depth + 1 %>" class="<%= category.children? ? "toggle" : nil %>">
+          <td class="expandable">
+            <% if category.id.present? %>
+              <%= link_to category.name, "#", class: "select-category", data: { id: category.id } %>
+            <% else %>
+              <%= category.name %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>
 
 <% @index_title = proc do |item| %>

--- a/app/views/gws/schedule/facilities/index.html.erb
+++ b/app/views/gws/schedule/facilities/index.html.erb
@@ -6,20 +6,14 @@
 
   SS_TreeUI.render("form.search .index.categories");
 
-  $(".main-box form.search .dropdown").on("click", function(e) {
-    $(".main-box form.search .index.categories").toggle();
-
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
+  SS_DropDown.render();
 
   $(".main-box form.search .select-category").on("click", function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    $(".main-box form.search .index.categories").hide();
     $(".main-box form.search #s_category").val($(e.target).data("id"));
     $(".main-box form.search").submit();
+
+    e.preventDefault();
+    e.stopPropagation();
     return false;
   });
 <% end %>
@@ -32,15 +26,15 @@
       <% if @categories.present? %>
         <button class="dropdown btn" type="button"><%= tryb { @category.name } || t('gws/schedule.tabs.facility') %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[category]", @category.try(:id)) %>
-        <table class="index categories pulldown-index">
+        <table class="index categories pulldown-index dropdown-target">
           <tbody>
-          <tr data-depth="1" class="toggle">
+          <tr data-depth="1">
             <td class="expandable">
               <%= link_to t('gws/schedule.tabs.facility'), "#", class: "select-category" %>
             </td>
           </tr>
           <% @categories.each do |item| %>
-            <tr data-depth="<%= item.depth + 1 %>" class="toggle">
+            <tr data-depth="<%= item.depth + 1 %>" class="<%= item.children? ? "toggle" : nil %>">
               <td class="expandable">
                 <% if item.id.present? %>
                   <%= link_to item.name, "#", class: "select-category", data: { id: item.id } %>

--- a/app/views/gws/schedule/facilities/index.html.erb
+++ b/app/views/gws/schedule/facilities/index.html.erb
@@ -6,7 +6,7 @@
 
   SS_TreeUI.render("form.search .index.categories");
 
-  SS_DropDown.render();
+  SS_Dropdown.render();
 
   $(".main-box form.search .select-category").on("click", function(e) {
     $(".main-box form.search #s_category").val($(e.target).data("id"));
@@ -26,26 +26,28 @@
       <% if @categories.present? %>
         <button class="dropdown btn" type="button"><%= tryb { @category.name } || t('gws/schedule.tabs.facility') %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[category]", @category.try(:id)) %>
-        <table class="index categories pulldown-index dropdown-target">
-          <tbody>
-          <tr data-depth="1">
-            <td class="expandable">
-              <%= link_to t('gws/schedule.tabs.facility'), "#", class: "select-category" %>
-            </td>
-          </tr>
-          <% @categories.each do |item| %>
-            <tr data-depth="<%= item.depth + 1 %>" class="<%= item.children? ? "toggle" : nil %>">
+        <div class="dropdown-container">
+          <table class="index categories">
+            <tbody>
+            <tr data-depth="1">
               <td class="expandable">
-                <% if item.id.present? %>
-                  <%= link_to item.name, "#", class: "select-category", data: { id: item.id } %>
-                <% else %>
-                  <%= item.name %>
-                <% end %>
+                <%= link_to t('gws/schedule.tabs.facility'), "#", class: "select-category" %>
               </td>
             </tr>
-          <% end %>
-          </tbody>
-        </table>
+            <% @categories.each do |item| %>
+              <tr data-depth="<%= item.depth + 1 %>" class="<%= item.children? ? "toggle" : nil %>">
+                <td class="expandable">
+                  <% if item.id.present? %>
+                    <%= link_to item.name, "#", class: "select-category", data: { id: item.id } %>
+                  <% else %>
+                    <%= item.name %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
       <% else %>
       <%= t('gws/schedule.tabs.facility') %>
       <% end %>

--- a/app/views/gws/share/apis/categories/index.html.erb
+++ b/app/views/gws/share/apis/categories/index.html.erb
@@ -2,21 +2,15 @@
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.categories");
 
-  $("form.search .dropdown").on("click", function(e) {
-    $("form.search .index.categories").toggle();
-
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
+  SS_DropDown.render();
 
   $("form.search .select-category").on("click", function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    $("form.search .index.categories").hide();
     $("#ajax-box #s_group").val($(e.target).data("id"));
     SS_SearchUI.selectItems()
     $("#ajax-box form.search").submit()
+
+    e.preventDefault();
+    e.stopPropagation();
     return false;
   });
 <% end %>
@@ -29,16 +23,16 @@
       <dd>
         <button class="dropdown btn" type="button"><%= tryb { @group.name } || t("gws.apis.categories.parent_id") %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.try(:id)) %>
-        <table class="index categories pulldown-index">
+        <table class="index categories pulldown-index dropdown-target">
           <tbody>
-          <tr data-depth="1" class="toggle">
+          <tr data-depth="0" class="toggle">
             <td class="expandable">
               <%= link_to t("gws.apis.categories.parent_id"), "#", class: "select-category" %>
             </td>
           </tr>
           <% @groups.each do |group| %>
             <% next if !group.children? && group.depth > 0 %>
-            <tr data-depth="<%= group.depth + 1 %>" class="toggle">
+            <tr data-depth="<%= group.depth + 1 %>" class="<%= group.children? ? "toggle" : nil %>">
               <td class="expandable">
                 <% if group.id.present? %>
                   <%= link_to group.name, "#", class: "select-category", data: { id: group.id } %>

--- a/app/views/gws/share/apis/categories/index.html.erb
+++ b/app/views/gws/share/apis/categories/index.html.erb
@@ -2,7 +2,7 @@
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.categories");
 
-  SS_DropDown.render();
+  SS_Dropdown.render();
 
   $("form.search .select-category").on("click", function(e) {
     $("#ajax-box #s_group").val($(e.target).data("id"));
@@ -21,29 +21,31 @@
     <dl class="see">
       <dt><%= t("gws.apis.categories.parent_id") %></dt>
       <dd>
-        <button class="dropdown btn" type="button"><%= tryb { @group.name } || t("gws.apis.categories.parent_id") %> <span class="caret">&#x25BC;</span></button>
+        <button class="dropdown btn" type="button"><%= tryb { @group.name } || t("mongoid.models.gws/share/category") %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.try(:id)) %>
-        <table class="index categories pulldown-index dropdown-target">
-          <tbody>
-          <tr data-depth="0" class="toggle">
-            <td class="expandable">
-              <%= link_to t("gws.apis.categories.parent_id"), "#", class: "select-category" %>
-            </td>
-          </tr>
-          <% @groups.each do |group| %>
-            <% next if !group.children? && group.depth > 0 %>
-            <tr data-depth="<%= group.depth + 1 %>" class="<%= group.children? ? "toggle" : nil %>">
+        <div class="dropdown-container">
+          <table class="index categories">
+            <tbody>
+            <tr data-depth="0" class="toggle">
               <td class="expandable">
-                <% if group.id.present? %>
-                  <%= link_to group.name, "#", class: "select-category", data: { id: group.id } %>
-                <% else %>
-                  <%= group.name %>
-                <% end %>
+                <%= link_to t("mongoid.models.gws/share/category"), "#", class: "select-category" %>
               </td>
             </tr>
-          <% end %>
-          </tbody>
-        </table>
+            <% @groups.each do |group| %>
+              <% next if !group.children? && group.depth > 0 %>
+              <tr data-depth="<%= group.depth + 1 %>" class="<%= group.children? ? "toggle" : nil %>">
+                <td class="expandable">
+                  <% if group.id.present? %>
+                    <%= link_to group.name, "#", class: "select-category", data: { id: group.id } %>
+                  <% else %>
+                    <%= group.name %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
       </dd>
 
       <dt><%= @model.t :name %></dt>

--- a/app/views/gws/share/files/index.html.erb
+++ b/app/views/gws/share/files/index.html.erb
@@ -11,7 +11,7 @@ end
 
   SS_TreeUI.render(".gws-category-navi-menu .index.categories");
 
-  SS_DropDown.render();
+  SS_Dropdown.render();
 
   $(".gws-category-navi-menu .select-category").on("click", function(e) {
     var id = $(e.target).data("id");
@@ -27,26 +27,28 @@ end
 
 <div class="gws-category-navi-menu">
   <button class="dropdown btn" type="button"><%= tryb { category.name } || t('modules.gws/share') %> <span class="caret">&#x25BC;</span></button>
-  <table class="index categories pulldown-index dropdown-target">
-    <tbody>
-    <tr data-depth="1" class="toggle">
-      <td class="expandable">
-        <%= link_to t('modules.gws/share'), "#", class: "select-category" %>
-      </td>
-    </tr>
-    <% categories.flatten.each do |category| %>
-      <tr data-depth="<%= category.depth + 1 %>" class="toggle">
+  <div class="dropdown-container">
+    <table class="index categories">
+      <tbody>
+      <tr data-depth="1" class="toggle">
         <td class="expandable">
-          <% if category.id.present? %>
-            <%= link_to category.name, "#", class: "select-category", data: { id: category.id } %>
-          <% else %>
-            <%= category.name %>
-          <% end %>
+          <%= link_to t('modules.gws/share'), "#", class: "select-category" %>
         </td>
       </tr>
-    <% end %>
-    </tbody>
-  </table>
+      <% categories.flatten.each do |category| %>
+        <tr data-depth="<%= category.depth + 1 %>" class="toggle">
+          <td class="expandable">
+            <% if category.id.present? %>
+              <%= link_to category.name, "#", class: "select-category", data: { id: category.id } %>
+            <% else %>
+              <%= category.name %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>
 
 <% @index_meta = proc do |item| %>

--- a/app/views/gws/share/files/index.html.erb
+++ b/app/views/gws/share/files/index.html.erb
@@ -9,31 +9,17 @@ end
 %>
 <%= jquery do %>
 
-  //$('.gws-category-navi-menu #category_id').change(function() {
-  //  var cid = $(this).val();
-  //  if (cid) location.href = '<%= gws_share_category_files_path(category: 'ID') %>'.replace('ID', cid);
-  //  else location.href = '<%= gws_share_files_path %>';
-  //});
-
   SS_TreeUI.render(".gws-category-navi-menu .index.categories");
 
-  $(".gws-category-navi-menu .dropdown").on("click", function(e) {
-    $(".gws-category-navi-menu .index.categories").toggle();
-
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
+  SS_DropDown.render();
 
   $(".gws-category-navi-menu .select-category").on("click", function(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    $(".gws-category-navi-menu .index.categories").hide();
-
     var id = $(e.target).data("id");
     if (id) location.href = '<%= gws_share_category_files_path(category: 'ID') %>'.replace('ID', id);
     else location.href = '<%= gws_share_files_path %>';
 
+    e.preventDefault();
+    e.stopPropagation();
     return false;
   });
 
@@ -41,7 +27,7 @@ end
 
 <div class="gws-category-navi-menu">
   <button class="dropdown btn" type="button"><%= tryb { category.name } || t('modules.gws/share') %> <span class="caret">&#x25BC;</span></button>
-  <table class="index categories pulldown-index">
+  <table class="index categories pulldown-index dropdown-target">
     <tbody>
     <tr data-depth="1" class="toggle">
       <td class="expandable">

--- a/app/views/workflow/search_approvers/index.html.erb
+++ b/app/views/workflow/search_approvers/index.html.erb
@@ -1,10 +1,42 @@
-<%= jquery do %> SS_SearchUI.modal(); <% end %>
+<%= jquery do %>
+  SS_SearchUI.modal();
+  SS_TreeUI.render("form.search .index.groups");
+  $("form.search .dropdown").on("click", function(e) {
+    $("form.search .index.groups").toggle();
+
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+  });
+  $("form.search .index.groups .select-group").on("click", function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    $("#ajax-box #s_group").val($(e.target).data("id"));
+    SS_SearchUI.selectItems()
+    $("#ajax-box form.search").submit()
+    return false;
+  });
+<% end %>
 
 <div style="margin-bottom: 20px; padding: 10px; border: 1px solid #ddd;">
   <%= form_for :s, url: { action: :index, level: @level }, html: { method: "GET", class: :search } do |f| %>
     <dl class="see">
       <dt><%= t "cms.group" %></dt>
-      <dd><%= select_tag "s[group]", options_for_select(@group_options, @group_id) %></dd>
+      <dd>
+        <button class="dropdown btn"><%= @group.name %> <span class="caret">&#x25BC;</span></button>
+        <%= hidden_field_tag("s[group]", @group.id) %>
+        <table class="index groups pulldown-index">
+          <tbody>
+          <% @groups.each do |item| %>
+            <tr data-depth="<%= item.name.count("/") + @cur_site.name.count("/") %>" class="toggle">
+              <td class="expandable">
+                <%= link_to item.trailing_name, "#", class: "select-group", data: { id: item.id } %>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </dd>
       <dt><%= t "cms.user" %></dt>
       <dd><%= f.text_field :keyword, value: params[:s].try(:[], :keyword) %>
       <%= f.submit t("workflow.search_approvers.search"), class: "btn" %></dd>

--- a/app/views/workflow/search_approvers/index.html.erb
+++ b/app/views/workflow/search_approvers/index.html.erb
@@ -1,13 +1,8 @@
 <%= jquery do %>
   SS_SearchUI.modal();
   SS_TreeUI.render("form.search .index.groups");
-  $("form.search .dropdown").on("click", function(e) {
-    $("form.search .index.groups").toggle();
+  SS_Dropdown.render();
 
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  });
   $("form.search .index.groups .select-group").on("click", function(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -25,17 +20,19 @@
       <dd>
         <button class="dropdown btn"><%= @group.name %> <span class="caret">&#x25BC;</span></button>
         <%= hidden_field_tag("s[group]", @group.id) %>
-        <table class="index groups pulldown-index">
-          <tbody>
-          <% @groups.each do |item| %>
-            <tr data-depth="<%= item.name.count("/") + @cur_site.name.count("/") %>" class="toggle">
-              <td class="expandable">
-                <%= link_to item.trailing_name, "#", class: "select-group", data: { id: item.id } %>
-              </td>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
+        <div class="dropdown-container">
+          <table class="index groups">
+            <tbody>
+            <% @groups.each do |item| %>
+              <tr data-depth="<%= item.name.count("/") + @cur_site.name.count("/") %>" class="toggle">
+                <td class="expandable">
+                  <%= link_to item.trailing_name, "#", class: "select-group", data: { id: item.id } %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
       </dd>
       <dt><%= t "cms.user" %></dt>
       <dd><%= f.text_field :keyword, value: params[:s].try(:[], :keyword) %>

--- a/app/views/workflow/search_approvers/index.html.erb
+++ b/app/views/workflow/search_approvers/index.html.erb
@@ -18,8 +18,8 @@
     <dl class="see">
       <dt><%= t "cms.group" %></dt>
       <dd>
-        <button class="dropdown btn"><%= @group.name %> <span class="caret">&#x25BC;</span></button>
-        <%= hidden_field_tag("s[group]", @group.id) %>
+        <button class="dropdown btn"><%= @group.try(:name) %> <span class="caret">&#x25BC;</span></button>
+        <%= hidden_field_tag("s[group]", @group.try(:id)) %>
         <div class="dropdown-container">
           <table class="index groups">
             <tbody>

--- a/config/locales/gws/board/ja.yml
+++ b/config/locales/gws/board/ja.yml
@@ -70,6 +70,7 @@ ja:
     models:
       gws/board/topic: 掲示板トピック
       gws/board/post: 掲示板投稿
+      gws/board/category: カテゴリー
     errors:
       models:
         gws/board/category:

--- a/config/locales/gws/share/ja.yml
+++ b/config/locales/gws/share/ja.yml
@@ -35,7 +35,7 @@ ja:
   mongoid:
     models:
       gws/share/file: 共有ファイル
-      gws/share/category: 共有ファイル種類
+      gws/share/category: カテゴリー
     errors:
       models:
         gws/share/file:

--- a/spec/features/gws/board/topics/basic_crud_spec.rb
+++ b/spec/features/gws/board/topics/basic_crud_spec.rb
@@ -25,7 +25,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         visit new_path
         click_on "カテゴリーを選択する"
         wait_for_cbox
-        click_on category.name
+        within "tbody.items" do
+          click_on category.name
+        end
 
         within "form#item-form" do
           fill_in "item[name]", with: "name"
@@ -57,7 +59,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
       visit edit_path
       click_on "カテゴリーを選択する"
       wait_for_cbox
-      click_on category.name
+      within "tbody.items" do
+        click_on category.name
+      end
       within "form#item-form" do
         fill_in "item[name]", with: "modify"
         click_button "保存"

--- a/spec/features/gws/share/files_spec.rb
+++ b/spec/features/gws/share/files_spec.rb
@@ -35,7 +35,9 @@ describe "gws_share_files", type: :feature, dbscope: :example do
       first('#addon-gws-agents-addons-share-category .toggle-head').click
       click_on "カテゴリーを選択する"
       wait_for_cbox
-      click_on category.name
+      within "tbody.items" do
+        click_on category.name
+      end
       within "form#item-form" do
         attach_file "item[in_files][]", "#{Rails.root}/spec/fixtures/ss/logo.png"
         click_button "保存"

--- a/spec/features/gws/workflow/files/basic_crud_spec.rb
+++ b/spec/features/gws/workflow/files/basic_crud_spec.rb
@@ -35,7 +35,6 @@ describe "gws_workflow_files", type: :feature, dbscope: :example, tmpdir: true d
         click_on "保存"
       end
 
-      # puts page.html
       expect(page).to have_css("div.addon-body dd", text: item_name)
 
       expect(Gws::Workflow::File.site(site).count).to eq 1
@@ -52,7 +51,7 @@ describe "gws_workflow_files", type: :feature, dbscope: :example, tmpdir: true d
       within "form#item-form" do
         fill_in "item[name]", with: item_name2
         fill_in "item[text]", with: item_text2
-        click_on "保存"
+        click_on "公開保存"
       end
 
       expect(page).to have_css("div.addon-body dd", text: item_name2)

--- a/spec/features/workflow/routes_spec.rb
+++ b/spec/features/workflow/routes_spec.rb
@@ -46,7 +46,7 @@ describe "workflow_routes", type: :feature, dbscope: :example do
         end
         # wait a while to load contents of dialog
         wait_for_cbox
-        within "div#ajax-box table.index" do
+        within "div#ajax-box table.index tbody.items" do
           click_link user.name
         end
 

--- a/spec/features/workflow/search_approvers_spec.rb
+++ b/spec/features/workflow/search_approvers_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe "workflow_search_approvers" do
-  subject(:site) { cms_site }
-  subject(:user) { cms_user }
-  subject(:group) { cms_group }
-  subject(:index_path) { workflow_search_approvers_path site.id }
+describe "workflow_search_approvers", type: :feature, dbscope: :example do
+  let(:site) { cms_site }
+  let(:user) { cms_user }
+  let(:group) { cms_group }
+  let(:index_path) { workflow_search_approvers_path site.id }
 
   it "without login" do
     visit index_path
@@ -14,7 +14,8 @@ describe "workflow_search_approvers" do
   it "without auth" do
     login_ss_user
     visit index_path
-    expect(status_code).to eq 403
+    expect(status_code).to eq 200
+    expect(page).to have_css("table.index tbody.items tr", count: 0)
   end
 
   context "with auth" do
@@ -22,12 +23,7 @@ describe "workflow_search_approvers" do
 
     it "#index" do
       visit index_path
-      # save_and_open_page
-      # print page.html
-      within("form.search") do
-        expect(all("option").reduce([]) { |a, e| a << e.value }).to include group.id.to_s
-      end
-      within("table.index") do
+      within("table.index tbody.items") do
         expect(find("a.select-item").text).to eq user.long_name.to_s
       end
 


### PR DESCRIPTION
ユーザー選択ダイアログの次の問題を修正。

* グループ数が多いと画面の下にはみ出してしまってグループが選択できない。
  * スクロールバーを表示するようにしました（下図）。
* 全組織の中からユーザーを選択できない。
  * ドロップダウンの先頭にグループ名を表示するようにしました（下図）。<br>グループ名を選択すると、全組織内からユーザーを選択できます。

![image](https://cloud.githubusercontent.com/assets/3593466/14736377/a5ef695a-08b1-11e6-9dc4-3f684393eb2a.png)


他:

* ワークフロー経路作成時のユーザー選択もツリー表示しました。
* スマホでもテストし、スマホでも操作できるようにドロップダウンの高さを 250px としています。
  * クリック範囲を通常より広げているため、スマホでも割合ストレス無く操作できました。

HTML 量の削減については、おいおい検討していきたいと思います。

※以下ぐらいの簡潔さで表示できるのが目標。

```
<%= f.tree_select :groups %>
```