### PR TITLE
公開予約の開始／終了日時のデフォルト設定

### DIFF
--- a/app/models/ads/node.rb
+++ b/app/models/ads/node.rb
@@ -2,6 +2,7 @@ module Ads::Node
   class Banner
     include Cms::Model::Node
     include Cms::Addon::NodeSetting
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
 
     default_scope ->{ where(route: "ads/banner") }

--- a/app/models/article/node.rb
+++ b/app/models/article/node.rb
@@ -12,6 +12,7 @@ module Article::Node
     include Cms::Addon::PageList
     include Category::Addon::Setting
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/models/category/node.rb
+++ b/app/models/category/node.rb
@@ -23,6 +23,7 @@ module Category::Node
     include Cms::Addon::Meta
     include Cms::Addon::PageList
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/models/cms/node.rb
+++ b/app/models/cms/node.rb
@@ -29,6 +29,7 @@ class Cms::Node
     include Cms::Addon::Meta
     include Cms::Addon::PageList
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/models/cms/site.rb
+++ b/app/models/cms/site.rb
@@ -2,6 +2,7 @@ class Cms::Site
   include SS::Model::Site
   include Cms::SitePermission
   include Cms::Addon::PageSetting
+  include Cms::Addon::DefaultReleasePlan
   include SS::Addon::MobileSetting
 
   set_permission_name "cms_sites"

--- a/app/models/concerns/cms/addon/default_release_plan.rb
+++ b/app/models/concerns/cms/addon/default_release_plan.rb
@@ -1,0 +1,42 @@
+module Cms::Addon
+  module DefaultReleasePlan
+    extend ActiveSupport::Concern
+    extend SS::Addon
+
+    included do
+      field :default_release_plan_state, type: String, default: 'disabled'
+      field :default_release_date_delay, type: Integer
+      field :default_close_date_delay, type: Integer
+
+      permit_params :default_release_plan_state, :default_release_date_delay, :default_close_date_delay
+
+      validates :default_release_date_delay, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: ->{ default_release_plan_enabled? }
+      validates :default_close_date_delay, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: ->{ default_release_plan_enabled? }
+      validate :validate_default_close_date_delay
+    end
+
+    def default_release_plan_state_options
+      %w(disabled enabled).map do |v|
+        [ I18n.t("views.options.state.#{v}"), v ]
+      end
+    end
+
+    def default_release_plan_enabled?
+      self.default_release_plan_state == 'enabled'
+    end
+
+    def default_release_plan_disabled?
+      !default_release_plan_enabled?
+    end
+
+    private
+      def validate_default_close_date_delay
+        return if default_release_date_delay.blank?
+        return if default_close_date_delay.blank?
+
+        if default_release_date_delay >= default_close_date_delay
+          errors.add :default_close_date_delay, :greater_than, count: t(:default_release_date_delay)
+        end
+      end
+  end
+end

--- a/app/models/concerns/cms/addon/default_release_plan.rb
+++ b/app/models/concerns/cms/addon/default_release_plan.rb
@@ -5,14 +5,14 @@ module Cms::Addon
 
     included do
       field :default_release_plan_state, type: String, default: 'disabled'
-      field :default_release_date_delay, type: Integer
-      field :default_close_date_delay, type: Integer
+      field :default_release_days_after, type: Integer
+      field :default_close_days_after, type: Integer
 
-      permit_params :default_release_plan_state, :default_release_date_delay, :default_close_date_delay
+      permit_params :default_release_plan_state, :default_release_days_after, :default_close_days_after
 
-      validates :default_release_date_delay, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: ->{ default_release_plan_enabled? }
-      validates :default_close_date_delay, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: ->{ default_release_plan_enabled? }
-      validate :validate_default_close_date_delay
+      validates :default_release_days_after, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: ->{ default_release_plan_enabled? }
+      validates :default_close_days_after, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: ->{ default_release_plan_enabled? }
+      validate :validate_default_close_days_after
     end
 
     def default_release_plan_state_options
@@ -30,12 +30,12 @@ module Cms::Addon
     end
 
     private
-      def validate_default_close_date_delay
-        return if default_release_date_delay.blank?
-        return if default_close_date_delay.blank?
+      def validate_default_close_days_after
+        return if default_release_days_after.blank?
+        return if default_close_days_after.blank?
 
-        if default_release_date_delay >= default_close_date_delay
-          errors.add :default_close_date_delay, :greater_than, count: t(:default_release_date_delay)
+        if default_release_days_after >= default_close_days_after
+          errors.add :default_close_days_after, :greater_than, count: t(:default_release_days_after)
         end
       end
   end

--- a/app/models/concerns/cms/addon/release_plan.rb
+++ b/app/models/concerns/cms/addon/release_plan.rb
@@ -31,5 +31,49 @@ module Cms::Addon
         self.state = "closed" if close_date && close_date <= Time.zone.now
       end
     end
