### PR TITLE
モバイル設定にサイズ（KB）を追加

### DIFF
--- a/app/assets/javascripts/cms/lib/form.coffee.erb
+++ b/app/assets/javascripts/cms/lib/form.coffee.erb
@@ -585,7 +585,7 @@ class @Mobile_Size_Checker
     SizeCheckError    : "<%= I18n.t('errors.messages.mobile_size_check_failed_to_size') %>"
   }
 
-  @error   = ""
+  @error   = []
   @url     = "/.cms/mobile_size_check/check.json"
   @rootUrl = ""
   @imgs    = []
@@ -607,8 +607,10 @@ class @Mobile_Size_Checker
       Mobile_Size_Checker.check html, true, ()->
         result = Mobile_Size_Checker.result_open()
 
-        if Mobile_Size_Checker.error != ""
-          result.append(Mobile_Size_Checker.error)
+        if Mobile_Size_Checker.error.length > 0
+          for err in Mobile_Size_Checker.error
+            result.append("<p>#{err}</p>")
+
         else
           result.append("<p>" + Mobile_Size_Checker.message["mobile_check"] + "</p>")
 
@@ -664,7 +666,14 @@ class @Mobile_Size_Checker
     size = Mobile_Size_Checker.get_str_byte(html)
     console.log("mobile_size=#{mobile_size}, size=#{size}")
     if mobile_size < size
-      Mobile_Size_Checker.error = "<p class=\"error\">" + Mobile_Size_Checker.message["SizeCheckError"] + "</p>"
+      err_str = "<p class=\"error\">"
+      err_str += Mobile_Size_Checker.message["SizeCheckError"]
+      err_str += "(本文サイズ：#{parseInt(size/1024)}KB、"
+      err_str += "制限サイズ：#{Mobile_Size_Checker.check_size})"
+      err_str += "</p>"
+
+      Mobile_Size_Checker.error = [err_str]
+
       complete()
       return
 
@@ -697,14 +706,13 @@ class @Mobile_Size_Checker
       async: async,
       success: (res, status) ->
         if res["errors"].length > 0
-          for err in res["errors"]
-            Mobile_Size_Checker.error += "<p>" + err + "</p>"
+          Mobile_Size_Checker.error = res["errors"]
 
       error: (xhr, status, error) ->
         str_err = "<p>"
         str_err += Mobile_Size_Checker.message["SizeCheckError"]
         str_err += "</p>"
-        Mobile_Size_Checker.error = str_err
+        Mobile_Size_Checker.error = [str_err]
         return
       complete: (xhr, status) ->
         complete()
@@ -716,17 +724,19 @@ class @Mobile_Size_Checker
     Mobile_Size_Checker.reset()
     if Mobile_Size_Checker.enabled
       Mobile_Size_Checker.check html, false, ()->
-        if Mobile_Size_Checker.error != ""
-          errors = [{
-            code: ""
-            msg: Mobile_Size_Checker.error
-            detail: Mobile_Size_Checker.error
-          }]
-          Syntax_Checker.pushError(errors)
+        if Mobile_Size_Checker.error.length > 0
           result = Mobile_Size_Checker.result_open()
-          result.append(Mobile_Size_Checker.error)
-          Mobile_Size_Checker.result_close(result)
+          errors = []
+          for err in Mobile_Size_Checker.error
+            errors.push({
+              code: ""
+              msg: err
+              detail: err
+            })
+            result.append("<p>#{err}</p>")
 
+          Syntax_Checker.pushError(errors)
+          Mobile_Size_Checker.result_close(result)
 
   @validateHtml: (form, submit)->
     count = Syntax_Checker.errorCount

--- a/app/assets/javascripts/cms/lib/form.coffee.erb
+++ b/app/assets/javascripts/cms/lib/form.coffee.erb
@@ -664,7 +664,6 @@ class @Mobile_Size_Checker
   @check: (html, async, complete)->
     mobile_size = Mobile_Size_Checker.mobile_size
     size = Mobile_Size_Checker.get_str_byte(html)
-    console.log("mobile_size=#{mobile_size}, size=#{size}")
     if mobile_size < size
       err_str = "<p class=\"error\">"
       err_str += Mobile_Size_Checker.message["SizeCheckError"]

--- a/app/assets/javascripts/cms/lib/form.coffee.erb
+++ b/app/assets/javascripts/cms/lib/form.coffee.erb
@@ -582,7 +582,7 @@ class @Mobile_Size_Checker
     failure           : "<%= I18n.t('errors.messages.mobile_size_check_failure') %>"
     mobile_disable    : "<%= I18n.t('errors.messages.mobile_size_check_disable') %>"
     mobile_check      : "<%= I18n.t('errors.messages.mobile_size_check_size') %>"
-    SizeCheckError    : "<%= I18n.t('errors.messages.mobile_size_check_failed_to_size') %>"
+    SizeCheckServerError: "<%= I18n.t('errors.messages.mobile_size_check_server_error') %>"
   }
 
   @error   = []
@@ -668,8 +668,7 @@ class @Mobile_Size_Checker
     if mobile_size < size
       err_str = "<p class=\"error\">"
       err_str += Mobile_Size_Checker.message["SizeCheckError"]
-      err_str += "(本文サイズ：#{parseInt(size/1024)}KB、"
-      err_str += "制限サイズ：#{Mobile_Size_Checker.check_size})"
+      err_str += "(本文サイズ：#{parseInt(size/1024)}KB"
       err_str += "</p>"
 
       Mobile_Size_Checker.error = [err_str]
@@ -710,7 +709,7 @@ class @Mobile_Size_Checker
 
       error: (xhr, status, error) ->
         str_err = "<p>"
-        str_err += Mobile_Size_Checker.message["SizeCheckError"]
+        str_err += Mobile_Size_Checker.message["SizeCheckServerError"]
         str_err += "</p>"
         Mobile_Size_Checker.error = [str_err]
         return

--- a/app/assets/javascripts/cms/lib/form.coffee.erb
+++ b/app/assets/javascripts/cms/lib/form.coffee.erb
@@ -698,7 +698,7 @@ class @Mobile_Size_Checker
       success: (res, status) ->
         if res["errors"].length > 0
           for err in res["errors"]
-            Mobile_Size_Checker.error += "<li>" + err + "</li>"
+            Mobile_Size_Checker.error += "<p>" + err + "</p>"
 
       error: (xhr, status, error) ->
         str_err = "<p>"

--- a/app/assets/javascripts/cms/lib/form.coffee.erb
+++ b/app/assets/javascripts/cms/lib/form.coffee.erb
@@ -3,11 +3,13 @@ class @Cms_Form
     #$(window).load ->
     Syntax_Checker.render()
     Link_Checker.render()
