### PR TITLE
[fixup] app error: undefined method `silence' for Logger in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,8 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Logger
-  config.logger = ActiveSupport::Logger.new("#{Rails.root}/log/development.log")
+  # config.logger = ActiveSupport::Logger.new("#{Rails.root}/log/development.log")
+  config.log_formatter = ::Logger::Formatter.new
   config.log_level = ENV['DEVELOPMENT_LOG_LEVEL'] || :warn
 
   # ActiveJob Queue Adapter


### PR DESCRIPTION
You can see 'ActiveSupport::Logger' is a default logger class at railties-5.2.3/lib/rails/application/bootstrap.rb:46.
And also you can get several benefits by config.logger is unset.
So you don't need to pass 'ActiveSupport::Logger' explicitly.

And I strongly need long log format for development.