### PR TITLE
[fix] add option "--disable-binary" to "rvm install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
 # gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 # \curl -sSL https://get.rvm.io | sudo bash -s stable
 # source /etc/profile
-# rvm install 2.6.3
+# rvm install 2.6.3 --disable-binary
 # rvm use 2.6.3 --default
 # gem install bundler
 ```

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -46,7 +46,7 @@ else
 fi
 export PATH="$PATH:$RVM_HOME/bin"
 source $RVM_HOME/scripts/rvm
-rvm install 2.6.3
+rvm install 2.6.3 --disable-binary
 rvm use 2.6.3 --default
 gem install bundler
 


### PR DESCRIPTION
for protecting to install improperly configured ruby (wrong binary).