### PR TITLE
[modified] 【CMS不具合】フォルダー：メールマガジン/会員向けメール配信 HTML エディタを非表示に設定

### DIFF
--- a/app/views/ezine/agents/addons/body/_form.html.erb
+++ b/app/views/ezine/agents/addons/body/_form.html.erb
@@ -26,11 +26,13 @@
 <%= html_editor ".ezine-page-html", height: "400px", advanced: Cms::EditorExtension.allowed?(:use, @cur_user, site: @cur_site) %>
 
 <dl class="see mod-ezine-page-body">
-  <dt><%= @model.t :html %></dt>
-  <dd><%= f.text_area :html, class: "ezine-page-html", style: "height:400px;" %></dd>
+  <% if SS.config.ezine.html_editor? %>
+    <dt><%= @model.t :html %></dt>
+    <dd><%= f.text_area :html, class: "ezine-page-html", style: "height:400px;" %></dd>
 
-  <dt>&nbsp;</dt>
-  <dd><%= button_tag t("ezine.buttons.convert_html_to_text"), { type: :button, class: "ezine-convert-button btn" } %></dd>
+    <dt>&nbsp;</dt>
+    <dd><%= button_tag t("ezine.buttons.convert_html_to_text"), { type: :button, class: "ezine-convert-button btn" } %></dd>
+  <%end%>
 
   <dt><%= @model.t :text %></dt>
   <dd><%= f.text_area :text, class: "ezine-page-text monospace", style: "height:400px;" %></dd>

--- a/app/views/ezine/agents/addons/body/_form.html.erb
+++ b/app/views/ezine/agents/addons/body/_form.html.erb
@@ -26,7 +26,7 @@
 <%= html_editor ".ezine-page-html", height: "400px", advanced: Cms::EditorExtension.allowed?(:use, @cur_user, site: @cur_site) %>
 
 <dl class="see mod-ezine-page-body">
-  <% if SS.config.ezine.html_editor? %>
+  <% if SS.config.ezine.html_editor %>
     <dt><%= @model.t :html %></dt>
     <dd><%= f.text_area :html, class: "ezine-page-html", style: "height:400px;" %></dd>
 

--- a/config/defaults/ezine.yml
+++ b/config/defaults/ezine.yml
@@ -31,7 +31,7 @@ development: &development
   interval: 1
   sleep_seconds: 0
   # disable html editor
-  html-editor: false
+  html_editor: false
 
 test:
   <<: *development

--- a/config/defaults/ezine.yml
+++ b/config/defaults/ezine.yml
@@ -9,7 +9,7 @@ production:
   sleep_seconds: 10
 
   # disable html editor
-  html-editor: false
+  html_editor: false
 
 ## Multiple servers example
 #

--- a/config/defaults/ezine.yml
+++ b/config/defaults/ezine.yml
@@ -7,6 +7,8 @@ production:
   # Sleep $sleep_seconds each $interval deliverys.
   interval: 50
   sleep_seconds: 10
+
+  # disable html editor
   html-editor: false
 
 ## Multiple servers example
@@ -28,6 +30,7 @@ development: &development
   register_member_here: true
   interval: 1
   sleep_seconds: 0
+  # disable html editor
   html-editor: false
 
 test:

--- a/config/defaults/ezine.yml
+++ b/config/defaults/ezine.yml
@@ -7,6 +7,7 @@ production:
   # Sleep $sleep_seconds each $interval deliverys.
   interval: 50
   sleep_seconds: 10
+  html-editor: false
 
 ## Multiple servers example
 #
@@ -27,6 +28,7 @@ development: &development
   register_member_here: true
   interval: 1
   sleep_seconds: 0
+  html-editor: false
 
 test:
   <<: *development


### PR DESCRIPTION
## 修正内容
HTMLエディタを非表示に設定


## 詳細
`config/defaults/ezine.yml` に `html_editor: false`を追記して、値がfalseであればHTMLエディタを非表示に設定