### PR TITLE
[fix] mail padding

### DIFF
--- a/app/views/webmail/main/_navi.html.erb
+++ b/app/views/webmail/main/_navi.html.erb
@@ -35,7 +35,7 @@ end
           href="<%= webmail_mails_path(mailbox: box.original_name) %>"
         <% end %>
       >
-        <%== "<span class='pad'></span>" * (box.depth - 1) %>
+        <%== box.depth > 0 ? "<span class='pad'></span>" * (box.depth - 1) : "" %>
         <i class="material-icons md-18"><%== box.icon %></i>
         <span class="mailbox-name""><%= box.basename %></span>
         <span class="unseen count<%= box.unseen %>">(<%= box.unseen %>)</span>


### PR DESCRIPTION
メールを利用するときにbox.depthに0が入っている場合があり、このときnegative argumentのエラーが発生しました。

```
0> box.depth
=> 0

0> "<span class='pad'></span>" * (box.depth - 1)
=> negative argument
```

box.depthが0、もしくは負の値の場合はbox.depthが1の時と同じように空文字列「""」が出力されるように修正しました。