+    Mobile_Size_Checker.render()
 
     Form_Alert.addValidation(Form_Alert.clonedName)
     Form_Alert.addValidation(Form_Alert.closeConfirmation)
     Form_Alert.addValidation(Form_Alert.presence)
     Form_Alert.addValidation(Syntax_Checker.validateHtml)
+    Form_Alert.addValidation(Mobile_Size_Checker.validateHtml)
 
     if Syntax_Checker.autoCorrect
       Form_Alert.addBeforeSave(Syntax_Checker.correctAll)
@@ -131,6 +133,7 @@ class @Syntax_Checker
 
   @validateHtml: (form, submit)->
     unless Syntax_Checker.check()
+
       for key, errors of Syntax_Checker.errors
         for error, i in errors
           if error["correct"] && Syntax_Checker.autoCorrect
@@ -570,6 +573,167 @@ class @Syntax_Checker
           detail: Syntax_Checker.detail["checkEmbeddedMedia"]
         }]
         Syntax_Checker.pushError(errors)
+
+class @Mobile_Size_Checker
+  @message = {
+    header            : "<%= I18n.t('cms.mobile_size_check') %>"
+    body              : ""
+    success           : "<%= I18n.t('errors.messages.mobile_size_check_success') %>"
+    failure           : "<%= I18n.t('errors.messages.mobile_size_check_failure') %>"
+    mobile_disable    : "<%= I18n.t('errors.messages.mobile_size_check_disable') %>"
+    mobile_check      : "<%= I18n.t('errors.messages.mobile_size_check_size') %>"
+    SizeCheckError    : "<%= I18n.t('errors.messages.mobile_size_check_failed_to_size') %>"
+  }
+
+  @error   = ""
+  @url     = "/.cms/mobile_size_check/check.json"
+  @rootUrl = ""
+  @imgs    = []
+
+  @render: ()->
+    $("button.mobile-size-check").on "click", ->
+      button = this
+      $(button).attr('disabled', true)
+      Mobile_Size_Checker.reset()
+      if !Mobile_Size_Checker.enabled
+        result = Mobile_Size_Checker.result_open()
+        result.append("<p>" + Mobile_Size_Checker.message["mobile_disable"] + "</p>")
+        Mobile_Size_Checker.result_close(result)
+        $(button).removeAttr('disabled')
+        return
+
+      html = Cms_Form.getEditorHtml()
+
+      Mobile_Size_Checker.check html, true, ()->
+        result = Mobile_Size_Checker.result_open()
+
+        if Mobile_Size_Checker.error != ""
+          result.append(Mobile_Size_Checker.error)
+        else
+          result.append("<p>" + Mobile_Size_Checker.message["mobile_check"] + "</p>")
+
+        Mobile_Size_Checker.result_close(result)
+        $(button).removeAttr('disabled')
+        return
+      return
+  @result_open: ()->
+    result = $("<div>")
+    result.attr('id', 'errorMobileChecker')
+    result.attr('class', 'errorExplanation')
+    result.append("<h2>" + Mobile_Size_Checker.message["header"] + "</h2>")
+    return result
+
+  @result_close: (result)->
+    $(Cms_Form.addonSelector).find("#errorMobileChecker").remove()
+    $(Cms_Form.addonSelector).append(result)
+    return
+
+  @reset: ()->
+    @message["body"] = ""
+    $("#errorMobileChecker").remove()
+    @imgs = {}
+    @error = ""
+    return
+
+  @addMessage: (imgs, state)->
+    if state
+      msg = '<span class="success">' + Mobile_Size_Checker.message["success"] + '</span>'
+      Mobile_Size_Checker.imgs[imgs] = imgs + " " + msg
+    else
+      msg = '<span class="failure">' + Mobile_Size_Checker.message["failure"] + '</span>'
+      Mobile_Size_Checker.imgs[imgs] = imgs + " " + msg
+
+
+  @get_str_byte: (str)->
+    ESCAPECHAR = ";,/?:@&=+$ "
+    ESCAPEDLEN_TABLE = [0, 1, 1, 1, 2, 3, 2, 3, 4, 3]
+    size = 0
+    if str == null || str == ""
+      return size
+
+    for i, char of str
+      if ESCAPECHAR.indexOf(char) >= 0
+        size++
+      else
+        size += ESCAPEDLEN_TABLE[encodeURI(char).length]
+
+    return size
+
+  @check: (html, async, complete)->
+    mobile_size = Mobile_Size_Checker.mobile_size
+    size = Mobile_Size_Checker.get_str_byte(html)
+    console.log("mobile_size=#{mobile_size}, size=#{size}")
+    if mobile_size < size
+      Mobile_Size_Checker.error = "<p class=\"error\">" + Mobile_Size_Checker.message["SizeCheckError"] + "</p>"
+      complete()
+      return
+
+    numOfImage = $(html).find('img').length
+    if numOfImage == 0
+      complete()
+      return
+
+    imgs = []
+    for src in $(html).find('img[src]')
+      str_src = $(src).attr('src')
+      str_id = str_src.match(/^\/fs\/(.+?)\/_\//)
+
+      imgs.push(
+        parseInt(str_id[1].replace(/\//, ""))
+      )
+
+    $.ajax {
+      type: "POST", url: Mobile_Size_Checker.url, cache: false,
+      data: JSON.stringify({img_ids: imgs, mobile_size: mobile_size }),
+      contentType: 'application/json',
+      dataType: "json",
+      crossDomain: true,
+      async: async,
+      success: (res, status) ->
+        if res["errors"].length > 0
+          for err in res["errors"]
+            Mobile_Size_Checker.error = "<p>" + err+ "</p>"
+
+        else
+          for file_name in res["file_name"]
+            Mobile_Size_Checker.addMessage(file_name, true)
+
+      error: (xhr, status, error) ->
+        Mobile_Size_Checker.error = "<p>" + Mobile_Size_Checker.message["SizeCheckError"] + "</p>"
+        return
+      complete: (xhr, status) ->
+        complete()
+        return
+    }
+    return
+
+  @checkHtmlSize: (html)->
+    Mobile_Size_Checker.reset()
+    if Mobile_Size_Checker.enabled
+      Mobile_Size_Checker.check html, false, ()->
+        if Mobile_Size_Checker.error != ""
+          errors = [{
+            code: ""
+            msg: Mobile_Size_Checker.error
+            detail: Mobile_Size_Checker.error
+          }]
+          Syntax_Checker.pushError(errors)
+          result = Mobile_Size_Checker.result_open()
+          result.append(Mobile_Size_Checker.error)
+          Mobile_Size_Checker.result_close(result)
+
+
+  @validateHtml: (form, submit)->
+    count = Syntax_Checker.errorCount
+    html = Cms_Form.getEditorHtml()
+    unless Mobile_Size_Checker.checkHtmlSize html
+      if Syntax_Checker.errors[count]
+        for error, i in Syntax_Checker.errors[count]
+          if error["correct"] && Syntax_Checker.autoCorrect
+            Form_Alert.add "<%= I18n.t('cms.auto_correct.notice') %>", this, error["msg"]
+          else
+            Form_Alert.add "<%= I18n.t('cms.syntax_check') %>", this, error["msg"]
+
 
 class @Link_Checker
   @message = {

--- a/app/assets/javascripts/cms/lib/form.coffee.erb
+++ b/app/assets/javascripts/cms/lib/form.coffee.erb
@@ -674,9 +674,11 @@ class @Mobile_Size_Checker
       return
 
     imgs = []
+    isThumb = {}
     for src in $(html).find('img[src]')
       str_src = $(src).attr('src')
       str_id = str_src.match(/^\/fs\/(.+?)\/_\//)
+      isThumb[str_id[1].replace(/\//, "")] = str_src.match(/_\/thumb\//)
 
       imgs.push(
         parseInt(str_id[1].replace(/\//, ""))
@@ -684,7 +686,11 @@ class @Mobile_Size_Checker
 
     $.ajax {
       type: "POST", url: Mobile_Size_Checker.url, cache: false,
-      data: JSON.stringify({img_ids: imgs, mobile_size: mobile_size }),
+      data: JSON.stringify({
+        img_ids: imgs,
+        mobile_size: mobile_size,
+        is_thumb: isThumb
+      }),
       contentType: 'application/json',
       dataType: "json",
       crossDomain: true,
@@ -692,14 +698,13 @@ class @Mobile_Size_Checker
       success: (res, status) ->
         if res["errors"].length > 0
           for err in res["errors"]
-            Mobile_Size_Checker.error = "<p>" + err+ "</p>"
-
-        else
-          for file_name in res["file_name"]
-            Mobile_Size_Checker.addMessage(file_name, true)
+            Mobile_Size_Checker.error += "<li>" + err + "</li>"
 
       error: (xhr, status, error) ->
-        Mobile_Size_Checker.error = "<p>" + Mobile_Size_Checker.message["SizeCheckError"] + "</p>"
+        str_err = "<p>"
+        str_err += Mobile_Size_Checker.message["SizeCheckError"]
+        str_err += "</p>"
+        Mobile_Size_Checker.error = str_err
         return
       complete: (xhr, status) ->
         complete()
@@ -732,7 +737,7 @@ class @Mobile_Size_Checker
           if error["correct"] && Syntax_Checker.autoCorrect
             Form_Alert.add "<%= I18n.t('cms.auto_correct.notice') %>", this, error["msg"]
           else
-            Form_Alert.add "<%= I18n.t('cms.syntax_check') %>", this, error["msg"]
+            Form_Alert.add "<%= I18n.t('cms.mobile_size_check') %>", this, error["msg"]
 
 
 class @Link_Checker

--- a/app/controllers/cms/mobile_size_check_controller.rb
+++ b/app/controllers/cms/mobile_size_check_controller.rb
@@ -1,6 +1,3 @@
-require "timeout"
-require "open-uri"
-
 class Cms::MobileSizeCheckController < ApplicationController
   protect_from_forgery except: :check
   skip_before_action :verify_authenticity_token unless SS.config.env.csrf_protect
@@ -10,6 +7,7 @@ class Cms::MobileSizeCheckController < ApplicationController
     result = {}
     imgs_ids = params[:img_ids]
     mobile_size = params[:mobile_size]
+    is_thumb = params[:is_thumb]
 
     raise "400" if imgs_ids.blank?
     imgs_ids = imgs_ids.values if imgs_ids.is_a?(Hash)
@@ -17,15 +15,37 @@ class Cms::MobileSizeCheckController < ApplicationController
 
     img_files = SS::File.where(:id.in => ids)
     size = 0
-    result[:file_name] = []
+    result[:file_id] = []
     result[:errors] = []
     img_files.each do |file|
-      next if result[:file_name].include?(file.name)
-      size += file.size
-      if size > mobile_size
-        result[:errors] << I18n.t("errors.messages.too_bigsize")
+      next if result[:file_id].include?(file.id)
+
+      if is_thumb[file.id.to_s]
+        if file.thumb.size > 0
+          result[:errors] << I18n.t(
+            "errors.messages.too_bigfile",
+            filename: file.name,
+            filesize: view_context.number_to_human_size(file.thumb.size)
+          )
+        end
+
+        size += file.thumb.size
+      else
+        if file.size > 0
+          result[:errors] << I18n.t(
+            "errors.messages.too_bigfile",
+            filename: file.name,
+            filesize: view_context.number_to_human_size(file.size)
+          )
+        end
+
+        size += file.size
+        result[:file_id] << file.id
       end
-      result[:file_name] << file.name
+
+    end
+    if size > mobile_size
+      result[:errors] << I18n.t("errors.messages.too_bigsize")
     end
     result[:size] = size
 

--- a/app/controllers/cms/mobile_size_check_controller.rb
+++ b/app/controllers/cms/mobile_size_check_controller.rb
@@ -1,0 +1,37 @@
+require "timeout"
+require "open-uri"
+
+class Cms::MobileSizeCheckController < ApplicationController
+  protect_from_forgery except: :check
+  skip_before_action :verify_authenticity_token unless SS.config.env.csrf_protect
+  before_action :accept_cors_request
+
+  def check
+    result = {}
+    imgs_ids = params[:img_ids]
+    mobile_size = params[:mobile_size]
+
+    raise "400" if imgs_ids.blank?
+    imgs_ids = imgs_ids.values if imgs_ids.is_a?(Hash)
+    ids = imgs_ids.map { |e| e.to_i }
+
+    img_files = SS::File.where(:id.in => ids)
+    size = 0
+    result[:file_name] = []
+    result[:errors] = []
+    img_files.each do |file|
+      next if result[:file_name].include?(file.name)
+      size += file.size
+      if size > mobile_size
+        result[:errors] << I18n.t("errors.messages.too_bigsize")
+      end
+      result[:file_name] << file.name
+    end
+    result[:size] = size
+
+    respond_to do |format|
+      format.json { render json: result.to_json }
+    end
+  end
+
+end

--- a/app/controllers/cms/mobile_size_check_controller.rb
+++ b/app/controllers/cms/mobile_size_check_controller.rb
@@ -25,7 +25,8 @@ class Cms::MobileSizeCheckController < ApplicationController
           result[:errors] << I18n.t(
             "errors.messages.too_bigfile",
             filename: file.name,
-            filesize: view_context.number_to_human_size(file.thumb.size)
+            filesize: view_context.number_to_human_size(file.thumb.size),
+            mobile_size: view_context.number_to_human_size(mobile_size)
           )
         end
 
@@ -35,7 +36,8 @@ class Cms::MobileSizeCheckController < ApplicationController
           result[:errors] << I18n.t(
             "errors.messages.too_bigfile",
             filename: file.name,
-            filesize: view_context.number_to_human_size(file.size)
+            filesize: view_context.number_to_human_size(file.size),
+            mobile_size: view_context.number_to_human_size(mobile_size)
           )
         end
 

--- a/app/controllers/cms/mobile_size_check_controller.rb
+++ b/app/controllers/cms/mobile_size_check_controller.rb
@@ -45,7 +45,11 @@ class Cms::MobileSizeCheckController < ApplicationController
 
     end
     if size > mobile_size
-      result[:errors] << I18n.t("errors.messages.too_bigsize")
+      result[:errors] << I18n.t(
+        "errors.messages.too_bigsize",
+        total: view_context.number_to_human_size(size),
+        mobile_size: view_context.number_to_human_size(mobile_size)
+      )
     end
     result[:size] = size
 

--- a/app/controllers/cms/mobile_size_check_controller.rb
+++ b/app/controllers/cms/mobile_size_check_controller.rb
@@ -21,7 +21,7 @@ class Cms::MobileSizeCheckController < ApplicationController
       next if result[:file_id].include?(file.id)
 
       if is_thumb[file.id.to_s]
-        if file.thumb.size > 0
+        if file.thumb.size > mobile_size
           result[:errors] << I18n.t(
             "errors.messages.too_bigfile",
             filename: file.name,
@@ -31,7 +31,7 @@ class Cms::MobileSizeCheckController < ApplicationController
 
         size += file.thumb.size
       else
-        if file.size > 0
+        if file.size > mobile_size
           result[:errors] << I18n.t(
             "errors.messages.too_bigfile",
             filename: file.name,

--- a/app/models/concerns/cms/addon/body.rb
+++ b/app/models/concerns/cms/addon/body.rb
@@ -46,8 +46,10 @@ module Cms::Addon
       end
 
       def check_mobile_html_size
-        if @cur_site.mobile_enabled?
-          if html_size > @cur_site.mobile_size * 1000
+        return true if self.html.blank?
+
+        if self.site.mobile_enabled?
+          if html_size > self.site.mobile_size * 1000
             errors.add(:html, I18n.t("errors.messages.too_bigsize"))
           end
         end
@@ -55,7 +57,7 @@ module Cms::Addon
 
       def html_size
         size = 0
-        size += self[:html].bytesize
+        size += self.html.bytesize
         if self.try(:files)
           size += file_size
         end
@@ -67,7 +69,7 @@ module Cms::Addon
         html_files.each do |file|
           size += file.size
         end
-        if size > @cur_site.mobile_size * 1000
+        if size > self.site.mobile_size * 1000
           errors.add(:files, I18n.t("errors.messages.too_bigsize"))
         end
         size
@@ -75,7 +77,7 @@ module Cms::Addon
 
       def html_files
         in_html_files = []
-        file_id_str = self[:html].scan(%r{src=\"/fs/(.+?)/_/})
+        file_id_str = self.html.scan(%r{src=\"/fs/(.+?)/_/})
         ids = []
 
         file_id_str.each do |src|

--- a/app/models/concerns/cms/addon/body.rb
+++ b/app/models/concerns/cms/addon/body.rb
@@ -26,7 +26,7 @@ module Cms::Addon
     end
 
     def mobile_size
-      self.site.mobile_size * 1000
+      self.site.mobile_size
     end
 
     private

--- a/app/models/concerns/cms/addon/body.rb
+++ b/app/models/concerns/cms/addon/body.rb
@@ -8,6 +8,8 @@ module Cms::Addon
       field :markdown, type: String
       permit_params :html, :markdown
 
+      validate :check_mobile_html_size
+
       if respond_to?(:template_variable_handler)
         template_variable_handler('img.src', :template_variable_handler_img_src)
       end
@@ -41,6 +43,51 @@ module Cms::Addon
         img_source = img_source[0..-2] if img_source.end_with?("'", '"')
         img_source = img_source.strip
         img_source
+      end
+
+      def check_mobile_html_size
+        if @cur_site.mobile_enabled?
+          if html_size > @cur_site.mobile_size * 1000
+            errors.add(:html, I18n.t("errors.messages.too_bigsize"))
+          end
+        end
+      end
+
+      def html_size
+        size = 0
+        size += self[:html].bytesize
+        if self.try(:files)
+          size += file_size
+        end
+        size
+      end
+
+      def file_size
+        size = 0
+        html_files.each do |file|
+          size += file.size
+        end
+        if size > @cur_site.mobile_size * 1000
+          errors.add(:files, I18n.t("errors.messages.too_bigsize"))
+        end
+        size
+      end
+
+      def html_files
+        in_html_files = []
+        file_id_str = self[:html].scan(%r{src=\"/fs/(.+?)/_/})
+        ids = []
+
+        file_id_str.each do |src|
+          ids << src[0].delete("/").to_i
+        end
+
+        self.files.each do |file|
+          if ids.include?(file.id)
+            in_html_files << file
+          end
+        end
+        in_html_files
       end
   end
 end

--- a/app/models/concerns/ss/addon/mobile_setting.rb
+++ b/app/models/concerns/ss/addon/mobile_setting.rb
@@ -4,15 +4,17 @@ module SS::Addon
     extend SS::Addon
 
     included do
+      attr_accessor :in_mobile_size
       field :mobile_state, type: String
-      field :mobile_size, type: Integer, default: 500 # 500kb
+      field :mobile_size, type: Integer, default: 500 * 1_024 # 500kb
       field :mobile_location, type: String
       field :mobile_css, type: SS::Extensions::Words
-      permit_params :mobile_state, :mobile_size, :mobile_location, :mobile_css
+      permit_params :mobile_state, :in_mobile_size, :mobile_location, :mobile_css
       before_validation :normalize_mobile_location
+      before_validation :set_mobile_size
       validates :mobile_state, inclusion: { in: %w(disabled enabled) }, if: ->{ mobile_state.present? }
       validates :mobile_size,
-        numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 1000 },
+        numericality: { only_integer: true, greater_than_or_equal_to: 1_024, less_than_or_equal_to: 1_024_000 },
         if: ->{ mobile_enabled? }
     end
 
@@ -21,6 +23,10 @@ module SS::Addon
         return if mobile_location.blank?
         self.mobile_location = "/#{mobile_location}" unless mobile_location.start_with?('/')
         self.mobile_location = mobile_location[0, mobile_location.length - 1] if mobile_location.end_with?('/')
+      end
+
+      def set_mobile_size
+        self.mobile_size = Integer(in_mobile_size) * 1_024 if in_mobile_size.present?
       end
 
     public

--- a/app/models/concerns/ss/addon/mobile_setting.rb
+++ b/app/models/concerns/ss/addon/mobile_setting.rb
@@ -5,11 +5,15 @@ module SS::Addon
 
     included do
       field :mobile_state, type: String
+      field :mobile_size, type: Integer, default: 500 # 500kb
       field :mobile_location, type: String
       field :mobile_css, type: SS::Extensions::Words
-      permit_params :mobile_state, :mobile_location, :mobile_css
+      permit_params :mobile_state, :mobile_size, :mobile_location, :mobile_css
       before_validation :normalize_mobile_location
       validates :mobile_state, inclusion: { in: %w(disabled enabled) }, if: ->{ mobile_state.present? }
+      validates :mobile_size,
+        numericality: { only_integer: true, greater_than_or_equal_to: 100, less_than_or_equal_to: 1000 },
+        if: ->{ mobile_enabled? }
     end
 
     private
@@ -53,5 +57,6 @@ module SS::Addon
       def mobile_state_options
         %w(disabled enabled).map { |m| [ I18n.t("views.options.state.#{m}"), m ] }.to_a
       end
+
   end
 end

--- a/app/models/concerns/ss/addon/mobile_setting.rb
+++ b/app/models/concerns/ss/addon/mobile_setting.rb
@@ -12,7 +12,7 @@ module SS::Addon
       before_validation :normalize_mobile_location
       validates :mobile_state, inclusion: { in: %w(disabled enabled) }, if: ->{ mobile_state.present? }
       validates :mobile_size,
-        numericality: { only_integer: true, greater_than_or_equal_to: 100, less_than_or_equal_to: 1000 },
+        numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 1000 },
         if: ->{ mobile_enabled? }
     end
 

--- a/app/views/cms/agents/addons/body/_form.html.erb
+++ b/app/views/cms/agents/addons/body/_form.html.erb
@@ -25,6 +25,10 @@
     Mobile_Size_Checker.enabled    = <%= @cur_site.mobile_enabled? %>;
     Mobile_Size_Checker.mobile_size = <%= @cur_site.mobile_size %>;
     Mobile_Size_Checker.check_size = "<%= number_to_human_size(@cur_site.mobile_size) %>";
+    Mobile_Size_Checker.message["SizeCheckError"] = "<%= I18n.t(
+      'errors.messages.mobile_size_check_failed_to_size',
+      mobile_size: number_to_human_size(@cur_site.mobile_size)
+      ) %>"
     Syntax_Checker.autoCorrect     = <%= SS.config.cms.auto_correct_page_html == true %>;
 
     <% if replace_words_conf[:replace_words].present? %>

--- a/app/views/cms/agents/addons/body/_form.html.erb
+++ b/app/views/cms/agents/addons/body/_form.html.erb
@@ -24,6 +24,7 @@
     Link_Checker.rootUrl           = "<%= @cur_site.full_url %>";
     Mobile_Size_Checker.enabled    = <%= @cur_site.mobile_enabled? %>;
     Mobile_Size_Checker.mobile_size = <%= @cur_site.mobile_size %>;
+    Mobile_Size_Checker.check_size = "<%= number_to_human_size(@cur_site.mobile_size) %>";
     Syntax_Checker.autoCorrect     = <%= SS.config.cms.auto_correct_page_html == true %>;
 
     <% if replace_words_conf[:replace_words].present? %>

--- a/app/views/cms/agents/addons/body/_form.html.erb
+++ b/app/views/cms/agents/addons/body/_form.html.erb
@@ -22,6 +22,8 @@
   <%= jquery do %>
     Link_Checker.url               = "<%= SS.config.cms.link_check_url %>";
     Link_Checker.rootUrl           = "<%= @cur_site.full_url %>";
+    Mobile_Size_Checker.enabled    = <%= @cur_site.mobile_enabled? %>;
+    Mobile_Size_Checker.mobile_size = <%= @cur_site.mobile_size * 1000 %>;
     Syntax_Checker.autoCorrect     = <%= SS.config.cms.auto_correct_page_html == true %>;
 
     <% if replace_words_conf[:replace_words].present? %>
@@ -43,6 +45,7 @@
     <dd class="wide"><%= f.text_area :html, class: "html", style: "height: 400px;" %></dd>
     <dd class="wide">
     <%= button_tag t("cms.syntax_check"), { type: :button, class: "btn syntax-check" } %>
+    <%= button_tag t("cms.mobile_size_check"), { type: :button, class: "btn mobile-size-check" } %>
     <%= button_tag t("cms.link_check"), { type: :button, class: "btn link-check" } %>
     <%= button_tag t("cms.source_cleaner"), { type: :button, class: "btn source-cleaner" } if source_cleaner_conf[:source_cleaner].present? %>
     <%= button_tag t("cms.preview_page"), { type: :button, class: "btn preview" } if @item.respond_to?(:route) %>

--- a/app/views/cms/agents/addons/body/_form.html.erb
+++ b/app/views/cms/agents/addons/body/_form.html.erb
@@ -23,7 +23,7 @@
     Link_Checker.url               = "<%= SS.config.cms.link_check_url %>";
     Link_Checker.rootUrl           = "<%= @cur_site.full_url %>";
     Mobile_Size_Checker.enabled    = <%= @cur_site.mobile_enabled? %>;
-    Mobile_Size_Checker.mobile_size = <%= @cur_site.mobile_size * 1000 %>;
+    Mobile_Size_Checker.mobile_size = <%= @cur_site.mobile_size %>;
     Syntax_Checker.autoCorrect     = <%= SS.config.cms.auto_correct_page_html == true %>;
 
     <% if replace_words_conf[:replace_words].present? %>

--- a/app/views/ss/agents/addons/mobile_setting/_form.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_form.html.erb
@@ -1,12 +1,15 @@
 <%= jquery do %>
   SS_AddonTabs.hide(".mod-ss-mobile-setting");
 <% end %>
+<%
+  @item.in_mobile_size ||= @item.mobile_size / 1_024
+%>
 <dl class="see mod-ss-mobile-setting">
   <dt><%= @model.t :mobile_state %><%= @model.tt :mobile_state %></dt>
   <dd><%= f.select :mobile_state, @item.mobile_state_options %></dd>
 
   <dt><%= @model.t :mobile_size %><%= @model.tt :mobile_size %></dt>
-  <dd><%= f.number_field :mobile_size, value: @item.mobile_size %>　<%= t("views.units.mobile_size") %></dd>
+  <dd><%= f.number_field :in_mobile_size, value: @item.in_mobile_size %>　<%= t("views.units.mobile_size") %></dd>
 
   <dt><%= @model.t :mobile_location %><%= @model.tt :mobile_location %></dt>
   <dd><%= f.text_field :mobile_location %></dd>

--- a/app/views/ss/agents/addons/mobile_setting/_form.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_form.html.erb
@@ -5,6 +5,9 @@
   <dt><%= @model.t :mobile_state %><%= @model.tt :mobile_state %></dt>
   <dd><%= f.select :mobile_state, @item.mobile_state_options %></dd>
 
+  <dt><%= @model.t :mobile_size %><%= @model.tt :mobile_size %></dt>
+  <dd><%= f.number_field :mobile_size, value: @item.mobile_size %>　<%= t("views.units.mobile_size") %></dd>
+
   <dt><%= @model.t :mobile_location %><%= @model.tt :mobile_location %></dt>
   <dd><%= f.text_field :mobile_location %></dd>
 

--- a/app/views/ss/agents/addons/mobile_setting/_show.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_show.html.erb
@@ -3,7 +3,7 @@
   <dd><%= @item.label :mobile_state %></dd>
 
   <dt><%= @model.t :mobile_size %></dt>
-  <dd><%= number_to_human_size(@item.mobile_size) %> <%= t("views.units.mobile_size") %></dd>
+  <dd><%= number_to_human_size(@item.mobile_size) %></dd>
 
   <dt><%= @model.t :mobile_location %></dt>
   <dd><%= @item.mobile_location %></dd>

--- a/app/views/ss/agents/addons/mobile_setting/_show.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_show.html.erb
@@ -3,7 +3,7 @@
   <dd><%= @item.label :mobile_state %></dd>
 
   <dt><%= @model.t :mobile_size %></dt>
-  <dd><%= @item.mobile_size %> <%= t("views.units.mobile_size") %></dd>
+  <dd><%= number_to_human_size(@item.mobile_size) %> <%= t("views.units.mobile_size") %></dd>
 
   <dt><%= @model.t :mobile_location %></dt>
   <dd><%= @item.mobile_location %></dd>

--- a/app/views/ss/agents/addons/mobile_setting/_show.html.erb
+++ b/app/views/ss/agents/addons/mobile_setting/_show.html.erb
@@ -2,6 +2,9 @@
   <dt><%= @model.t :mobile_state %></dt>
   <dd><%= @item.label :mobile_state %></dd>
 
+  <dt><%= @model.t :mobile_size %></dt>
+  <dd><%= @item.mobile_size %> <%= t("views.units.mobile_size") %></dd>
+
   <dt><%= @model.t :mobile_location %></dt>
   <dd><%= @item.mobile_location %></dd>
 

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -18,7 +18,6 @@ ja:
     layout: レイアウト
     body_layout: 本文レイアウト
     link_check: リンクチェック
-    mobile_size_check: データサイズチェック
     source_cleaner: ソースクリーニング
     word_dictionary: 単語置換辞書
     preview: プレビュー
@@ -41,6 +40,7 @@ ja:
     site: サイト
     site_menu: サイトメニュー
     syntax_check: アクセシビリティチェック
+    mobile_size_check: 携帯データサイズチェック
     user: ユーザー
     view_page: 公開画面
     view_site: サイト確認
@@ -551,7 +551,8 @@ ja:
     messages:
       set_filename: ファイル名を入力してください。
       invalid_filename: ファイル名は不正な値です。
-      too_bigsize: 本文のファイルサイズが大き過ぎます。
+      too_bigsize: 携帯電話で表示する場合、本文のファイルサイズ合計が大き過ぎます。
+      too_bigfile: 携帯電話で表示する場合、%{filename}(%{filesize})のファイルサイズが大き過ぎます。
       set_name: タイトルを入力してください。
       same_filename: 移動先と移動前が同じファイル名です。
       exist_physical_file: 移動先に物理ファイルが既に存在します。

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -551,8 +551,8 @@ ja:
     messages:
       set_filename: ファイル名を入力してください。
       invalid_filename: ファイル名は不正な値です。
-      too_bigsize: 携帯電話で表示する場合、ファイルサイズ合計(%{total})が制限値の%{mobile_size}より大き過ぎます。
-      too_bigfile: 携帯電話で表示する場合、%{filename}(%{filesize})のファイルサイズが大き過ぎます。
+      too_bigsize: 携帯電話で表示する場合、ファイルサイズ合計(%{total})が制限値の%{mobile_size}以下になるようにしてください。
+      too_bigfile: 携帯電話で表示する場合、%{filename}(%{filesize})のファイルサイズを%{mobile_size}以下になるようにしてください。
       set_name: タイトルを入力してください。
       same_filename: 移動先と移動前が同じファイル名です。
       exist_physical_file: 移動先に物理ファイルが既に存在します。
@@ -573,7 +573,8 @@ ja:
       mobile_size_check_failure: 失敗
       mobile_size_check_disable: モバイルサイズが設定されていません。
       mobile_size_check_size: 本文のデータサイズはOKです。
-      mobile_size_check_failed_to_size: 携帯で表示する場合、本文のデータサイズが大きすぎます。
+      mobile_size_check_failed_to_size: 携帯で表示する場合、本文のデータサイズが%{mobile_size}以下になるようにしてください。
+      mobile_size_check_server_error: 本文データサイズのチェック中にサーバーエラーが発生しました。
       not_a_child_group: はサイトに所属するグループを設定してください。
       not_found_parent_group: 親グループが存在しません。
       invalid_order_of_h: 見出しの順番が不正です。

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -550,6 +550,7 @@ ja:
     messages:
       set_filename: ファイル名を入力してください。
       invalid_filename: ファイル名は不正な値です。
+      too_bigsize: サイズが大き過ぎます。
       set_name: タイトルを入力してください。
       same_filename: 移動先と移動前が同じファイル名です。
       exist_physical_file: 移動先に物理ファイルが既に存在します。

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -18,6 +18,7 @@ ja:
     layout: レイアウト
     body_layout: 本文レイアウト
     link_check: リンクチェック
+    mobile_size_check: データサイズチェック
     source_cleaner: ソースクリーニング
     word_dictionary: 単語置換辞書
     preview: プレビュー
@@ -550,7 +551,7 @@ ja:
     messages:
       set_filename: ファイル名を入力してください。
       invalid_filename: ファイル名は不正な値です。
-      too_bigsize: サイズが大き過ぎます。
+      too_bigsize: 本文のファイルサイズが大き過ぎます。
       set_name: タイトルを入力してください。
       same_filename: 移動先と移動前が同じファイル名です。
       exist_physical_file: 移動先に物理ファイルが既に存在します。
@@ -567,6 +568,11 @@ ja:
       link_check_success: 成功
       link_check_failure: 失敗
       link_check_failed_to_connect: リンクチェックに失敗しました。次のURLに接続できません。
+      mobile_size_check_success: 成功
+      mobile_size_check_failure: 失敗
+      mobile_size_check_disable: モバイルサイズが設定されていません。
+      mobile_size_check_size: 本文のデータサイズはOKです。
+      mobile_size_check_failed_to_size: 本文のデータサイズが大きすぎます。
       not_a_child_group: はサイトに所属するグループを設定してください。
       not_found_parent_group: 親グループが存在しません。
       invalid_order_of_h: 見出しの順番が不正です。

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -551,7 +551,7 @@ ja:
     messages:
       set_filename: ファイル名を入力してください。
       invalid_filename: ファイル名は不正な値です。
-      too_bigsize: 携帯電話で表示する場合、本文のファイルサイズ合計が大き過ぎます。
+      too_bigsize: 携帯電話で表示する場合、ファイルサイズ合計(%{total})が制限値の%{mobile_size}より大き過ぎます。
       too_bigfile: 携帯電話で表示する場合、%{filename}(%{filesize})のファイルサイズが大き過ぎます。
       set_name: タイトルを入力してください。
       same_filename: 移動先と移動前が同じファイル名です。
@@ -573,7 +573,7 @@ ja:
       mobile_size_check_failure: 失敗
       mobile_size_check_disable: モバイルサイズが設定されていません。
       mobile_size_check_size: 本文のデータサイズはOKです。
-      mobile_size_check_failed_to_size: 本文のデータサイズが大きすぎます。
+      mobile_size_check_failed_to_size: 携帯で表示する場合、本文のデータサイズが大きすぎます。
       not_a_child_group: はサイトに所属するグループを設定してください。
       not_found_parent_group: 親グループが存在しません。
       invalid_order_of_h: 見出しの順番が不正です。

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -183,6 +183,7 @@ ja:
       count: 件
       mega_byte: MB
       days_after: 日後
+      mobile_size: KB(キロバイト)
 
   ss:
     views:
@@ -345,6 +346,7 @@ ja:
         html: 内容
       ss/addon/mobile_setting:
         mobile_state: 状態
+        mobile_size: １ページの最大サイズ
         mobile_location: ロケーション
         mobile_css: CSS
       ss/addon/map_setting:
@@ -514,6 +516,9 @@ ja:
     ss/addon/mobile_setting:
       mobile_state:
         - モバイルページの有効無効を設定します。
+      mobile_size:
+        - モバイルページの最大サイズを設定します。
+        - 100kbから1000kbが設定できます。
       mobile_location:
         - モバイルページのパスを設定します。
       mobile_css:

--- a/config/routes/cms/routes_end.rb
+++ b/config/routes/cms/routes_end.rb
@@ -149,6 +149,7 @@ SS::Application.routes.draw do
 
   namespace "cms", path: ".cms" do
     match "link_check/check" => "link_check#check", via: [:post, :options], as: "link_check"
+    match "mobile_size_check/check" => "mobile_size_check#check", via: [:post, :options], as: "mobile_size_check"
   end
 
   content "cms", name: "node", module: "cms/node" do

--- a/spec/factories/cms/sites.rb
+++ b/spec/factories/cms/sites.rb
@@ -7,4 +7,5 @@ FactoryGirl.define do
     auto_description "disabled"
     #group_id 1
   end
+
 end

--- a/spec/models/cms/page_spec.rb
+++ b/spec/models/cms/page_spec.rb
@@ -58,11 +58,10 @@ describe Cms::Page do
         end
 
         fill_in_ckeditor "item_html", with: html_text
-
         click_on I18n.t("cms.mobile_size_check")
-
+        sleep 1
         expect(page).to have_css "form #errorMobileChecker"
-        expect(page).to have_selector "form #errorMobileChecker p.error", text: I18n.t("errors.messages.mobile_size_check_failed_to_size")
+        expect(page).to have_selector "form #errorMobileChecker p.error", text: /携帯で表示する場合、本文のデータサイズが大きすぎます。(.+)/i
       end
 
       it "on click check_size_button html_size ok" do
@@ -73,8 +72,9 @@ describe Cms::Page do
         visit new_cms_page_path(site)
 
         fill_in_ckeditor "item_html", with: html_text
-
         click_on I18n.t("cms.mobile_size_check")
+        sleep 1
+
         expect(page).to have_css "form #errorMobileChecker"
         expect(page).to have_selector "form #errorMobileChecker p", text: I18n.t('errors.messages.mobile_size_check_size')
       end
@@ -85,6 +85,9 @@ describe Cms::Page do
       let(:test_file_path) { Rails.root.join("spec", "fixtures", "ss", "logo.png") }
 
       it "mobile_size 1" do
+        site.mobile_state = "enabled"
+        site.mobile_size = 1_024
+        site.save!
 
         html_text = ""
         html_text += "<img src=\"/fs/#{file.id}/_/logo.png\">"
@@ -93,10 +96,11 @@ describe Cms::Page do
         visit new_cms_page_path(site)
 
         fill_in_ckeditor "item_html", with: html_text
-
         click_on I18n.t("cms.mobile_size_check")
+        sleep 1
+
         expect(page).to have_css "form #errorMobileChecker"
-        expect(page).to have_selector "form #errorMobileChecker p", text: I18n.t('errors.messages.too_bigsize')
+        expect(page).to have_selector "form #errorMobileChecker p", text: /携帯電話で表示する場合、ファイルサイズ合計(.+)/i
       end
 
       it "mobile_size 100" do
@@ -112,8 +116,8 @@ describe Cms::Page do
         visit new_cms_page_path(site)
 
         fill_in_ckeditor "item_html", with: html_text
-
         click_on I18n.t("cms.mobile_size_check")
+        sleep 1
         expect(page).to have_selector "form #errorMobileChecker p", text: I18n.t('errors.messages.mobile_size_check_size')
       end
 
@@ -132,6 +136,7 @@ describe Cms::Page do
 
         fill_in_ckeditor "item_html", with: html_text
         click_on I18n.t("cms.mobile_size_check")
+        sleep 1
         expect(page).to have_selector "#errorMobileChecker p", text: I18n.t('errors.messages.mobile_size_check_size')
 
         3.times.each do
@@ -140,11 +145,17 @@ describe Cms::Page do
 
         fill_in_ckeditor "item_html", with: html_text
         click_on I18n.t("cms.mobile_size_check")
+        sleep 1
         expect(page).to have_selector "#errorMobileChecker p", text: I18n.t('errors.messages.mobile_size_check_size')
 
       end
 
       it "many different files in html" do
+
+        site.mobile_state = "enabled"
+        site.mobile_size = 20 * 1_024
+        site.save!
+        site.reload
 
         file2 = Cms::File.new model: "cms/file", site_id: site.id
         file_path = Rails.root.join("spec", "fixtures", "ss", "file", "keyvisual.jpg")
@@ -161,9 +172,9 @@ describe Cms::Page do
         visit new_cms_page_path(site)
 
         fill_in_ckeditor "item_html", with: html_text
-
         click_on I18n.t("cms.mobile_size_check")
-        expect(page).to have_selector "form #errorMobileChecker p", text: I18n.t('errors.messages.too_bigsize')
+        sleep 1
+        expect(page).to have_selector "form #errorMobileChecker p", text: /携帯電話で表示する場合、ファイルサイズ合計(.+)/i
       end
     end
   end
@@ -173,5 +184,8 @@ describe Cms::Page do
       $('textarea##{locator}').text(#{content});
       CKEDITOR.instances['#{locator}'].setData(#{content});
     SCRIPT
+
+    sleep 1
   end
+
 end

--- a/spec/models/cms/page_spec.rb
+++ b/spec/models/cms/page_spec.rb
@@ -61,7 +61,7 @@ describe Cms::Page do
         click_on I18n.t("cms.mobile_size_check")
         sleep 1
         expect(page).to have_css "form #errorMobileChecker"
-        expect(page).to have_selector "form #errorMobileChecker p.error", text: /携帯で表示する場合、本文のデータサイズが大きすぎます。(.+)/i
+        expect(page).to have_selector "form #errorMobileChecker p.error", text: /携帯で表示する場合、本文のデータサイズが(.+)/i
       end
 
       it "on click check_size_button html_size ok" do

--- a/spec/models/cms/page_spec.rb
+++ b/spec/models/cms/page_spec.rb
@@ -46,7 +46,7 @@ describe Cms::Page do
     let(:site) { cms_site }
     context "check_mobile_html_size" do
       it "on click check_size_button html_size too big" do
-        site.mobile_size = 1
+        site.mobile_size = 1_024
         site.save!
 
         login_cms_user
@@ -101,7 +101,7 @@ describe Cms::Page do
 
       it "mobile_size 100" do
         site.mobile_state = "enabled"
-        site.mobile_size = 100
+        site.mobile_size = 100 * 1_024
         site.save!
         site.reload
 
@@ -120,7 +120,7 @@ describe Cms::Page do
       it "many same files in html" do
 
         site.mobile_state = "enabled"
-        site.mobile_size = 20
+        site.mobile_size = 20 * 1_024
         site.save!
         site.reload
 

--- a/spec/models/cms/page_spec.rb
+++ b/spec/models/cms/page_spec.rb
@@ -40,4 +40,92 @@ describe Cms::Page do
       it { is_expected.to eq item.name }
     end
   end
+
+  # check_mobile_html_size at addon body
+  describe "addon body" do
+    let(:html) { "<p>本文本文</p>" }
+    let(:item) { create(:cms_page, route: "article/page", html: html) }
+    context "check_mobile_html_size" do
+
+      it "html_size too big" do
+        item.site.mobile_size = 1
+        item.site.mobile_state = 'enabled'
+        100.times.each do
+          item.html += "<p>あいうえおカキクケコ</p>"
+        end
+        expect(item.save).to be_falsey
+
+        item.site.mobile_state = 'disabled'
+        expect(item.save).to be_truthy
+      end
+
+      it "html_size ok" do
+        item.site.mobile_size = 1
+        expect(item.valid?).to be_truthy
+
+        item.html = "<p>あいうえおカキクケコ</p>"
+        expect(item.valid?).to be_truthy
+      end
+
+      context "file_size" do
+        let(:test_file_path) { Rails.root.join("spec", "fixtures", "ss", "logo.png") }
+        it "mobile_size 1/1000 and 100" do
+          file = Cms::File.new model: "cms/file", site_id: item.site.id
+          Fs::UploadedFile.create_from_file(test_file_path, basename: "spec") do |test_file|
+            file.in_file = test_file
+            file.save!
+          end
+          item.file_ids = [file.id]
+          item.html += "<img src=\"/fs/#{file.id}/_/\""
+          item.site.mobile_size = 1/1000
+          expect(item.valid?).to be_falsey
+
+          item.site.mobile_size = 100
+          expect(item.valid?).to be_truthy
+        end
+
+        it "many same files in html" do
+          file = Cms::File.new model: "cms/file", site_id: item.site.id
+          Fs::UploadedFile.create_from_file(test_file_path, basename: "spec") do |test_file|
+            file.in_file = test_file
+            file.save!
+          end
+          item.file_ids = [file.id]
+          item.site.mobile_size = 20
+          item.html += "<img src=\"/fs/#{file.id}/_/\">"
+          expect(item.valid?).to be_truthy
+          10.times.each do
+            item.html += "<img src=\"/fs/#{file.id}/_/\">"
+          end
+
+          expect(item.valid?).to be_truthy
+
+        end
+
+        it "many different files in html" do
+          file = Cms::File.new model: "cms/file", site_id: item.site.id
+          Fs::UploadedFile.create_from_file(test_file_path, basename: "spec") do |test_file|
+            file.in_file = test_file
+            file.save!
+          end
+          file2 = Cms::File.new model: "cms/file", site_id: item.site.id
+          file_path = Rails.root.join("spec", "fixtures", "ss", "file", "keyvisual.jpg")
+          Fs::UploadedFile.create_from_file(file_path, basename: "spec") do |test_file|
+            file2.in_file = test_file
+            file2.save!
+          end
+
+          item.file_ids = [file.id, file2.id]
+          item.site.mobile_size = 20
+
+          item.html += "<img src=\"/fs/#{file.id}/_/\">"
+          expect(item.valid?).to be_truthy
+
+          item.html += "<img src=\"/fs/#{file2.id}/_/\">"
+          expect(item.valid?).to be_falsey
+        end
+
+      end
+    end
+  end
 end


### PR DESCRIPTION
モバイル設定がenabledの時、htmlのサイズを取得し判定するバリデーションを追加しました。
アップロードされたファイルが本文に挿入されていた場合にはファイルサイズを加えます。
