### PR TITLE
[gws][fix][#3299] appropriate default setting to workflow portlet

### DIFF
--- a/app/models/concerns/gws/addon/portal/portlet/workflow.rb
+++ b/app/models/concerns/gws/addon/portal/portlet/workflow.rb
@@ -6,7 +6,7 @@ module Gws::Addon::Portal::Portlet
     set_addon_type :gws_portlet
 
     included do
-      field :workflow_state, type: String
+      field :workflow_state, type: String, default: "all"
       permit_params :workflow_state
     end
 


### PR DESCRIPTION
to protect from causing 500 error on portlet initialized by YAML