### PR TITLE
[fix] before_action :x_sendfile condition for #1070

### DIFF
--- a/app/controllers/concerns/cms/public_filter.rb
+++ b/app/controllers/concerns/cms/public_filter.rb
@@ -11,8 +11,8 @@ module Cms::PublicFilter
     before_action :deny_path
     before_action :parse_path
     before_action :compile_scss
-    before_action :x_sendfile, if: ->{ filters.blank? }
-  end
+    before_action :x_sendfile, unless: ->{ filters.include?(:mobile) || filters.include?(:kana) }
+ end
 
   def index
     if @cur_path =~ /\.p[1-9]\d*\.html$/

--- a/app/controllers/concerns/cms/public_filter.rb
+++ b/app/controllers/concerns/cms/public_filter.rb
@@ -11,7 +11,7 @@ module Cms::PublicFilter
     before_action :deny_path
     before_action :parse_path
     before_action :compile_scss
-    before_action :x_sendfile, if: ->{ !filters.include?(:mobile) }
+    before_action :x_sendfile, if: ->{ filters.blank? }
   end
 
   def index

--- a/app/controllers/concerns/cms/public_filter.rb
+++ b/app/controllers/concerns/cms/public_filter.rb
@@ -12,7 +12,7 @@ module Cms::PublicFilter
     before_action :parse_path
     before_action :compile_scss
     before_action :x_sendfile, unless: ->{ filters.include?(:mobile) || filters.include?(:kana) }
- end
+  end
 
   def index
     if @cur_path =~ /\.p[1-9]\d*\.html$/


### PR DESCRIPTION
filters に :kana が入っている場合、動的に処理（#render_kana）する必要があります。
filters に :kana が入っている場合でも静的ファイルがあれば先にx_sendfileされるようになった為、
書き出されているページにかなが振られなくなっているようです。
