### PR TITLE
Fix gws

### DIFF
--- a/app/controllers/gws/apis/users_controller.rb
+++ b/app/controllers/gws/apis/users_controller.rb
@@ -39,7 +39,7 @@ class Gws::Apis::UsersController < ApplicationController
     @multi = params[:single].blank?
 
     if @custom_group.present?
-      criteria = @custom_group.members
+      criteria = @custom_group.overall_members
     else
       criteria = @model.site(@cur_site)
     end

--- a/app/controllers/gws/facility/state/daily_controller.rb
+++ b/app/controllers/gws/facility/state/daily_controller.rb
@@ -5,6 +5,7 @@ class Gws::Facility::State::DailyController < ApplicationController
 
   navi_view "gws/schedule/main/navi"
   menu_view 'gws/facility/state/main/menu'
+  helper Gws::Facility::State::Daily::PlanHelper
 
   private
 

--- a/app/helpers/gws/facility/state/daily/plan_helper.rb
+++ b/app/helpers/gws/facility/state/daily/plan_helper.rb
@@ -1,0 +1,10 @@
+module Gws::Facility::State::Daily::PlanHelper
+  extend ActiveSupport::Concern
+
+  def group_section_name(group_id)
+    group = Gws::Group.find(group_id) rescue nil
+    return if group.nil?
+
+    group.section_name
+  end
+end

--- a/app/views/gws/facility/state/daily/index.html.erb
+++ b/app/views/gws/facility/state/daily/index.html.erb
@@ -15,12 +15,22 @@
       <tbody>
         <% @items.each do |item| %>
           <% item.plans.each do |plan| %>
+            <%
+              plan_history = plan.histories.where(mode: 'update').first
+              if plan_history.present?
+                group_name = plan_history.user_group_name.split("/")[1..-1].join(' ')
+                user_name = plan_history.user_name
+              else
+                group_name = plan.section_name
+                user_name = plan.user.name
+              end
+            %>
             <tr>
               <td><%= item.name %></td>
               <td><%= l(plan.start_at, format: :gws_long) %></td>
               <td><%= l(plan.end_at, format: :gws_long) %></td>
-              <td><%= plan.section_name %></td>
-              <td><%= tryb { plan.user.name } %></td>
+              <td><%= group_name %></td>
+              <td><%= user_name %></td>
 
               <% if plan.readable?(@cur_user, site: @cur_site) %>
               <td><%= plan.name %></td>

--- a/app/views/gws/facility/state/daily/index.html.erb
+++ b/app/views/gws/facility/state/daily/index.html.erb
@@ -18,18 +18,19 @@
             <%
               plan_history = plan.histories.where(mode: 'update').first
               if plan_history.present?
-                group_name = plan_history.user_group_name.split("/")[1..-1].join(' ')
+                group_id = plan_history.user_group_id
                 user_name = plan_history.user_name
               else
-                group_name = plan.section_name
+                group_id = plan.user_group_id
                 user_name = plan.user.name
               end
+              group_id = plan.user.gws_main_group(@cur_site).id if group_id.nil?
             %>
             <tr>
               <td><%= item.name %></td>
               <td><%= l(plan.start_at, format: :gws_long) %></td>
               <td><%= l(plan.end_at, format: :gws_long) %></td>
-              <td><%= group_name %></td>
+              <td><%= group_section_name(group_id) %></td>
               <td><%= user_name %></td>
 
               <% if plan.readable?(@cur_user, site: @cur_site) %>


### PR DESCRIPTION
以下の修正のプルリクエストです。

## 項番8(課題番号なし): カスタムグループのメンバーが検索対象とならない

カスタムグループを以下のように作成した場合、組織アドレス帳からカスタムグループを選択しても、参加部署のメンバーが表示されない。

## 項番2(課題番号なし): 設備利用状況画面

設備利用状況で表示される「利用課」の項目は、設備予約した利用者が所属する部署名が表示される。
従って、登録者が異動した場合、「利用課」に表示される部署名は異動後の部署名となってしまう。
異動前の部署で、Aさん以外の人が設備予約の情報を更新し、更新者として再登録を行っても、更新者の情報が反映されずに、Aさんの名前だけが表示される。
