### PR TITLE
[fix] unable send inquiry's reply mail

### DIFF
--- a/app/controllers/inquiry/agents/nodes/form_controller.rb
+++ b/app/controllers/inquiry/agents/nodes/form_controller.rb
@@ -80,7 +80,10 @@ class Inquiry::Agents::Nodes::FormController < ApplicationController
         Inquiry::Mailer.notify_mail(@cur_site, @cur_node, @answer).deliver_now
       end
       if @cur_node.reply_mail_enabled?
-        Inquiry::Mailer.reply_mail(@cur_site, @cur_node, @answer).try(:deliver_now)
+        # `try` method doesn't work as you think because mail is an instance of Delegator.
+        # see: http://tech.misoca.jp/entry/2015/12/04/110000
+        mail = Inquiry::Mailer.reply_mail(@cur_site, @cur_node, @answer)
+        mail.deliver_now if mail.present?
       end
 
       query = {}


### PR DESCRIPTION
メールは、Delegator のインスタンスです。Delegator のインスタンスの場合、`try` は、想像通りに動作しません。

Delegator インスタンスの場合、レシーバーオブジェクトの移譲先で `try(:deliver_now)` が評価されます。
このため、メールの移譲先であるメッセージ上で `try(:deliver_now)` が評価されます。

`deliver_now` は、レシーバーオブジェクトが提供するメソッドであり、メッセージオブジェクは `deliver_now` を提供しません。

http://tech.misoca.jp/entry/2015/12/04/110000

※なお Ruby 2.3 から導入された safe navigation operator は想像通りに動作しました。
※想像通りに動作しましたが、修正は Ruby 2.2 でも動作するようにしています。