### PR TITLE
[add] .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,32 @@
+engines:
+  rubocop:
+    enabled: true
+  brakeman:
+    enabled: true
+  bundler-audit:
+    enabled: true
+  coffeelint:
+    enabled: true
+  csslint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - ruby
+  rubymotion:
+    enabled: true
+  scss-lint:
+    enabled: true
+ratings:
+  paths:
+  - Gemfile.lock
+  - "**.rb"
+  - "**.coffee"
+  - "**.css"
+exclude_paths:
+- bin/**/*
+- private/**/*
+- public/**/*
+- spec/**/*
+- "**/vendor/**/*"


### PR DESCRIPTION
codeclimate の仕様変更（？）により public/assets の下のファイルが、点数の判定に含まれるようになってしまっています。
それを除外する設定を書いてみました。

あわせて codeclimate は[様々な engine](https://docs.codeclimate.com/docs/list-of-engines) を有効・無効にできるようですので、Ruby に関係しそうな全てのエンジン `rubocop`, `brakeman`, `bundler-audit`, `coffeelint`, `csslint`, `duplication`, `rubymotion`, `scss-lint` を有効にしてみました。