+
+    def default_release_plan_enabled?
+      parent = self.try(:parent)
+      parent = parent.becomes_with_route if parent.present?
+      return true if parent.try(:default_release_plan_enabled?)
+
+      site = self.try(:site)
+      site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
+      return true if site.try(:default_release_plan_enabled?)
+
+      site = self.try(:cur_site)
+      site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
+      return true if site.try(:default_release_plan_enabled?)
+
+      false
+    end
+
+    def default_release_date(now = Time.zone.now)
+      parent = self.try(:parent)
+      parent = parent.becomes_with_route if parent.present?
+      return (now.to_date + parent.default_release_date_delay.days).to_time if parent.try(:default_release_plan_enabled?)
+
+      site = self.try(:site)
+      site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
+      return (now.to_date + site.default_release_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+
+      site = self.try(:cur_site)
+      site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
+      return (now.to_date + site.default_release_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+    end
+
+    def default_close_date(now = Time.zone.now)
+      parent = self.try(:parent)
+      parent = parent.becomes_with_route if parent.present?
+      return (now.to_date + parent.default_close_date_delay.days).to_time if parent.try(:default_release_plan_enabled?)
+
+      site = self.try(:site)
+      site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
+      return (now.to_date + site.default_close_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+
+      site = self.try(:cur_site)
+      site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
+      return (now.to_date + site.default_close_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+    end
   end
 end

--- a/app/models/concerns/cms/addon/release_plan.rb
+++ b/app/models/concerns/cms/addon/release_plan.rb
@@ -51,29 +51,30 @@ module Cms::Addon
     def default_release_date(now = Time.zone.now)
       parent = self.try(:parent)
       parent = parent.becomes_with_route if parent.present?
-      return calc_beginning_of_day(now, parent.default_release_date_delay) if parent.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, parent.default_release_days_after) if parent.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, parent.default_release_days_after) if parent.try(:default_release_plan_enabled?)
 
       site = self.try(:site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return calc_beginning_of_day(now, site.default_release_date_delay) if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_release_days_after) if site.try(:default_release_plan_enabled?)
 
       site = self.try(:cur_site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return calc_beginning_of_day(now, site.default_release_date_delay) if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_release_days_after) if site.try(:default_release_plan_enabled?)
     end
 
     def default_close_date(now = Time.zone.now)
       parent = self.try(:parent)
       parent = parent.becomes_with_route if parent.present?
-      return calc_beginning_of_day(now, parent.default_close_date_delay) if parent.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, parent.default_close_days_after) if parent.try(:default_release_plan_enabled?)
 
       site = self.try(:site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return calc_beginning_of_day(now, site.default_close_date_delay) if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_close_days_after) if site.try(:default_release_plan_enabled?)
 
       site = self.try(:cur_site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return calc_beginning_of_day(now, site.default_close_date_delay) if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_close_days_after) if site.try(:default_release_plan_enabled?)
     end
 
     private

--- a/app/models/concerns/cms/addon/release_plan.rb
+++ b/app/models/concerns/cms/addon/release_plan.rb
@@ -51,29 +51,36 @@ module Cms::Addon
     def default_release_date(now = Time.zone.now)
       parent = self.try(:parent)
       parent = parent.becomes_with_route if parent.present?
-      return (now.to_date + parent.default_release_date_delay.days).to_time if parent.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, parent.default_release_date_delay) if parent.try(:default_release_plan_enabled?)
 
       site = self.try(:site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return (now.to_date + site.default_release_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_release_date_delay) if site.try(:default_release_plan_enabled?)
 
       site = self.try(:cur_site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return (now.to_date + site.default_release_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_release_date_delay) if site.try(:default_release_plan_enabled?)
     end
 
     def default_close_date(now = Time.zone.now)
       parent = self.try(:parent)
       parent = parent.becomes_with_route if parent.present?
-      return (now.to_date + parent.default_close_date_delay.days).to_time if parent.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, parent.default_close_date_delay) if parent.try(:default_release_plan_enabled?)
 
       site = self.try(:site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return (now.to_date + site.default_close_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_close_date_delay) if site.try(:default_release_plan_enabled?)
 
       site = self.try(:cur_site)
       site = Cms::Site.find(site.id) if site.present? && !site.is_a?(Cms::Site)
-      return (now.to_date + site.default_close_date_delay.days).to_time if site.try(:default_release_plan_enabled?)
+      return calc_beginning_of_day(now, site.default_close_date_delay) if site.try(:default_release_plan_enabled?)
     end
+
+    private
+      def calc_beginning_of_day(now, days)
+        ret = now + days.days
+        ret = ret.beginning_of_day
+        return ret
+      end
   end
 end

--- a/app/models/event/node.rb
+++ b/app/models/event/node.rb
@@ -12,6 +12,7 @@ module Event::Node
     include Category::Addon::Setting
     include Event::Addon::PageList
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/models/ezine/node.rb
+++ b/app/models/ezine/node.rb
@@ -13,6 +13,7 @@ module Ezine::Node
     include Ezine::Addon::SenderAddress
     include Ezine::Addon::Reply
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/models/facility/node.rb
+++ b/app/models/facility/node.rb
@@ -31,6 +31,7 @@ module Facility::Node
     include Facility::Addon::Service
     include Facility::Addon::Location
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/models/faq/node.rb
+++ b/app/models/faq/node.rb
@@ -12,6 +12,7 @@ module Faq::Node
     include Cms::Addon::PageList
     include Category::Addon::Setting
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/models/sitemap/node.rb
+++ b/app/models/sitemap/node.rb
@@ -10,6 +10,7 @@ module Sitemap::Node
     include Cms::Addon::NodeSetting
     include Cms::Addon::Meta
     include Cms::Addon::Release
+    include Cms::Addon::DefaultReleasePlan
     include Cms::Addon::GroupPermission
     include History::Addon::Backup
 

--- a/app/views/cms/agents/addons/default_release_plan/_form.html.erb
+++ b/app/views/cms/agents/addons/default_release_plan/_form.html.erb
@@ -1,0 +1,18 @@
+<%= jquery do %>
+  SS_AddonTabs.hide(".mod-cms-default-release-plan");
+<% end %>
+<%
+  @item.default_release_date_delay ||= 3
+  @item.default_close_date_delay ||= 1000
+%>
+
+<dl class="see mod-cms-default-release-plan">
+  <dt><%= @model.t :default_release_plan_state %><%= @model.tt :default_release_plan_state %></dt>
+  <dd><%= f.select :default_release_plan_state, @item.default_release_plan_state_options %></dd>
+
+  <dt><%= @model.t :default_release_date_delay %><%= @model.tt :default_release_date_delay %></dt>
+  <dd><%= f.number_field :default_release_date_delay %> <%= t("views.units.days_after") %></dd>
+
+  <dt><%= @model.t :default_close_date_delay %><%= @model.tt :default_close_date_delay %></dt>
+  <dd><%= f.number_field :default_close_date_delay %> <%= t("views.units.days_after") %></dd>
+</dl>

--- a/app/views/cms/agents/addons/default_release_plan/_form.html.erb
+++ b/app/views/cms/agents/addons/default_release_plan/_form.html.erb
@@ -2,17 +2,17 @@
   SS_AddonTabs.hide(".mod-cms-default-release-plan");
 <% end %>
 <%
-  @item.default_release_date_delay ||= 3
-  @item.default_close_date_delay ||= 1000
+  @item.default_release_days_after ||= 3
+  @item.default_close_days_after ||= 1000
 %>
 
 <dl class="see mod-cms-default-release-plan">
   <dt><%= @model.t :default_release_plan_state %><%= @model.tt :default_release_plan_state %></dt>
   <dd><%= f.select :default_release_plan_state, @item.default_release_plan_state_options %></dd>
 
-  <dt><%= @model.t :default_release_date_delay %><%= @model.tt :default_release_date_delay %></dt>
-  <dd><%= f.number_field :default_release_date_delay %> <%= t("views.units.days_after") %></dd>
+  <dt><%= @model.t :default_release_days_after %><%= @model.tt :default_release_days_after %></dt>
+  <dd><%= f.number_field :default_release_days_after %> <%= t("views.units.days_after") %></dd>
 
-  <dt><%= @model.t :default_close_date_delay %><%= @model.tt :default_close_date_delay %></dt>
-  <dd><%= f.number_field :default_close_date_delay %> <%= t("views.units.days_after") %></dd>
+  <dt><%= @model.t :default_close_days_after %><%= @model.tt :default_close_days_after %></dt>
+  <dd><%= f.number_field :default_close_days_after %> <%= t("views.units.days_after") %></dd>
 </dl>

--- a/app/views/cms/agents/addons/default_release_plan/_show.html.erb
+++ b/app/views/cms/agents/addons/default_release_plan/_show.html.erb
@@ -1,0 +1,18 @@
+<dl class="see">
+  <dt><%= @model.t :default_release_plan_state %></dt>
+  <dd><%= @item.label :default_release_plan_state %></dd>
+
+  <dt><%= @model.t :default_release_date_delay %></dt>
+  <dd>
+    <% if @item.default_release_date_delay %>
+    <%= @item.default_release_date_delay %> <%= t("views.units.days_after") %>
+    <% end %>
+  </dd>
+
+  <dt><%= @model.t :default_close_date_delay %></dt>
+  <dd>
+    <% if @item.default_close_date_delay %>
+    <%= @item.default_close_date_delay %> <%= t("views.units.days_after") %>
+    <% end %>
+  </dd>
+</dl>

--- a/app/views/cms/agents/addons/default_release_plan/_show.html.erb
+++ b/app/views/cms/agents/addons/default_release_plan/_show.html.erb
@@ -2,17 +2,17 @@
   <dt><%= @model.t :default_release_plan_state %></dt>
   <dd><%= @item.label :default_release_plan_state %></dd>
 
-  <dt><%= @model.t :default_release_date_delay %></dt>
+  <dt><%= @model.t :default_release_days_after %></dt>
   <dd>
-    <% if @item.default_release_date_delay %>
-    <%= @item.default_release_date_delay %> <%= t("views.units.days_after") %>
+    <% if @item.default_release_days_after %>
+    <%= @item.default_release_days_after %> <%= t("views.units.days_after") %>
     <% end %>
   </dd>
 
-  <dt><%= @model.t :default_close_date_delay %></dt>
+  <dt><%= @model.t :default_close_days_after %></dt>
   <dd>
-    <% if @item.default_close_date_delay %>
-    <%= @item.default_close_date_delay %> <%= t("views.units.days_after") %>
+    <% if @item.default_close_days_after %>
+    <%= @item.default_close_days_after %> <%= t("views.units.days_after") %>
     <% end %>
   </dd>
 </dl>

--- a/app/views/cms/agents/addons/release_plan/_form.html.erb
+++ b/app/views/cms/agents/addons/release_plan/_form.html.erb
@@ -2,7 +2,7 @@
   SS_AddonTabs.hide(".mod-cms-release_plan");
 <% end %>
 <%
-  if (@item.state == 'closed' || @item.new_record?) && @item.default_release_plan_enabled?
+  if @item.new_record? && @item.default_release_plan_enabled?
     @item.release_date ||= @item.default_release_date
     @item.close_date ||= @item.default_close_date
   end

--- a/app/views/cms/agents/addons/release_plan/_form.html.erb
+++ b/app/views/cms/agents/addons/release_plan/_form.html.erb
@@ -1,6 +1,12 @@
 <%= jquery do %>
   SS_AddonTabs.hide(".mod-cms-release_plan");
 <% end %>
+<%
+  if (@item.state == 'closed' || @item.new_record?) && @item.default_release_plan_enabled?
+    @item.release_date ||= @item.default_release_date
+    @item.close_date ||= @item.default_close_date
+  end
+%>
 
 <dl class="see mod-cms-release_plan">
   <dt><%= @model.t :release_date %><%= @model.tt :release_date %></dt>

--- a/app/views/ss/agents/addons/mobile_setting/_form.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_form.html.erb
@@ -1,4 +1,7 @@
-<dl class="see mod-mobile-setting">
+<%= jquery do %>
+  SS_AddonTabs.hide(".mod-ss-mobile-setting");
+<% end %>
+<dl class="see mod-ss-mobile-setting">
   <dt><%= @model.t :mobile_state %><%= @model.tt :mobile_state %></dt>
   <dd><%= f.select :mobile_state, @item.mobile_state_options %></dd>
 

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -348,8 +348,8 @@ ja:
         in_file: ファイル
       cms/addon/default_release_plan:
         default_release_plan_state: 公開予約の既定値
-        default_release_date_delay: 公開開始日
-        default_close_date_delay: 公開終了日
+        default_release_days_after: 公開開始日
+        default_close_days_after: 公開終了日
 
   errors:
     messages:
@@ -821,10 +821,10 @@ ja:
         - 既定で公開予約を設定するかどうかを選択します。
         - 「無効]を選択している場合、既定で公開予約を設定しません。
         - 「有効]を選択している場合、既定で公開予約開始日と公開予約終了日を設定します。
