### PR TITLE
[fix][#2741] remove workflow/approver from member/photo

### DIFF
--- a/app/models/member/initializer.rb
+++ b/app/models/member/initializer.rb
@@ -49,12 +49,6 @@ module Member
     Cms::Role.permission :delete_private_member_photos
     Cms::Role.permission :release_other_member_photos
     Cms::Role.permission :release_private_member_photos
-    Cms::Role.permission :approve_other_member_photos
-    Cms::Role.permission :approve_private_member_photos
-    Cms::Role.permission :reroute_other_member_photos
-    Cms::Role.permission :reroute_private_member_photos
-    Cms::Role.permission :revoke_other_member_photos
-    Cms::Role.permission :revoke_private_member_photos
 
     SS::File.model "member/photo", Member::PhotoFile
     SS::File.model "member/blog_page", Member::File

--- a/app/models/member/initializer.rb
+++ b/app/models/member/initializer.rb
@@ -40,12 +40,6 @@ module Member
     Cms::Role.permission :delete_private_member_blogs
     Cms::Role.permission :release_other_member_blogs
     Cms::Role.permission :release_private_member_blogs
-    Cms::Role.permission :approve_other_member_blogs
-    Cms::Role.permission :approve_private_member_blogs
-    Cms::Role.permission :reroute_other_member_blogs
-    Cms::Role.permission :reroute_private_member_blogs
-    Cms::Role.permission :revoke_other_member_blogs
-    Cms::Role.permission :revoke_private_member_blogs
 
     Cms::Role.permission :read_other_member_photos
     Cms::Role.permission :read_private_member_photos
@@ -55,6 +49,12 @@ module Member
     Cms::Role.permission :delete_private_member_photos
     Cms::Role.permission :release_other_member_photos
     Cms::Role.permission :release_private_member_photos
+    Cms::Role.permission :approve_other_member_photos
+    Cms::Role.permission :approve_private_member_photos
+    Cms::Role.permission :reroute_other_member_photos
+    Cms::Role.permission :reroute_private_member_photos
+    Cms::Role.permission :revoke_other_member_photos
+    Cms::Role.permission :revoke_private_member_photos
 
     SS::File.model "member/photo", Member::PhotoFile
     SS::File.model "member/blog_page", Member::File

--- a/app/models/member/photo.rb
+++ b/app/models/member/photo.rb
@@ -1,7 +1,7 @@
 class Member::Photo
   include Cms::Model::Page
   include Cms::Reference::Member
-  include Workflow::Addon::Approver
+  # include Workflow::Addon::Approver
   include Member::Addon::Photo::Body
   include Member::Addon::Photo::Category
   include Member::Addon::Photo::Location

--- a/config/locales/member/ja.yml
+++ b/config/locales/member/ja.yml
@@ -335,12 +335,6 @@ ja:
     delete_private_member_photos: メンバーフォトの削除（所有）
     release_other_member_photos: メンバーフォトの公開（全て）
     release_private_member_photos: メンバーフォトの公開（所有）
-    approve_other_member_photos: メンバーフォトの承認（全て）
-    approve_private_member_photos: メンバーフォトの承認（所有）
-    reroute_other_member_photos: メンバーフォトの承認申請取消（全て）
-    reroute_private_member_photos: メンバーフォトの承認申請取消（所有）
-    revoke_other_member_photos: メンバーフォトの承認経路変更（全て）
-    revoke_private_member_photos: メンバーフォトの承認経路変更（所有）
 
   views:
     registration:

--- a/config/locales/member/ja.yml
+++ b/config/locales/member/ja.yml
@@ -327,12 +327,6 @@ ja:
     delete_private_member_blogs: メンバーブログの削除（所有）
     release_other_member_blogs: メンバーブログの公開（全て）
     release_private_member_blogs: メンバーブログの公開（所有）
-    approve_other_member_blogs: メンバーブログの承認（全て）
-    approve_private_member_blogs: メンバーブログの承認（所有）
-    reroute_other_member_blogs: メンバーブログの承認申請取消（全て）
-    reroute_private_member_blogs: メンバーブログの承認申請取消（所有）
-    revoke_other_member_blogs: メンバーブログの承認経路変更（全て）
-    revoke_private_member_blogs: メンバーブログの承認経路変更（所有）
     read_other_member_photos: メンバーフォトの閲覧（全て）
     read_private_member_photos: メンバーフォトの閲覧（所有）
     edit_other_member_photos: メンバーフォトの編集（全て）
@@ -341,6 +335,12 @@ ja:
     delete_private_member_photos: メンバーフォトの削除（所有）
     release_other_member_photos: メンバーフォトの公開（全て）
     release_private_member_photos: メンバーフォトの公開（所有）
+    approve_other_member_photos: メンバーフォトの承認（全て）
+    approve_private_member_photos: メンバーフォトの承認（所有）
+    reroute_other_member_photos: メンバーフォトの承認申請取消（全て）
+    reroute_private_member_photos: メンバーフォトの承認申請取消（所有）
+    revoke_other_member_photos: メンバーフォトの承認経路変更（全て）
+    revoke_private_member_photos: メンバーフォトの承認経路変更（所有）
 
   views:
     registration:


### PR DESCRIPTION
メンバー/フォトの承認は、初期リリースの時点（v1.3.0）でエラーになり動作していなかった。
