### PR TITLE
Fix/kurashi guide

### DIFF
--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -5,7 +5,7 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
 %><dl class="see">
   <dt><%= @model.t :route %><%= @model.tt :route %></dt>
   <dd><%= f.hidden_field :route %>
-    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path, class: "ajax-box" %></dd>
+    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path, base_url: url_path(action: :index), class: "ajax-box" %></dd>
 
   <dt><%= @model.t :name %><%= @model.tt :title %></dt>
   <dd><%= f.text_field :name %></dd>

--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -7,8 +7,8 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
   <dd><%= f.hidden_field :route %>
     <%= @item.label :route %> &nbsp;
     <% case controller.action_name
-      when "new", "create" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :new, cid: params[:cid])), class: "ajax-box" %></dd>
-    <% when "edit", "update" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :edit, cid: params[:cid])), class: "ajax-box" %></dd>
+      when "new", "create" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :new)), class: "ajax-box" %></dd>
+    <% when "edit", "update" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :edit)), class: "ajax-box" %></dd>
     <% else %><%= link_to t('ss.links.change'), routes_cms_nodes_path, class: "ajax-box" %></dd>
     <% end %>
 

--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -5,7 +5,11 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
 %><dl class="see">
   <dt><%= @model.t :route %><%= @model.tt :route %></dt>
   <dd><%= f.hidden_field :route %>
-    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path(base_action: controller.action_name, id: params[:id]), class: "ajax-box" %></dd>
+    <%= @item.label :route %> &nbsp;
+    <% case controller.action_name
+      when "new", "create" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :new, cid: params[:cid])), class: "ajax-box" %></dd>
+    <% when "edit", "update" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :edit, cid: params[:cid], id: params[:id])), class: "ajax-box" %></dd>
+    <% end %>
 
   <dt><%= @model.t :name %><%= @model.tt :title %></dt>
   <dd><%= f.text_field :name %></dd>

--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -9,6 +9,7 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
     <% case controller.action_name
       when "new", "create" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :new, cid: params[:cid])), class: "ajax-box" %></dd>
     <% when "edit", "update" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :edit, cid: params[:cid])), class: "ajax-box" %></dd>
+    <% else %><%= link_to t('ss.links.change'), routes_cms_nodes_path, class: "ajax-box" %></dd>
     <% end %>
 
   <dt><%= @model.t :name %><%= @model.tt :title %></dt>

--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -5,7 +5,7 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
 %><dl class="see">
   <dt><%= @model.t :route %><%= @model.tt :route %></dt>
   <dd><%= f.hidden_field :route %>
-    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path, class: "ajax-box" %></dd>
+    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path(base_action: controller.action_name), class: "ajax-box" %></dd>
 
   <dt><%= @model.t :name %><%= @model.tt :title %></dt>
   <dd><%= f.text_field :name %></dd>

--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -5,7 +5,7 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
 %><dl class="see">
   <dt><%= @model.t :route %><%= @model.tt :route %></dt>
   <dd><%= f.hidden_field :route %>
-    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path(base_action: controller.action_name), class: "ajax-box" %></dd>
+    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path(base_action: controller.action_name, id: params[:id]), class: "ajax-box" %></dd>
 
   <dt><%= @model.t :name %><%= @model.tt :title %></dt>
   <dd><%= f.text_field :name %></dd>

--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -8,7 +8,7 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
     <%= @item.label :route %> &nbsp;
     <% case controller.action_name
       when "new", "create" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :new, cid: params[:cid])), class: "ajax-box" %></dd>
-    <% when "edit", "update" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :edit, cid: params[:cid], id: params[:id])), class: "ajax-box" %></dd>
+    <% when "edit", "update" %><%= link_to t('ss.links.change'), routes_cms_nodes_path(base_url: url_for(action: :edit, cid: params[:cid])), class: "ajax-box" %></dd>
     <% end %>
 
   <dt><%= @model.t :name %><%= @model.tt :title %></dt>

--- a/app/views/cms/nodes/_form.html.erb
+++ b/app/views/cms/nodes/_form.html.erb
@@ -5,7 +5,7 @@ file = "#{Rails.root}/app/views/" + @item.route.sub('/', '/agents/nodes/') + "/e
 %><dl class="see">
   <dt><%= @model.t :route %><%= @model.tt :route %></dt>
   <dd><%= f.hidden_field :route %>
-    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path, base_url: url_path(action: :index), class: "ajax-box" %></dd>
+    <%= @item.label :route %> &nbsp;<%= link_to t('ss.links.change'), routes_cms_nodes_path, class: "ajax-box" %></dd>
 
   <dt><%= @model.t :name %><%= @model.tt :title %></dt>
   <dd><%= f.text_field :name %></dd>

--- a/app/views/cms/nodes/routes.html.erb
+++ b/app/views/cms/nodes/routes.html.erb
@@ -4,7 +4,11 @@
     <h1><%= mod[:name] %></h1>
     <div>
       <% mod[:items].each do |name, path| %>
+      <% if request.fullpath.include?("new") %>
       <%= link_to name, "?route=#{path}", target: "_self" %>
+      <% elsif !request.fullpath.include?("new") %>
+      <%= link_to name, url_for(action: :new, route: path), target: "_self" %>
+      <% end %>
       <% end %>
     </div>
   </article>

--- a/app/views/cms/nodes/routes.html.erb
+++ b/app/views/cms/nodes/routes.html.erb
@@ -8,7 +8,7 @@
       when "new", "edit" %><%= link_to name, "?route=#{path}", target: "_self" %>
       <% when "create" %><%= link_to name, url_for(action: :new, route: path), target: "_self" %>
       <% when "update" %><%= link_to name, url_for(action: :edit, route: path, id: params[:id]), target: "_self" %>