-      default_release_date_delay:
+      default_release_days_after:
         - 公開開始日を設定します。
         - 「3 日後」を設定した場合、当日日付＋3日後の0時0分に公開開始日時が設定されます。
-      default_close_date_delay:
+      default_close_days_after:
         - 公開終了日を設定します。
         - 「1000 日後」を設定した場合、当日日付＋1,000日後の0時0分に公開開始日時が設定されます。
 

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -214,6 +214,7 @@ ja:
       cms/sns_share: SNS共有
       cms/captcha: 認証
       cms/body_layout_html: HTML
+      cms/default_release_plan: 公開予約の既定値
 
   mongoid:
     models:
@@ -345,6 +346,10 @@ ja:
         in_file: ファイル
       cms/addon/import/user:
         in_file: ファイル
+      cms/addon/default_release_plan:
+        default_release_plan_state: 公開予約の既定値
+        default_release_date_delay: 公開開始日
+        default_close_date_delay: 公開終了日
 
   errors:
     messages:
@@ -810,6 +815,18 @@ ja:
       notice_target:
         - 「全ユーザー」に表示するか、「管理グループ」に表示するかを選択します。
         - 「管理グループ」を選択した場合、「管理グループ」欄に設定したグループに表示されます。
+
+    cms/addon/default_release_plan:
+      default_release_plan_state:
+        - 既定で公開予約を設定するかどうかを選択します。
+        - 「無効]を選択している場合、既定で公開予約を設定しません。
+        - 「有効]を選択している場合、既定で公開予約開始日と公開予約終了日を設定します。
+      default_release_date_delay:
+        - 公開開始日を設定します。
+        - 「3 日後」を設定した場合、当日日付＋3日後の0時0分に公開開始日時が設定されます。
+      default_close_date_delay:
+        - 公開終了日を設定します。
+        - 「1000 日後」を設定した場合、当日日付＋1,000日後の0時0分に公開開始日時が設定されます。
 
   all_content:
     url: URL

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -126,6 +126,7 @@ ja:
     units:
       count: 件
       mega_byte: MB
