### PR TITLE
[modify] install.sh / README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ Platform
 Installation (Auto)
 -------------------
 
+- CentOS7の環境で実行してください。<br />
+- 一般ユーザーで実行する場合は、sudoが利用できることを確認してください。<br />
+- パラメーターの"example.jp"には、ブラウザでアクセスする際のドメイン名または、IPアドレスを指定してください。<br />
+
 ```
 $ su - user-which-executes-shirasagi-server
-$ curl https://raw.githubusercontent.com/shirasagi/shirasagi/master/bin/install.sh | SS_HOSTNAME=example.jp bash -s
+$ curl https://raw.githubusercontent.com/shirasagi/shirasagi/master/bin/install.sh | bash -s example.jp
 ```
 
 Installation (CentOS 7)


### PR DESCRIPTION
インストールスクリプトで投入するサンプルデータに下記を追加しました。
・企業サンプル
・子育て支援サンプル
・オープンデータサンプル
・グループウェア
また、企業、子育て、オープンデータの各サンプルサイトへのアクセスは、ポート8001～8003でアクセス可能としています。

README.mdは従来のパラメータではホスト名がスクリプトに渡らなかったので、"example.jp"の指定の仕方を変えています。また、スクリプト実行の際の環境要件について追記しています。
