### PR TITLE
[modified] .merge(fix_params)の削除

### DIFF
--- a/app/controllers/gws/staff_record/public_duties_controller.rb
+++ b/app/controllers/gws/staff_record/public_duties_controller.rb
@@ -18,7 +18,7 @@ class Gws::StaffRecord::PublicDutiesController < ApplicationController
   end
 
   def get_charge_params
-    params.require(:item).permit(:charge_address, :charge_tel).merge(fix_params).to_h
+    params.require(:item).permit(:charge_address, :charge_tel).to_h
   end
 
   def prepare_edit_charge


### PR DESCRIPTION
## backlog
K03012-561 IE11でのシラサギの確認

## backlog詳細
https://web-tips.backlog.jp/view/K03012-561#comment-88210021

## やったこと
エラー原因と考えられる`merge(fix_params)`を削除