+      days_after: 日後
 
   ss:
     views:

--- a/spec/features/article/pages/auth_spec.rb
+++ b/spec/features/article/pages/auth_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe "article_pages", dbscope: :example do
+  let(:site) { cms_site }
+  let(:node) { create_once :article_node_page, filename: "docs", name: "article" }
+  # let(:item) { create(:article_page, cur_node: node) }
+  let(:index_path) { article_pages_path site.id, node }
+  # let(:new_path) { new_article_page_path site.id, node }
+  # let(:show_path) { article_page_path site.id, node, item }
+  # let(:edit_path) { edit_article_page_path site.id, node, item }
+  # let(:delete_path) { delete_article_page_path site.id, node, item }
+  # let(:move_path) { move_article_page_path site.id, node, item }
+  # let(:copy_path) { copy_article_page_path site.id, node, item }
+  # let(:lock_path) { lock_article_page_path site.id, node, item }
+
+  it "without login" do
+    visit index_path
+    expect(current_path).to eq sns_login_path
+  end
+
+  it "without auth" do
+    login_ss_user
+    visit index_path
+    expect(status_code).to eq 403
+  end
+end

--- a/spec/features/article/pages/basic_crud_spec.rb
+++ b/spec/features/article/pages/basic_crud_spec.rb
@@ -11,20 +11,8 @@ describe "article_pages", dbscope: :example do
   let(:delete_path) { delete_article_page_path site.id, node, item }
   let(:move_path) { move_article_page_path site.id, node, item }
   let(:copy_path) { copy_article_page_path site.id, node, item }
