### PR TITLE
[fix] restore @cur_path.dup

### DIFF
--- a/app/controllers/concerns/cms/public_filter.rb
+++ b/app/controllers/concerns/cms/public_filter.rb
@@ -59,6 +59,7 @@ module Cms::PublicFilter
 
     def set_request_path
       @cur_path ||= request_path
+      cur_path = @cur_path.dup
 
       filter_methods = self.class.private_instance_methods.select { |m| m =~ /^set_request_path_with_/ }
       filter_methods.each do |name|


### PR DESCRIPTION
以下はサブディレクトリ対応時のミスではなく、以前からこのコードでした。
~~~
cur_path = @cur_path.dup
~~~