### PR TITLE
[modified]  パスワードポリシー 使用禁止文字の表示

### DIFF
--- a/app/validators/sys/password_validator.rb
+++ b/app/validators/sys/password_validator.rb
@@ -59,7 +59,7 @@ class Sys::PasswordValidator < ActiveModel::Validator
     return if @setting.password_prohibited_char.blank?
     return unless @setting.password_prohibited_char.chars.any? { |ch| record.in_password.include?(ch) }
 
-    record.errors.add :password, :password_contains_prohibited_chars
+    record.errors.add :password, :password_contains_prohibited_chars, prohibited_chars: @setting.password_prohibited_char
   end
 
   def validate_password_min_change_char(record)

--- a/config/locales/member/ja.yml
+++ b/config/locales/member/ja.yml
@@ -400,7 +400,7 @@ ja:
       password_short_downcase: "は英小文字（a-z）を%{count}文字以上含むようにしてください。"
       password_short_digit: "は数字（0-9）を%{count}文字以上含むようにしてください。"
       password_short_symbol: "は記号を%{count}文字以上含むようにしてください。"
-      password_contains_prohibited_chars: "は使用禁止文字が含まれています。"
+      password_contains_prohibited_chars: "に使用禁止文字（%{prohibited_chars}）が含まれています。"
       password_min_change_chars: "は以前のものから%{count}文字以上違う文字を含むようにしてください。"
       password_alphabet_only: に英字のみの文字は使用できません。
       password_numeric_only: に数字のみの文字は使用できません。


### PR DESCRIPTION
## 修正内容
パスワードポリシー 使用禁止文字の表示
「パスワードに使用禁止文字（?%）が含まれています。」の形で括弧内に使用禁止文字を表示させるようにした。