-  let(:lock_path) { lock_article_page_path site.id, node, item }
 
-  it "without login" do
-    visit index_path
-    expect(current_path).to eq sns_login_path
-  end
-
-  it "without auth" do
-    login_ss_user
-    visit index_path
-    expect(status_code).to eq 403
-  end
-
-  context "with auth" do
+  context "basic crud" do
     before { login_cms_user }
 
     it "#index" do
@@ -96,37 +84,6 @@ describe "article_pages", dbscope: :example do
         click_button "削除"
       end
       expect(current_path).to eq index_path
-    end
-
-    feature "lock and unlock" do
-      given(:group) { cms_group }
-      given(:user1) { create(:cms_test_user, group: group) }
-
-      background do
-        item.acquire_lock(user: user1)
-      end
-
-      scenario "locked by other then unlock and edit forcibly" do
-        expect(item.lock_owner_id).not_to eq cms_user.id
-
-        visit show_path
-        expect(status_code).to eq 200
-
-        within "div#addon-cms-agents-addons-edit_lock" do
-          expect(page).to have_content(I18n.t("errors.messages.locked", user: item.lock_owner.long_name))
-        end
-
-        click_link "編集する"
-        expect(status_code).to eq 200
-        expect(current_path).to eq lock_path
-
-        click_button I18n.t("views.button.unlock_and_edit_forcibly")
-        expect(status_code).to eq 200
-        expect(current_path).to eq edit_path
-
-        item.reload
-        expect(item.lock_owner_id).to eq cms_user.id
-      end
     end
   end
 end

--- a/spec/features/article/pages/default_release_plan_spec.rb
+++ b/spec/features/article/pages/default_release_plan_spec.rb
@@ -17,7 +17,7 @@ describe "article_pages", dbscope: :example do
       end
 
       it do
-        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
+        Timecop.travel(Time.utc(2016, 4, 12, 10, 32)) do
           visit index_path
           click_on "新規作成"
 
@@ -32,12 +32,9 @@ describe "article_pages", dbscope: :example do
           end
           # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
-          expect(status_code).to eq 200
 
           # wait for a while because executes save in asynchornously
-          within "div#addon-basic" do
-            expect(page).to have_css("dd", text: "sample")
-          end
+          wait_for_selector("div#addon-basic dd", text: "sample")
 
           expect(Article::Page.count).to eq 1
           page = Article::Page.first
@@ -57,7 +54,7 @@ describe "article_pages", dbscope: :example do
       end
 
       it do
-        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
+        Timecop.travel(Time.utc(2016, 4, 12, 10, 32)) do
           visit index_path
           click_on "新規作成"
 
@@ -71,12 +68,9 @@ describe "article_pages", dbscope: :example do
           end
           # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
-          expect(status_code).to eq 200
 
           # wait for a while because executes save in asynchornously
-          within "div#addon-basic" do
-            expect(page).to have_css("dd", text: "sample")
-          end
+          wait_for_selector("div#addon-basic dd", text: "sample")
 
           expect(Article::Page.count).to eq 1
           page = Article::Page.first
@@ -96,7 +90,7 @@ describe "article_pages", dbscope: :example do
       end
 
       it do
-        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
+        Timecop.travel(Time.utc(2016, 4, 12, 10, 32)) do
           visit index_path
           click_on "新規作成"
 
@@ -110,12 +104,9 @@ describe "article_pages", dbscope: :example do
           end
           # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
