### PR TITLE
[fix] 【CMS不具合】フォルダー：メンバー/安否 登録者設定無しの場合の500エラーを解消

### DIFF
--- a/app/views/board/agents/nodes/anpi_post/_anpi_post.html.erb
+++ b/app/views/board/agents/nodes/anpi_post/_anpi_post.html.erb
@@ -27,7 +27,7 @@
     <% if @cur_node.show_email? %>
     <span class="member"><%= @model.t :member_id %>: <%= mail_to item.member.email, "#{item.member.name} <#{item.member.email}>", class: "email" %></span>
     <% else %>
-    <span class="member"><%= @model.t :member_id %>: <%= item.member.name %></span>
+    <span class="member"><%= @model.t :member_id %>: <%= item.member.try(:name) %></span>
     <% end %>
   </div>
 </article>

--- a/app/views/board/agents/nodes/anpi_post/_anpi_post.html.erb
+++ b/app/views/board/agents/nodes/anpi_post/_anpi_post.html.erb
@@ -24,10 +24,10 @@
     <% if @cur_node.show_email? && item.email.present? %>
     <span class="email"><%= @model.t :email %>: <%= item.email %></span>
     <% end %>
-    <% if @cur_node.show_email? %>
+    <% if @cur_node.show_email? && item.member.present? %>
     <span class="member"><%= @model.t :member_id %>: <%= mail_to item.member.email, "#{item.member.name} <#{item.member.email}>", class: "email" %></span>
-    <% else %>
-    <span class="member"><%= @model.t :member_id %>: <%= item.member.try(:name) %></span>
+    <% elsif !@cur_node.show_email? && item.member.present? %>
+    <span class="member"><%= @model.t :member_id %>: <%= item.member.name %></span>
     <% end %>
   </div>
 </article>

--- a/app/views/member/agents/nodes/my_anpi_post/_form.html.erb
+++ b/app/views/member/agents/nodes/my_anpi_post/_form.html.erb
@@ -12,7 +12,6 @@
 <dl class="column">
   <dt>
     <%= @model.t :email %>
-    <%= required_label %>
   </dt>
   <dd>
     <%= f.text_field :email %>

--- a/app/views/member/agents/nodes/my_anpi_post/_form.html.erb
+++ b/app/views/member/agents/nodes/my_anpi_post/_form.html.erb
@@ -11,6 +11,17 @@
 
 <dl class="column">
   <dt>
+    <%= @model.t :email %>
+    <%= required_label %>
+  </dt>
+  <dd>
+    <%= f.text_field :email %>
+    <%= remarks :email %>
+  </dd>
+</dl>
+
+<dl class="column">
+  <dt>
     <%= @model.t :text %>
     <%= required_label %>
   </dt>

--- a/app/views/member/agents/nodes/my_anpi_post/_show.html.erb
+++ b/app/views/member/agents/nodes/my_anpi_post/_show.html.erb
@@ -3,6 +3,13 @@
   <dd><%= @item.name %></dd>
 </dl>
 
+<% if @cur_node.show_email? %>
+<dl class="column">
+  <dt><%= @model.t :email %></dt>
+  <dd><%= @item.email %></dd>
+</dl>
+<% end %>
+
 <dl class="column">
   <dt><%= @model.t :text %></dt>
   <dd><%= br @item.text %></dd>

--- a/app/views/member/agents/nodes/my_profile/index.html.erb
+++ b/app/views/member/agents/nodes/my_profile/index.html.erb
@@ -7,10 +7,12 @@
       <dd><%= @item.name %></dd>
     </dl>
 
+    <% if @cur_node.try(:show_email?) %>
     <dl class="column">
       <dt><%= @model.t :email %></dt>
       <dd><%= @item.email %></dd>
     </dl>
+    <% end %>
 
     <dl class="column">
       <dt><%= @model.t :kana %></dt>

--- a/app/views/member/agents/nodes/my_profile/index.html.erb
+++ b/app/views/member/agents/nodes/my_profile/index.html.erb
@@ -7,12 +7,10 @@
       <dd><%= @item.name %></dd>
     </dl>
 
-    <% if @cur_node.try(:show_email?) %>
     <dl class="column">
       <dt><%= @model.t :email %></dt>
       <dd><%= @item.email %></dd>
     </dl>
-    <% end %>
 
     <dl class="column">
       <dt><%= @model.t :kana %></dt>


### PR DESCRIPTION
## 解決した課題
管理側から安否情報の新規作成を行う際に「登録者」を設定していないと、安否掲示板で該当の人を検索すると500エラーになる
K03012-359

## 実装概要
`undefined method `name' for nil:NilClass`となっていたので、tryメソッドを使用してmemberがnilであってもエラーが起こらないようにした。
