### PR TITLE
job logs 肥大化対応

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,19 @@
 class ApplicationJob < ActiveJob::Base
   include Job::SS::Core
+
+  after_perform :purge_old_job_logs
+
+  private
+
+  def purge_old_job_logs
+    return if rand(100) >= 20
+    keep_logs = SS.config.job.keep_logs
+    return if keep_logs.nil? || keep_logs <= 0
+
+    criteria = Job::Log.lte(created: Time.zone.now - keep_logs)
+    Rails.logger.debug("purged #{criteria.count} job logs")
+    criteria.destroy_all
+  rescue => e
+    Rails.logger.warn("#{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
+  end
 end

--- a/app/models/job/task_logger.rb
+++ b/app/models/job/task_logger.rb
@@ -8,11 +8,15 @@ class Job::TaskLogger < ::Logger
   private_class_method :new
 
   def initialize
-    @device = TaskLogDevice.new
+    if Fs.mode == :grid_fs
+      @device = TaskLogDevice.new
+    else
+      @device = WrapLogDevice.new
+    end
     super(@device)
   end
 
-  def_delegators(:@device, :loggable, :loggable=)
+  def_delegators(:@device, :attach, :detach)
 
   class << self
     def attach(loggable)
@@ -23,30 +27,86 @@ class Job::TaskLogger < ::Logger
         logger
       end
 
-      save = @@task_logger.loggable
-      @@task_logger.loggable = loggable
-      save
+      @@task_logger.attach(loggable)
     end
 
     def detach(_)
       return unless @@task_logger
-      @@task_logger.loggable = nil
+      @@task_logger.detach
     end
   end
 
   class TaskLogDevice
     attr_accessor :loggable
 
+    def attach(loggable)
+      save = detach
+      @loggable = loggable
+      save
+    end
+
+    def detach
+      save = @loggable
+      @loggable = nil
+
+      save.save if save
+      save
+    end
+
     def write(message)
-      if loggable
-        loggable.logs << message.chomp
-        elapsed = Time.zone.now - loggable.updated
-        loggable.save if elapsed > FLUSH_INTERVAL
+      if @loggable
+        @loggable.logs << message
+        elapsed = Time.zone.now - @loggable.updated
+        @loggable.save if elapsed > FLUSH_INTERVAL
       end
     end
 
     # do not remove close method
     def close
+    end
+  end
+
+  class WrapLogDevice
+    attr_accessor :loggable
+
+    def attach(loggable)
+      save = detach
+      @loggable = loggable
+      @file = open_logfile(loggable.file_path)
+      save
+    end
+
+    def detach
+      save = @loggable
+      @loggable = nil
+
+      if @file
+        @file.close
+      end
+      @file = nil
+
+      save
+    end
+
+    def write(message)
+      if @file
+        @file.puts(message)
+      end
+    end
+
+    # do not remove close method
+    def close
+    end
+
+    private
+
+    def open_logfile(filename)
+      dirname = ::File.dirname(filename)
+      ::FileUtils.mkdir_p(dirname) unless ::Dir.exists?(dirname)
+
+      file = ::File.open(filename, 'a')
+      file.sync = true
+      file
     end
   end
 end

--- a/config/defaults/job.yml
+++ b/config/defaults/job.yml
@@ -37,6 +37,10 @@ production: &production
       # 指定がない場合、無制限にジョブをプールへ登録できます。
       max_size: 100
 
+  # job_logs の保存期間を秒で設定
+  # 0 を設定すると無制限に保存
+  keep_logs: 1209600
+
 test:
   <<: *production
 

--- a/spec/models/job/log_spec.rb
+++ b/spec/models/job/log_spec.rb
@@ -22,4 +22,16 @@ describe Job::Log, dbscope: :example do
     it { expect(subject.closed_label).to eq subject.closed.strftime("%Y-%m-%d %H:%M") }
     it { expect(subject.joined_jobs).to eq subject.logs.join("\n") }
   end
+
+  context "log file was deleted on job log deletion" do
+    it do
+      job_log = create(:job_log, :job_log_completed, job: job)
+      ::FileUtils.mkdir_p(::File.dirname(job_log.file_path))
+      ::File.write(job_log.file_path, 'hello\n')
+      expect(::File.exists?(job_log.file_path)).to be_truthy
+
+      job_log.destroy
+      expect(::File.exists?(job_log.file_path)).to be_falsey
+    end
+  end
 end

--- a/spec/support/ss/database_cleaner_support.rb
+++ b/spec/support/ss/database_cleaner_support.rb
@@ -10,6 +10,7 @@ module SS
       obj.after(dbscope) do
         Rails.logger.debug "clean database at #{inspect}"
         ::Mongoid::Clients.default.database.drop
+        clear_files
       end
 
       obj.class_eval do

--- a/spec/support/ss/file.rb
+++ b/spec/support/ss/file.rb
@@ -1,9 +1,17 @@
+def root_dir
+  "#{Rails.root}/tmp/ss_files"
+end
+
+def clear_files
+  ::Fs.rm_rf(root_dir)
+  ::Fs.mkdir_p(root_dir)
+end
+
 RSpec.configuration.before(:suite) do
   # load all models
   ::Rails.application.eager_load!
 
-  root_dir = "#{Rails.root}/tmp/ss_files"
-  ::Fs.rm_rf(root_dir)
+  clear_files
 
   models = ::Mongoid.models
   models = models.select { |model| model.ancestors.include?(::SS::Model::File) }


### PR DESCRIPTION
- Fs.mode が :file のとき、ジョブのログをファイルに保存するようにした。
- ジョブの実行後、20% の確率で古い job logs を削除するようにした。
  - 何日前のログを削除するかは config/defaults/job.yml の keep_logs に設定する。