-          expect(status_code).to eq 200
 
           # wait for a while because executes save in asynchornously
-          within "div#addon-basic" do
-            expect(page).to have_css("dd", text: "sample")
-          end
+          wait_for_selector("div#addon-basic dd", text: "sample")
 
           expect(Article::Page.count).to eq 1
           page = Article::Page.first
@@ -142,7 +133,7 @@ describe "article_pages", dbscope: :example do
       end
 
       it do
-        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
+        Timecop.travel(Time.utc(2016, 4, 12, 10, 32)) do
           visit index_path
           click_on "新規作成"
 
@@ -156,12 +147,9 @@ describe "article_pages", dbscope: :example do
           end
           # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
-          expect(status_code).to eq 200
 
           # wait for a while because executes save in asynchornously
-          within "div#addon-basic" do
-            expect(page).to have_css("dd", text: "sample")
-          end
+          wait_for_selector("div#addon-basic dd", text: "sample")
 
           expect(Article::Page.count).to eq 1
           page = Article::Page.first

--- a/spec/features/article/pages/default_release_plan_spec.rb
+++ b/spec/features/article/pages/default_release_plan_spec.rb
@@ -8,7 +8,7 @@ describe "article_pages", dbscope: :example do
 
     before { login_cms_user }
 
-    context "with site setting" do
+    context "with site setting", js: true do
       before do
         site.default_release_plan_state = 'enabled'
         site.default_release_date_delay = 3
@@ -17,7 +17,7 @@ describe "article_pages", dbscope: :example do
       end
 
       it do
-        Timecop.travel("2016/04/12 16:32") do
+        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
           visit index_path
           click_on "新規作成"
 
@@ -27,9 +27,17 @@ describe "article_pages", dbscope: :example do
           within "form#item-form" do
             fill_in "item[name]", with: "sample"
             fill_in "item[basename]", with: "sample"
-            click_button "保存"
+            Rails.logger.debug("click 公開保存")
+            click_button "公開保存"
           end
+          # submit form forcibly, I dont't know why form is submitted.
+          page.execute_script("$('form#item-form').submit()")
           expect(status_code).to eq 200
+
+          # wait for a while because executes save in asynchornously
+          within "div#addon-basic" do
+            expect(page).to have_css("dd", text: "sample")
+          end
 
           expect(Article::Page.count).to eq 1
           page = Article::Page.first
@@ -40,7 +48,46 @@ describe "article_pages", dbscope: :example do
       end
     end
 
-    context "with node setting" do
+    context "save as draft with site setting", js: true do
+      before do
+        site.default_release_plan_state = 'enabled'
+        site.default_release_date_delay = 3
+        site.default_close_date_delay = 100
+        site.save!
+      end
+
+      it do
+        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
+          visit index_path
+          click_on "新規作成"
+
+          expect(page).to have_field("item[release_date]", with: "2016/04/15 00:00")
+          expect(page).to have_field("item[close_date]", with: "2016/07/21 00:00")
+
+          within "form#item-form" do
+            fill_in "item[name]", with: "sample"
+            fill_in "item[basename]", with: "sample"
+            click_button "下書き保存"
+          end
+          # submit form forcibly, I dont't know why form is submitted.
+          page.execute_script("$('form#item-form').submit()")
+          expect(status_code).to eq 200
+
+          # wait for a while because executes save in asynchornously
+          within "div#addon-basic" do
+            expect(page).to have_css("dd", text: "sample")
+          end
+
+          expect(Article::Page.count).to eq 1
+          page = Article::Page.first
+          expect(page.state).to eq "closed"
+          expect(page.release_date).to eq Time.zone.parse("2016/04/15 00:00")
+          expect(page.close_date).to eq Time.zone.parse("2016/07/21 00:00")
+        end
+      end
+    end
+
+    context "with node setting", js: true do
       before do
         node.default_release_plan_state = 'enabled'
         node.default_release_date_delay = 4
@@ -49,7 +96,7 @@ describe "article_pages", dbscope: :example do
       end
 
       it do
-        Timecop.travel("2016/04/12 16:32") do
+        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
           visit index_path
           click_on "新規作成"
 
@@ -59,9 +106,16 @@ describe "article_pages", dbscope: :example do
           within "form#item-form" do
             fill_in "item[name]", with: "sample"
             fill_in "item[basename]", with: "sample"
-            click_button "保存"
+            click_button "公開保存"
           end
+          # submit form forcibly, I dont't know why form is submitted.
+          page.execute_script("$('form#item-form').submit()")
           expect(status_code).to eq 200
+
+          # wait for a while because executes save in asynchornously
+          within "div#addon-basic" do
+            expect(page).to have_css("dd", text: "sample")
+          end
 
           expect(Article::Page.count).to eq 1
           page = Article::Page.first
@@ -72,7 +126,7 @@ describe "article_pages", dbscope: :example do
       end
     end
 
-    context "with site setting and node setting" do
+    context "with site setting and node setting", js: true do
       before do
         site.default_release_plan_state = 'enabled'
         site.default_release_date_delay = 3
