### PR TITLE
[modify] refactor Guardfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ group :development do
   gem 'brakeman', require: false
   gem 'guard-brakeman', require: false
   gem 'yard', require: false
+  gem 'terminal-notifier-guard', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -525,6 +525,7 @@ GEM
     temple (0.8.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
+    terminal-notifier-guard (1.7.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -659,6 +660,7 @@ DEPENDENCIES
   sparql
   sparql-client
   spring (~> 2.0.2)
+  terminal-notifier-guard
   therubyracer (~> 0.12.3)
   thinreports
   timecop

--- a/Guardfile
+++ b/Guardfile
@@ -1,53 +1,51 @@
-group :red_green_refactor, halt_on_fail: false do
-  # A sample Guardfile
-  # More info at https://github.com/guard/guard#readme
-
-  guard :rubocop, cli: '--rails --format fuubar' do
-    watch(/.+\.rb$/)
-    watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
-  end
-
-  # Note: The cmd option is now required due to the increasing number of ways
-  #       rspec may be run, below are examples of the most common uses.
-  #  * bundler: 'bundle exec rspec'
-  #  * bundler binstubs: 'bin/rspec'
-  #  * spring: 'bin/rsspec' (This will use spring if running and you have
-  #                          installed the spring binstubs per the docs)
-  #  * zeus: 'zeus rspec' (requires the server to be started separetly)
-  #  * 'just' rspec: 'rspec'
-  guard :rspec, cmd: 'bundle exec rspec' do
-    watch(%r{^spec/.+_spec\.rb$})
-    watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-    watch('spec/spec_helper.rb')  { "spec" }
-
-    # Rails example
-    watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
-    watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
-    watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
-    watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
-    watch('config/routes.rb')                           { "spec/routing" }
-    watch('app/controllers/application_controller.rb')  { "spec/controllers" }
-    watch('spec/rails_helper.rb')                       { "spec" }
-
-    # Capybara features specs
-    watch(%r{^app/views/(.+)/.*\.(erb|haml|slim)$})     { |m| "spec/features/#{m[1]}_spec.rb" }
-
-    # Turnip features and steps
-    watch(%r{^spec/acceptance/(.+)\.feature$})
-    watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
-  end
-end
-
-guard 'brakeman', :run_on_start => true do
-  watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
-  watch(%r{^config/.+\.rb$})
-  watch(%r{^lib/.+\.rb$})
-  watch('Gemfile')
-end
-
 # Load local Guardfile
+# ref. https://github.com/openmensa/openmensa/blob/ac3b063edfd3639091d2b4025a292feea7814ec9/Guardfile#L34-L38
 local_guardfile_path = File.expand_path('../Guardfile.local', __FILE__)
 if File.exist? local_guardfile_path
   self.instance_eval(File.open(local_guardfile_path).read)
+else
+  if ENV["GUARD_RSPEC"]
+    guard :rspec, cmd: 'bundle exec rspec', all_on_start: false do
+      watch(%r{^spec/.+_spec\.rb$})
+      watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+      watch('spec/spec_helper.rb')  { "spec" }
+
+      # Rails example
+      watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+      watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+      watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+      watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
+      watch('config/routes.rb')                           { "spec/routing" }
+      watch('app/controllers/application_controller.rb')  { "spec/controllers" }
+      watch('spec/rails_helper.rb')                       { "spec" }
+
+      # Capybara features specs
+      watch(%r{^app/views/(.+)/.*\.(erb|haml|slim)$})     { |m| "spec/features/#{m[1]}_spec.rb" }
+
+      # Turnip features and steps
+      watch(%r{^spec/acceptance/(.+)\.feature$})
+      watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
+    end
+  end
+
+  if ENV["GUARD_RUBOCOP"]
+    guard :rubocop, all_on_start: false do
+      watch(%r{^app/(.+)\.rb$})
+      watch(%r{^config/(.+)\.rb$})
+      watch(%r{^db/(.+)\.rb$})
+      watch(%r{^lib/(.+)\.rb$})
+      watch(%r{^spec/(.+)\.rb$})
+      watch('Gemfile')
+    end
+  end
+
+  if ENV["GUARD_BAKEMAN"]
+    guard 'brakeman', all_on_start: false do
+      watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
+      watch(%r{^config/.+\.rb$})
+      watch(%r{^db/(.+)\.rb$})
+      watch(%r{^lib/.+\.rb$})
+      watch('Gemfile')
+    end
+  end
 end
-# ref. https://github.com/openmensa/openmensa/blob/ac3b063edfd3639091d2b4025a292feea7814ec9/Guardfile#L34-L38


### PR DESCRIPTION
- Guard 実行時に、RSpec の実行、Rubocop の実行、Bakeman の実行を停止。ファイルを変更したときだけ実行するようにした。
- Rubocop の監視対象ファイルの拡充。
- 環境変数により RSpec の実行、Rubocop の実行、Bakeman の実行のそれぞれを制御可能に。
- 'terminal-notifier-guard' gem を追加して、Guard の実行結果を Mac の通知センターに通知するように変更。
