### PR TITLE
fb api 2.11

### DIFF
--- a/app/models/concerns/cms/addon/sns_poster.rb
+++ b/app/models/concerns/cms/addon/sns_poster.rb
@@ -6,16 +6,18 @@ module Cms::Addon
 
     included do
 
-      field :twitter_auto_post,  type: String, metadata: { branch: false }
-      field :facebook_auto_post, type: String, metadata: { branch: false }
-      field :sns_auto_delete,    type: String, metadata: { branch: false }
-      field :edit_auto_post,     type: String, metadata: { branch: false }
-      field :twitter_user_id,    type: String, metadata: { branch: false }
-      field :twitter_post_id,    type: String, metadata: { branch: false }
-      field :facebook_user_id,   type: String, metadata: { branch: false }
-      field :facebook_post_id,   type: String, metadata: { branch: false }
-      field :twitter_posted,     type: Array, default: [], metadata: { branch: false }
-      field :facebook_posted,    type: Array, default: [], metadata: { branch: false }
+      field :twitter_auto_post,   type: String, metadata: { branch: false }
+      field :facebook_auto_post,  type: String, metadata: { branch: false }
+      field :sns_auto_delete,     type: String, metadata: { branch: false }
+      field :edit_auto_post,      type: String, metadata: { branch: false }
+      field :twitter_user_id,     type: String, metadata: { branch: false }
+      field :twitter_post_id,     type: String, metadata: { branch: false }
+      field :facebook_user_id,    type: String, metadata: { branch: false }
+      field :facebook_post_id,    type: String, metadata: { branch: false }
+      field :twitter_posted,      type: Array, default: [], metadata: { branch: false }
+      field :facebook_posted,     type: Array, default: [], metadata: { branch: false }
+      field :twitter_post_error,  type: String, metadata: { branch: false }
+      field :facebook_post_error, type: String, metadata: { branch: false }
 
       permit_params :facebook_auto_post,
                     :twitter_auto_post,
@@ -144,7 +146,8 @@ module Cms::Addon
       self.set(twitter_post_id: twitter_id, twitter_user_id: user_screen_id)
       self.add_to_set(twitter_posted: { twitter_post_id: twitter_id.to_s, twitter_user_id: user_screen_id })
     rescue => e