@@ -88,7 +142,7 @@ describe "article_pages", dbscope: :example do
       end
 
       it do
-        Timecop.travel("2016/04/12 16:32") do
+        Timecop.travel(Time.new(2016, 4, 12, 16, 32)) do
           visit index_path
           click_on "新規作成"
 
@@ -98,9 +152,16 @@ describe "article_pages", dbscope: :example do
           within "form#item-form" do
             fill_in "item[name]", with: "sample"
             fill_in "item[basename]", with: "sample"
-            click_button "保存"
+            click_button "公開保存"
           end
+          # submit form forcibly, I dont't know why form is submitted.
+          page.execute_script("$('form#item-form').submit()")
           expect(status_code).to eq 200
+
+          # wait for a while because executes save in asynchornously
+          within "div#addon-basic" do
+            expect(page).to have_css("dd", text: "sample")
+          end
 
           expect(Article::Page.count).to eq 1
           page = Article::Page.first

--- a/spec/features/article/pages/default_release_plan_spec.rb
+++ b/spec/features/article/pages/default_release_plan_spec.rb
@@ -30,7 +30,7 @@ describe "article_pages", dbscope: :example do
             Rails.logger.debug("click 公開保存")
             click_button "公開保存"
           end
-          # submit form forcibly, I dont't know why form is submitted.
+          # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
           expect(status_code).to eq 200
 
@@ -69,7 +69,7 @@ describe "article_pages", dbscope: :example do
             fill_in "item[basename]", with: "sample"
             click_button "下書き保存"
           end
-          # submit form forcibly, I dont't know why form is submitted.
+          # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
           expect(status_code).to eq 200
 
@@ -108,7 +108,7 @@ describe "article_pages", dbscope: :example do
             fill_in "item[basename]", with: "sample"
             click_button "公開保存"
           end
-          # submit form forcibly, I dont't know why form is submitted.
+          # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
           expect(status_code).to eq 200
 
@@ -154,7 +154,7 @@ describe "article_pages", dbscope: :example do
             fill_in "item[basename]", with: "sample"
             click_button "公開保存"
           end
-          # submit form forcibly, I dont't know why form is submitted.
+          # submit form forcibly because form doesn't submit any data
           page.execute_script("$('form#item-form').submit()")
           expect(status_code).to eq 200
 

--- a/spec/features/article/pages/default_release_plan_spec.rb
+++ b/spec/features/article/pages/default_release_plan_spec.rb
@@ -11,8 +11,8 @@ describe "article_pages", dbscope: :example do
     context "with site setting", js: true do
       before do
         site.default_release_plan_state = 'enabled'
-        site.default_release_date_delay = 3
-        site.default_close_date_delay = 100
+        site.default_release_days_after = 3
+        site.default_close_days_after = 100
         site.save!
       end
 
@@ -48,8 +48,8 @@ describe "article_pages", dbscope: :example do
     context "save as draft with site setting", js: true do
       before do
         site.default_release_plan_state = 'enabled'
-        site.default_release_date_delay = 3
-        site.default_close_date_delay = 100
+        site.default_release_days_after = 3
+        site.default_close_days_after = 100
         site.save!
       end
 
@@ -84,8 +84,8 @@ describe "article_pages", dbscope: :example do
     context "with node setting", js: true do
       before do
         node.default_release_plan_state = 'enabled'
-        node.default_release_date_delay = 4
-        node.default_close_date_delay = 71
+        node.default_release_days_after = 4
+        node.default_close_days_after = 71
         node.save!
       end
 
@@ -120,15 +120,15 @@ describe "article_pages", dbscope: :example do
     context "with site setting and node setting", js: true do
       before do
         site.default_release_plan_state = 'enabled'
-        site.default_release_date_delay = 3
-        site.default_close_date_delay = 100
+        site.default_release_days_after = 3
+        site.default_close_days_after = 100
         site.save!
       end
 
       before do
         node.default_release_plan_state = 'enabled'
-        node.default_release_date_delay = 4
-        node.default_close_date_delay = 71
+        node.default_release_days_after = 4
+        node.default_close_days_after = 71
         node.save!
       end
 

