### PR TITLE
[fix] verify_authenticity_token has not been defined

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  skip_before_action :verify_authenticity_token, if: ->{ !protect_csrf? }
+  skip_before_action :verify_authenticity_token, raise: false, if: ->{ !protect_csrf? }
 
   # before_action -> { FileUtils.touch "#{Rails.root}/Gemfile" } if Rails.env.to_s == "development"
   before_action :set_cache_buster

--- a/app/controllers/cms/link_check_controller.rb
+++ b/app/controllers/cms/link_check_controller.rb
@@ -3,7 +3,7 @@ require "open-uri"
 
 class Cms::LinkCheckController < ApplicationController
   protect_from_forgery except: :check
-  skip_before_action :verify_authenticity_token unless SS.config.env.csrf_protect
+  skip_before_action :verify_authenticity_token, raise: false unless SS.config.env.csrf_protect
   before_action :accept_cors_request
 
   def check

--- a/app/controllers/cms/mobile_size_check_controller.rb
+++ b/app/controllers/cms/mobile_size_check_controller.rb
@@ -1,6 +1,6 @@
 class Cms::MobileSizeCheckController < ApplicationController
   protect_from_forgery except: :check
-  skip_before_action :verify_authenticity_token unless SS.config.env.csrf_protect
+  skip_before_action :verify_authenticity_token, raise: false unless SS.config.env.csrf_protect
   before_action :accept_cors_request
 
   def check

--- a/app/controllers/concerns/sns/login_filter.rb
+++ b/app/controllers/concerns/sns/login_filter.rb
@@ -5,7 +5,7 @@ module Sns::LoginFilter
     protect_from_forgery except: :remote_login
     after_action :user_logged_in, only: [:login]
     after_action :user_logged_out, only: [:logout]
-    skip_before_action :verify_authenticity_token unless SS.config.env.protect_csrf
+    skip_before_action :verify_authenticity_token, raise: false unless SS.config.env.protect_csrf
     prepend_view_path "app/views/sns/login"
     layout "ss/login"
     navi_view nil

--- a/app/controllers/sns/login/environment_controller.rb
+++ b/app/controllers/sns/login/environment_controller.rb
@@ -2,7 +2,7 @@ class Sns::Login::EnvironmentController < ApplicationController
   include Sns::BaseFilter
   include Sns::LoginFilter
 
-  skip_before_action :verify_authenticity_token, only: :consume
+  skip_before_action :verify_authenticity_token, raise: false, only: :consume
   skip_before_action :logged_in?
   before_action :set_item
 

--- a/app/controllers/sns/login/saml_controller.rb
+++ b/app/controllers/sns/login/saml_controller.rb
@@ -2,7 +2,7 @@ class Sns::Login::SamlController < ApplicationController
   include Sns::BaseFilter
   include Sns::LoginFilter
 
-  skip_before_action :verify_authenticity_token, only: :consume
+  skip_before_action :verify_authenticity_token, raise: false, only: :consume
   skip_before_action :logged_in?
   before_action :set_item
 


### PR DESCRIPTION
In some productions, raise "verify_authenticity_token has not been defined" on booting time.
see: https://stackoverflow.com/questions/39260198/verify-authenticity-token-has-not-been-defined
