### PR TITLE
[fix] spec/features/gws/histories_spec failure

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -69,7 +69,11 @@ module SS
     end
 
     def current_request_id
-      current_request.request_id
+      if current_request
+        current_request.request_id
+      else
+        nil
+      end
     end
   end
 


### PR DESCRIPTION
couldn't save history when @current_env was nil