### PR TITLE
Fix/facility locations

### DIFF
--- a/app/controllers/facility/agents/nodes/category_controller.rb
+++ b/app/controllers/facility/agents/nodes/category_controller.rb
@@ -1,5 +1,6 @@
 class Facility::Agents::Nodes::CategoryController < ApplicationController
   include Cms::NodeFilter::View
+  helper Cms::ListHelper
 
   def index
     @items = Facility::Node::Page.site(@cur_site).and_public.

--- a/app/controllers/facility/agents/nodes/location_controller.rb
+++ b/app/controllers/facility/agents/nodes/location_controller.rb
@@ -1,5 +1,6 @@
 class Facility::Agents::Nodes::LocationController < ApplicationController
   include Cms::NodeFilter::View
+  helper Cms::ListHelper
 
   def index
     @items = Facility::Node::Page.site(@cur_site).and_public.

--- a/app/controllers/facility/agents/nodes/service_controller.rb
+++ b/app/controllers/facility/agents/nodes/service_controller.rb
@@ -1,5 +1,6 @@
 class Facility::Agents::Nodes::ServiceController < ApplicationController
   include Cms::NodeFilter::View
+  helper Cms::ListHelper
 
   def index
     @items = Facility::Node::Page.site(@cur_site).and_public.

--- a/app/views/facility/agents/nodes/category/index.html.erb
+++ b/app/views/facility/agents/nodes/category/index.html.erb
@@ -1,1 +1,5 @@
-<%= render file: "facility/agents/nodes/node/index" %>
+<div class="cms-nodes nodes">
+<%= render_node_list %>
+</div>
+
+<%= paginate @items if @items.try(:current_page) %>

--- a/app/views/facility/agents/nodes/location/index.html.erb
+++ b/app/views/facility/agents/nodes/location/index.html.erb
@@ -1,1 +1,5 @@
-<%= render file: "facility/agents/nodes/node/index" %>
+<div class="cms-nodes nodes">
+<%= render_node_list %>
+</div>
+
+<%= paginate @items if @items.try(:current_page) %>

--- a/app/views/facility/agents/nodes/node/index.html.erb
+++ b/app/views/facility/agents/nodes/node/index.html.erb
@@ -1,4 +1,5 @@
 <% locations = @items.map(&:locations).flatten.uniq.sort_by{ |item| item.order } %>
+<% locations = locations.where(id: @items.location_ids) if locations[0].filename == "institution/chiki/*" %>
 
 <div class="facility-nodes">
   <% if locations.present? %>

--- a/app/views/facility/agents/nodes/node/index.html.erb
+++ b/app/views/facility/agents/nodes/node/index.html.erb
@@ -1,5 +1,4 @@
 <% locations = @items.map(&:locations).flatten.uniq.sort_by{ |item| item.order } %>
-<% locations = locations.where(id: @items.location_ids) if locations[0].filename == "institution/chiki/*" %>
 
 <div class="facility-nodes">
   <% if locations.present? %>

--- a/app/views/facility/agents/nodes/service/index.html.erb
+++ b/app/views/facility/agents/nodes/service/index.html.erb
@@ -1,1 +1,5 @@
-<%= render file: "facility/agents/nodes/node/index" %>
+<div class="cms-nodes nodes">
+<%= render_node_list %>
+</div>
+
+<%= paginate @items if @items.try(:current_page) %>


### PR DESCRIPTION
## エラー内容
打ち合わせ中に発見した「東区」や「文化施設」一覧の表示の問題。
カテゴリーを絞ろうとしてもブラウザでは一覧のまま表示されており、カテゴリー別に表示されていなかった。
（backlog等には上がっていない課題）

## 修正内容
HTMLループなどのカスタムが効くように修正すると、カテゴリー別に表示されるようになった。