--- a/spec/features/article/pages/default_release_plan_spec.rb
+++ b/spec/features/article/pages/default_release_plan_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+describe "article_pages", dbscope: :example do
+  context "default release plan" do
+    let(:site) { cms_site }
+    let(:node) { create :article_node_page, filename: "docs", name: "article" }
+    let(:index_path) { article_pages_path site.id, node }
+
+    before { login_cms_user }
+
+    context "with site setting" do
+      before do
+        site.default_release_plan_state = 'enabled'
+        site.default_release_date_delay = 3
+        site.default_close_date_delay = 100
+        site.save!
+      end
+
+      it do
+        Timecop.travel("2016/04/12 16:32") do
+          visit index_path
+          click_on "新規作成"
+
+          expect(page).to have_field("item[release_date]", with: "2016/04/15 00:00")
+          expect(page).to have_field("item[close_date]", with: "2016/07/21 00:00")
+
+          within "form#item-form" do
+            fill_in "item[name]", with: "sample"
+            fill_in "item[basename]", with: "sample"
+            click_button "保存"
+          end
+          expect(status_code).to eq 200
+
+          expect(Article::Page.count).to eq 1
+          page = Article::Page.first
+          expect(page.state).to eq "ready"
+          expect(page.release_date).to eq Time.zone.parse("2016/04/15 00:00")
+          expect(page.close_date).to eq Time.zone.parse("2016/07/21 00:00")
+        end
+      end
+    end
+
+    context "with node setting" do
+      before do
+        node.default_release_plan_state = 'enabled'
+        node.default_release_date_delay = 4
+        node.default_close_date_delay = 71
+        node.save!
+      end
+
+      it do
+        Timecop.travel("2016/04/12 16:32") do
+          visit index_path
+          click_on "新規作成"
+
+          expect(page).to have_field("item[release_date]", with: "2016/04/16 00:00")
+          expect(page).to have_field("item[close_date]", with: "2016/06/22 00:00")
+
+          within "form#item-form" do
+            fill_in "item[name]", with: "sample"
+            fill_in "item[basename]", with: "sample"
+            click_button "保存"
+          end
+          expect(status_code).to eq 200
+
+          expect(Article::Page.count).to eq 1
+          page = Article::Page.first
+          expect(page.state).to eq "ready"
+          expect(page.release_date).to eq Time.zone.parse("2016/04/16 00:00")
+          expect(page.close_date).to eq Time.zone.parse("2016/06/22 00:00")
+        end
+      end
+    end
+
+    context "with site setting and node setting" do
+      before do
+        site.default_release_plan_state = 'enabled'
+        site.default_release_date_delay = 3
+        site.default_close_date_delay = 100
+        site.save!
+      end
+
+      before do
+        node.default_release_plan_state = 'enabled'
+        node.default_release_date_delay = 4
+        node.default_close_date_delay = 71
+        node.save!
+      end
+
+      it do
+        Timecop.travel("2016/04/12 16:32") do
+          visit index_path
+          click_on "新規作成"
+
+          expect(page).to have_field("item[release_date]", with: "2016/04/16 00:00")
+          expect(page).to have_field("item[close_date]", with: "2016/06/22 00:00")
+
+          within "form#item-form" do
+            fill_in "item[name]", with: "sample"
+            fill_in "item[basename]", with: "sample"
+            click_button "保存"
+          end
+          expect(status_code).to eq 200
+
+          expect(Article::Page.count).to eq 1
+          page = Article::Page.first
+          expect(page.state).to eq "ready"
+          expect(page.release_date).to eq Time.zone.parse("2016/04/16 00:00")
+          expect(page.close_date).to eq Time.zone.parse("2016/06/22 00:00")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/article/pages/lock_spec.rb
+++ b/spec/features/article/pages/lock_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "article_pages", dbscope: :example do
+  let(:site) { cms_site }
+  let(:node) { create_once :article_node_page, filename: "docs", name: "article" }
+  let(:item) { create(:article_page, cur_node: node) }
+  let(:show_path) { article_page_path site.id, node, item }
+  let(:edit_path) { edit_article_page_path site.id, node, item }
+  let(:lock_path) { lock_article_page_path site.id, node, item }
+
+  feature "lock and unlock" do
+    given(:group) { cms_group }
+    given(:user1) { create(:cms_test_user, group: group) }
+
+    background do
+      item.acquire_lock(user: user1)
+    end
+
+    background { login_cms_user }
+
+    scenario "locked by other then unlock and edit forcibly" do
+      expect(item.lock_owner_id).not_to eq cms_user.id
+
+      visit show_path
+      expect(status_code).to eq 200
+
+      within "div#addon-cms-agents-addons-edit_lock" do
+        expect(page).to have_content(I18n.t("errors.messages.locked", user: item.lock_owner.long_name))
+      end
+
+      click_link "編集する"
+      expect(status_code).to eq 200
+      expect(current_path).to eq lock_path
+
+      click_button I18n.t("views.button.unlock_and_edit_forcibly")
+      expect(status_code).to eq 200
+      expect(current_path).to eq edit_path
+
+      item.reload
+      expect(item.lock_owner_id).to eq cms_user.id
+    end
+  end
+end


### PR DESCRIPTION
公開予約の開始／終了日時にデフォルトで日付が入力されるようにする機能拡張です。

* サイトとノードの両方に公開予約の既定値を設定できるように拡張。
* サイト全体に公開予約の既定値を入力させたければ、サイトに既定値を設定する。
* 特定のノードでのみ公開予約の既定値を入力させたければ、ノードに既定値を設定する。
* サイトとノードの両方に設定がある場合、ノードの方が優先。
  * ただしページは、親の設定しか見ません。grant parent やさらに親の設定は見ません。
* 固定ページをルートに作成する場合、サイトの設定を適用します。

![image](https://cloud.githubusercontent.com/assets/3593466/15208054/a0838d4e-1864-11e6-851a-c8de1961108d.png)
