### PR TITLE
[modify] add criteria `active` to default scope

### DIFF
--- a/app/controllers/cms/groups_controller.rb
+++ b/app/controllers/cms/groups_controller.rb
@@ -24,10 +24,11 @@ class Cms::GroupsController < ApplicationController
     def index
       raise "403" unless @model.allowed?(:read, @cur_user, site: @cur_site, node: @cur_node)
 
-      @items = @model.site(@cur_site).
+      @items = @model.unscoped.site(@cur_site).
         state(params.dig(:s, :state)).
         allow(:read, @cur_user, site: @cur_site).
-        search(params[:s]).sort_by(&:name)
+        search(params[:s]).
+        order_by(name: 1, order: 1, id: 1)
     end
 
     def destroy

--- a/app/models/cms/group.rb
+++ b/app/models/cms/group.rb
@@ -9,6 +9,7 @@ class Cms::Group
   attr_accessor :cur_site, :cms_role_ids
   permit_params :cms_role_ids
 
+  default_scope -> { active }
   scope :site, ->(site) { self.in(name: site.groups.pluck(:name).map{ |name| /^#{Regexp.escape(name)}(\/|$)/ }) }
 
   validate :validate_sites, if: ->{ cur_site.present? }


### PR DESCRIPTION
`Cms::Group` の `default_scope` に `active` を追加しました。

groups controller は、グループの有効・無効に関係なく、すべてを捜査対象とする必要がありますが、
この修正により groups controller が有効なグループしか捜査対象にできなくて困るので、groups controller では、default scope を無効にして group を検索するようにしました。