-      <%end%>
+      <% end %>
       <% end %>
     </div>
   </article>

--- a/app/views/cms/nodes/routes.html.erb
+++ b/app/views/cms/nodes/routes.html.erb
@@ -4,11 +4,11 @@
     <h1><%= mod[:name] %></h1>
     <div>
       <% mod[:items].each do |name, path| %>
-        <% case params[:base_action]
-        when "new", "edit" %><%= link_to name, "?route=#{path}", target: "_self" %>
-        <% when "create" %><%= link_to name, url_for(action: :new, route: path), target: "_self" %>
-        <% when "update" %><%= link_to name, url_for(action: :edit, route: path, id: params[:id]), target: "_self" %>
-        <%end%>
+      <% case params[:base_action]
+      when "new", "edit" %><%= link_to name, "?route=#{path}", target: "_self" %>
+      <% when "create" %><%= link_to name, url_for(action: :new, route: path), target: "_self" %>
+      <% when "update" %><%= link_to name, url_for(action: :edit, route: path, id: params[:id]), target: "_self" %>
+      <%end%>
       <% end %>
     </div>
   </article>

--- a/app/views/cms/nodes/routes.html.erb
+++ b/app/views/cms/nodes/routes.html.erb
@@ -4,11 +4,7 @@
     <h1><%= mod[:name] %></h1>
     <div>
       <% mod[:items].each do |name, path| %>
-      <% case params[:base_action]
-      when "new", "edit" %><%= link_to name, "?route=#{path}", target: "_self" %>
-      <% when "create" %><%= link_to name, url_for(action: :new, route: path), target: "_self" %>
-      <% when "update" %><%= link_to name, url_for(action: :edit, route: path, id: params[:id]), target: "_self" %>
-      <% end %>
+      <%= link_to name, "#{params[:base_url]}?route=#{path}", target: "_self" %>
       <% end %>
     </div>
   </article>

--- a/app/views/cms/nodes/routes.html.erb
+++ b/app/views/cms/nodes/routes.html.erb
@@ -4,13 +4,11 @@
     <h1><%= mod[:name] %></h1>
     <div>
       <% mod[:items].each do |name, path| %>
-      <% if params[:base_action] == "new" ||  params[:base_action] == "edit" %>
-      <%= link_to name, "?route=#{path}", target: "_self" %>
-      <% elsif params[:base_action] == "create" %>
-      <%= link_to name, url_for(action: :new, route: path), target: "_self" %>
-      <% elsif params[:base_action] == "update" %>
-      <%= link_to name, url_for(action: :edit, route: path, id: params[:id]), target: "_self" %>
-      <% end %>
+        <% case params[:base_action]
+        when "new", "edit" %><%= link_to name, "?route=#{path}", target: "_self" %>
+        <% when "create" %><%= link_to name, url_for(action: :new, route: path), target: "_self" %>
+        <% when "update" %><%= link_to name, url_for(action: :edit, route: path, id: params[:id]), target: "_self" %>
+        <%end%>
       <% end %>
     </div>
   </article>

--- a/app/views/cms/nodes/routes.html.erb
+++ b/app/views/cms/nodes/routes.html.erb
@@ -1,4 +1,3 @@
-
 <article class="routes-view">
   <% @items.each do |mod_name, mod| %>
   <article class="mod-<%= mod_name %>">
@@ -9,8 +8,8 @@
       <%= link_to name, "?route=#{path}", target: "_self" %>
       <% elsif params[:base_action] == "create" %>
       <%= link_to name, url_for(action: :new, route: path), target: "_self" %>
-      <% elsif params[:base_action] == "edit" %>
-      <%= link_to name, url_for(action: :edit, route: path), target: "_self" %>
+      <% elsif params[:base_action] == "update" %>
+      <%= link_to name, url_for(action: :edit, route: path, id: params[:id]), target: "_self" %>
       <% end %>
       <% end %>
     </div>

--- a/app/views/cms/nodes/routes.html.erb
+++ b/app/views/cms/nodes/routes.html.erb
@@ -1,13 +1,16 @@
+
 <article class="routes-view">
   <% @items.each do |mod_name, mod| %>
   <article class="mod-<%= mod_name %>">
     <h1><%= mod[:name] %></h1>
     <div>
       <% mod[:items].each do |name, path| %>
-      <% if request.fullpath.include?("new") %>
+      <% if params[:base_action] == "new" ||  params[:base_action] == "edit" %>
       <%= link_to name, "?route=#{path}", target: "_self" %>
-      <% elsif !request.fullpath.include?("new") %>
+      <% elsif params[:base_action] == "create" %>
       <%= link_to name, url_for(action: :new, route: path), target: "_self" %>
+      <% elsif params[:base_action] == "edit" %>
+      <%= link_to name, url_for(action: :edit, route: path), target: "_self" %>
       <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## backlog
validationエラー発生させた後に、再度フォルダー属性を別のフォルダに設定すると画面が飛ぶ
https://web-tips.backlog.jp/view/K03012-561#comment-86788341

## 原因
- validationエラー発生後のURLに`new`が含まれておらず、`createアクション`で画面を作成していた。
- また、編集時にvalidatonエラーを発生後のURLに`edit`が含まれておらず`updateアクション`で画面を作成していた。

## 対応
- `controller.action_name`で使用されているアクションを取り出し、アクションが`create`になっていれば`newアクション`を指定。アクションが`update`になっていれば`updateアクション`を指定し、`id`を渡して画面が飛ばないように修正。