-      Rails.logger.fatal("post_to_twitter failed: #{e.backtrace.join("\n  ")}")
+      Rails.logger.fatal("post_to_twitter failed: #{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
+      self.set(twitter_post_error: "#{e.class} (#{e.message})")
     end
 
     def post_to_facebook
@@ -167,7 +170,8 @@ module Cms::Addon
       self.set(facebook_user_id: facebook_id_array[0], facebook_post_id: facebook_id_array[1])
       self.add_to_set(facebook_posted: { facebook_user_id: facebook_id_array[0], facebook_post_id: facebook_id_array[1] })
     rescue => e
-      Rails.logger.fatal("post_to_facebook failed: #{e.backtrace.join("\n  ")}")
+      Rails.logger.fatal("post_to_facebook failed: #{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
+      self.set(facebook_post_error: "#{e.class} (#{e.message})")
     end
 
     def delete_sns

--- a/app/models/concerns/cms/addon/sns_poster.rb
+++ b/app/models/concerns/cms/addon/sns_poster.rb
@@ -145,6 +145,7 @@ module Cms::Addon
       user_screen_id = client.user.screen_name
       self.set(twitter_post_id: twitter_id, twitter_user_id: user_screen_id)
       self.add_to_set(twitter_posted: { twitter_post_id: twitter_id.to_s, twitter_user_id: user_screen_id })
+      self.unset(:twitter_post_error)
     rescue => e
       Rails.logger.fatal("post_to_twitter failed: #{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
       self.set(twitter_post_error: "#{e.class} (#{e.message})")
@@ -169,6 +170,7 @@ module Cms::Addon
       facebook_id_array = facebook_id_separator(facebook_param)
       self.set(facebook_user_id: facebook_id_array[0], facebook_post_id: facebook_id_array[1])
       self.add_to_set(facebook_posted: { facebook_user_id: facebook_id_array[0], facebook_post_id: facebook_id_array[1] })
+      self.unset(:facebook_post_error)
     rescue => e
       Rails.logger.fatal("post_to_facebook failed: #{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
       self.set(facebook_post_error: "#{e.class} (#{e.message})")
@@ -178,30 +180,42 @@ module Cms::Addon
       return if @deleted_sns
 
       if sns_auto_delete_enabled?
-        if twitter_posted.present?
-          client = connect_twitter
-          twitter_posted.each do |posted|
-            post_id = posted[:twitter_post_id]
-            client.destroy_status(post_id) rescue nil
-          end
-          self.set(twitter_post_id: nil, twitter_user_id: nil, twitter_posted: []) rescue nil
-        end
-        if facebook_posted.present?
-          access_token = self.site.facebook_access_token
-          graph = Koala::Facebook::API.new(access_token)
-          # UID_PIDの形式に組み替え、投稿を削除
-          facebook_posted.each do |posted|
-            post_id = posted[:facebook_post_id]
-            user_id = posted[:facebook_user_id]
-            graph.delete_object("#{user_id}_#{post_id}") rescue nil
-          end
-          self.set(facebook_user_id: nil, facebook_post_id: nil, facebook_posted: []) rescue nil
-        end
+        delete_sns_from_twitter
+        delete_sns_from_facebook
       end
 
       @deleted_sns = true
+    end
+
+    def delete_sns_from_twitter
+      return if twitter_posted.blank?
+
+      client = connect_twitter
+      twitter_posted.each do |posted|
+        post_id = posted[:twitter_post_id]
+        client.destroy_status(post_id) rescue nil
+      end
+      self.unset(:twitter_post_id, :twitter_user_id, :twitter_posted, :twitter_post_error) rescue nil
     rescue => e
-      Rails.logger.fatal("delete_sns failed: #{e.backtrace.join("\n  ")}")
+      Rails.logger.fatal("delete_sns_from_twitter failed: #{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
+      self.set(twitter_post_error: "#{e.class} (#{e.message})")
+    end
+
+    def delete_sns_from_facebook
+      return if facebook_posted.blank?
+
+      access_token = self.site.facebook_access_token
+      graph = Koala::Facebook::API.new(access_token)
+      # UID_PIDの形式に組み替え、投稿を削除
+      facebook_posted.each do |posted|
+        post_id = posted[:facebook_post_id]
+        user_id = posted[:facebook_user_id]
+        graph.delete_object("#{user_id}_#{post_id}") rescue nil
+      end
+      self.unset(:facebook_user_id, :facebook_post_id, :facebook_posted, :facebook_post_error) rescue nil
+    rescue => e
+      Rails.logger.fatal("delete_sns_from_facebook failed: #{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
+      self.set(facebook_post_error: "#{e.class} (#{e.message})")
     end
   end
 end

--- a/app/models/concerns/cms/addon/sns_poster.rb
+++ b/app/models/concerns/cms/addon/sns_poster.rb
@@ -153,18 +153,10 @@ module Cms::Addon
 
     def post_to_facebook
       message = message_format(html)
-      file_ids.present? ? image_path = files.first.full_url : nil
       access_token = self.site.facebook_access_token
       graph = Koala::Facebook::API.new(access_token)
       # facebokに投稿し、戻り値を取得
-      facebook_params = graph.put_wall_post(
-        message, {
-          "name"=> "#{name} - #{site.name}",
-          "link"=> full_url,
-          "picture"=> image_path,
-          "description"=> description
-        }
-      )
+      facebook_params = graph.put_wall_post(message, { "link"=> full_url })
       facebook_param = facebook_params['id'].to_s
       # 戻り値からUID/PID取得し、DBに保存
       facebook_id_array = facebook_id_separator(facebook_param)

--- a/app/views/cms/agents/addons/sns_poster/_show.html.erb
+++ b/app/views/cms/agents/addons/sns_poster/_show.html.erb
@@ -3,28 +3,36 @@
 
 <dl class="see">
   <% if @cur_site.facebook_token_enabled? %>
-  <dt><%= @model.t :facebook_auto_post %><%= @model.tt :facebook_auto_post %></dt>
-  <dd><%= @item.label :facebook_auto_post %></dd>
-  <% @item.facebook_posted.each do |posted| %>
-  <dd><a href="<%= @item.facebook_url(posted[:facebook_post_id], posted[:facebook_user_id]) %>" target="_blank"><%= @item.facebook_url(posted[:facebook_post_id], posted[:facebook_user_id]) %></a></dd>
-  <%
-    end
-  end
-  %>
+    <dt><%= @model.t :facebook_auto_post %></dt>
+    <dd><%= @item.label :facebook_auto_post %></dd>
+    <% @item.facebook_posted.each do |posted| %>
+    <dd><a href="<%= @item.facebook_url(posted[:facebook_post_id], posted[:facebook_user_id]) %>" target="_blank"><%= @item.facebook_url(posted[:facebook_post_id], posted[:facebook_user_id]) %></a></dd>
+    <% end %>
+    <% if @item.facebook_post_error.present? %>
+    <dt class="depth-2"><%= @model.t :facebook_post_error %></dt>
+    <dd class="depth-2">
+      <div class="errorExplanation"><%= br @item.facebook_post_error %></div>
+    </dd>
+    <% end %>
+  <% end %>
 
   <% if @cur_site.twitter_token_enabled? %>
-  <dt><%= @model.t :twitter_auto_post %><%= @model.tt :twitter_auto_post %></dt>
-  <dd><%= @item.label :twitter_auto_post %></dd>
-  <% @item.twitter_posted.each do |posted| %>
-  <dd><a href="<%= @item.twitter_url(posted[:twitter_post_id], posted[:twitter_user_id]) %>" target="_blank"><%= @item.twitter_url(posted[:twitter_post_id], posted[:twitter_user_id]) %></a></dd>
-  <%
-    end
-  end
-  %>
+    <dt><%= @model.t :twitter_auto_post %></dt>
+    <dd><%= @item.label :twitter_auto_post %></dd>
+    <% @item.twitter_posted.each do |posted| %>
+    <dd><a href="<%= @item.twitter_url(posted[:twitter_post_id], posted[:twitter_user_id]) %>" target="_blank"><%= @item.twitter_url(posted[:twitter_post_id], posted[:twitter_user_id]) %></a></dd>
+    <% end %>
+    <% if @item.twitter_post_error.present? %>
+    <dt class="depth-2"><%= @model.t :twitter_post_error %></dt>
+    <dd class="depth-2">
+      <div class="errorExplanation"><%= br @item.twitter_post_error %></div>
+    </dd>
+    <% end %>
+  <% end %>
 
-  <dt><%= @model.t :sns_auto_delete %><%= @model.tt :sns_auto_delete %></dt>
+  <dt><%= @model.t :sns_auto_delete %></dt>
   <dd><%= @item.label :sns_auto_delete %></dd>
 
-  <dt><%= @model.t :edit_auto_post %><%= @model.tt :edit_auto_post %></dt>
+  <dt><%= @model.t :edit_auto_post %></dt>
   <dd><%= @item.label :edit_auto_post %></dd>
 </dl>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -524,6 +524,8 @@ ja:
         twitter_auto_post: Twitter自動投稿
         sns_auto_delete: 非公開時に投稿を削除
         edit_auto_post: 編集時に自動投稿
+        twitter_post_error: 投稿エラー
+        facebook_post_error: 投稿エラー
       cms/addon/node_auto_post_setting:
         node_auto_post_setting: SNS自動投稿設定
         node_facebook_auto_post: Facebook自動投稿


### PR DESCRIPTION
v2.11 より幾つかの属性を利用するにはドメイン認証が必要になった。
https://developers.facebook.com/docs/graph-api/reference/v2.11/page/feed#custom-image

ただでさえ煩雑な Facebook 投稿連携設定が更に煩雑になる。
よって、プログラムを修正し、ドメイン認証なしでも動作するように修正した。