### PR TITLE
Fix/member registration

### DIFF
--- a/app/views/member/agents/nodes/my_profile/_form.html.erb
+++ b/app/views/member/agents/nodes/my_profile/_form.html.erb
@@ -6,6 +6,7 @@
   });
 <% end %>
 
+
 <dl class="column name">
   <dt>
     <%= @model.t :name %>

--- a/app/views/member/agents/nodes/my_profile/_form.html.erb
+++ b/app/views/member/agents/nodes/my_profile/_form.html.erb
@@ -7,115 +7,115 @@
 <% end %>
 
 
-<dl class="column name">
-  <dt>
+<fieldset class="column name">
+  <legend>
     <%= @model.t :name %>
     <%= required_label %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :name %>
     <%= remarks :name %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column email">
-  <dt>
+<fieldset class="column email">
+  <legend>
     <%= @model.t :email %>
     <%= required_label %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :email %>
     <%= remarks :email %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column kana">
-  <dt>
+<fieldset class="column kana">
+  <legend>
     <%= @model.t :kana %>
     <% if @cur_node.kana_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :kana %>
     <%= remarks :kana %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column organization-name">
-  <dt>
+<fieldset class="column organization-name">
+  <legend>
     <%= @model.t :organization_name %>
     <% if @cur_node.organization_name_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :organization_name %>
     <%= remarks :organization_name %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column job">
-  <dt>
+<fieldset class="column job">
+  <legend>
     <%= @model.t :job %>
     <% if @cur_node.job_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :job %>
     <%= remarks :job %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column tel">
-  <dt>
+<fieldset class="column tel">
+  <legend>
     <%= @model.t :tel %>
     <% if @cur_node.tel_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :tel %>
     <%= remarks :tel %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="colum postal-code">
-  <dt>
+<fieldset class="colum postal-code">
+  <legend>
     <%= @model.t :postal_code %>
     <% if @cur_node.postal_code_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :postal_code %>
     <%= f.button t('member.buttons.address_search'), name: 'postal-code-search', type: :button %>
     <span class="postal-code-search-error"></span>
     <%= remarks :postal_code %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column addr">
-  <dt>
+<fieldset class="column addr">
+  <legend>
     <%= @model.t :addr %>
     <% if @cur_node.addr_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <%= f.text_field :addr %>
     <%= remarks :addr %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column sex">
-  <dt>
+<fieldset class="column sex">
+  <legend>
     <%= @model.t :sex %>
     <% if @cur_node.sex_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <% @item.sex_options.each do |text, val| %>
       <%= label_tag("item_sex_#{val}", class: val) do %>
@@ -124,15 +124,15 @@
     <% end %>
     <%= remarks :sex %>
   </dd>
-</dl>
+</fieldset>
 
-<dl class="column birthday">
-  <dt>
+<fieldset class="column birthday">
+  <legend>
     <%= @model.t :birthday %>
     <% if @cur_node.birthday_required? %>
     <%= required_label %>
     <% end %>
-  </dt>
+  </legend>
   <dd>
     <%= f.fields_for :in_birth do |birth_f| %>
       <% era, year, month, day = @item.parse_in_birth %>
@@ -146,6 +146,6 @@
     <% end %>
     <%= remarks :birthday %>
   </dd>
-</dl>
+</fieldset>
 
 <%= render file: '_mail_category_form', locals: { f: f } %>

--- a/app/views/member/agents/nodes/my_profile/_form.html.erb
+++ b/app/views/member/agents/nodes/my_profile/_form.html.erb
@@ -41,7 +41,7 @@
   </dd>
 </dl>
 
-<dl class="column">
+<dl class="column organization-name">
   <dt>
     <%= @model.t :organization_name %>
     <% if @cur_node.organization_name_required? %>
@@ -54,7 +54,7 @@
   </dd>
 </dl>
 
-<dl class="column">
+<dl class="column job">
   <dt>
     <%= @model.t :job %>
     <% if @cur_node.job_required? %>
@@ -67,7 +67,7 @@
   </dd>
 </dl>
 
-<dl class="column">
+<dl class="column tel">
   <dt>
     <%= @model.t :tel %>
     <% if @cur_node.tel_required? %>
@@ -95,7 +95,7 @@
   </dd>
 </dl>
 
-<dl class="column">
+<dl class="column addr">
   <dt>
     <%= @model.t :addr %>
     <% if @cur_node.addr_required? %>
@@ -108,7 +108,7 @@
   </dd>
 </dl>
 
-<dl class="column">
+<dl class="column sex">
   <dt>
     <%= @model.t :sex %>
     <% if @cur_node.sex_required? %>
@@ -125,7 +125,7 @@
   </dd>
 </dl>
 
-<dl class="column">
+<dl class="column birthday">
   <dt>
     <%= @model.t :birthday %>
     <% if @cur_node.birthday_required? %>

--- a/app/views/member/agents/nodes/registration/_confirm.html.erb
+++ b/app/views/member/agents/nodes/registration/_confirm.html.erb
@@ -11,7 +11,7 @@
   <%= f.hidden_field :sends_verification_mail, value: 'yes' %>
   <% end %>
 
-  <dl class="colum name">
+  <dl class="column name">
     <dt><%= @item.class.t :name %></dt>
     <dd>
       <%= @item.name %>
@@ -19,7 +19,7 @@
     </dd>
   </dl>
 
-  <dl class="colum email">
+  <dl class="column email">
     <dt><%= @item.class.t :email %></dt>
     <dd>
       <%= @item.email %>
@@ -27,7 +27,7 @@
     </dd>
   </dl>
 
-  <dl class="colum kana">
+  <dl class="column kana">
     <dt><%= @item.class.t :kana %></dt>
     <dd>
       <%= @item.kana %>
@@ -35,7 +35,7 @@
     </dd>
   </dl>
 
-  <dl class="colum organization-name">
+  <dl class="column organization-name">
     <dt><%= @item.class.t :organization_name %></dt>
     <dd>
       <%= @item.organization_name %>
@@ -43,7 +43,7 @@
     </dd>
   </dl>
 
-  <dl class="colum job">
+  <dl class="column job">
     <dt><%= @item.class.t :job %></dt>
     <dd>
       <%= @item.job %>
@@ -51,7 +51,7 @@
     </dd>
   </dl>
 
-  <dl class="colum tel">
+  <dl class="column tel">
     <dt><%= @item.class.t :tel %></dt>
     <dd>
       <%= @item.tel %>
@@ -59,7 +59,7 @@
     </dd>
   </dl>
 
-  <dl class="colum postal-code">
+  <dl class="column postal-code">
     <dt><%= @item.class.t :postal_code %></dt>
     <dd>
       <%= @item.postal_code %>
@@ -67,7 +67,7 @@
     </dd>
   </dl>
 
-  <dl class="colum addr">
+  <dl class="column addr">
     <dt><%= @item.class.t :addr %></dt>
     <dd>
       <%= @item.addr %>
@@ -75,7 +75,7 @@
     </dd>
   </dl>
 
-  <dl class="colum sex">
+  <dl class="column sex">
     <dt><%= @item.class.t :sex %></dt>
     <dd>
       <%= @item.label :sex %>
@@ -83,7 +83,7 @@
     </dd>
   </dl>
 
-  <dl class="colum birthday">
+  <dl class="column birthday">
     <dt><%= @item.class.t :birthday %></dt>
     <dd>
       <% if @item.in_birth.present? %>
@@ -102,7 +102,7 @@
   </dl>
 
   <% if @cur_node.confirm_personal_data_state == 'enabled' %>
-  <dl class="colum personal-info">
+  <dl class="column personal-info">
     <dt><%= @item.class.t :in_confirm_personal_info %><span class="required"><%= t("ss.required_field") %></span></dt>
     <dd>
       <%= f.label(:in_confirm_personal_info) do %>

--- a/app/views/member/agents/nodes/registration/_new.html.erb
+++ b/app/views/member/agents/nodes/registration/_new.html.erb
@@ -2,91 +2,91 @@
 <%= javascript_include_tag 'member/public' %>
 
 <div class="columns">
-  <dl class="column name">
-    <dt><%= @item.class.t :name %><span class="required"><%= t("ss.required_field") %></span></dt>
+  <fieldset class="column name">
+    <legend><%= @item.class.t :name %><span class="required"><%= t("ss.required_field") %></span></legend>
     <dd><%= f.text_field :name %><%= remarks :name %></dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column email">
-    <dt><%= @item.class.t :email %><span class="required"><%= t("ss.required_field") %></span></dt>
+  <fieldset class="column email">
+    <legend><%= @item.class.t :email %><span class="required"><%= t("ss.required_field") %></span></legend>
     <dd><%= f.text_field :email %><%= remarks :email %></dd>
 
-    <dt><%= @item.class.t :email_again %><span class="required"><%= t("ss.required_field") %></span></dt>
+    <legend><%= @item.class.t :email_again %><span class="required"><%= t("ss.required_field") %></span></legend>
     <dd><%= f.text_field :email_again %><%= remarks :email_again %></dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column kana">
-    <dt>
+  <fieldset class="column kana">
+    <legend>
       <%= @item.class.t :kana %>
       <% if @cur_node.kana_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd><%= f.text_field :kana %><%= remarks :kana %></dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column organization-name">
-    <dt>
+  <fieldset class="column organization-name">
+    <legend>
       <%= @item.class.t :organization_name %>
       <% if @cur_node.organization_name_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd><%= f.text_field :organization_name %><%= remarks :organization_name %></dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column job">
-    <dt>
+  <fieldset class="column job">
+    <legend>
       <%= @item.class.t :job %>
       <% if @cur_node.job_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd><%= f.text_field :job %><%= remarks :job %></dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column tel">
-    <dt>
+  <fieldset class="column tel">
+    <legend>
       <%= @item.class.t :tel %>
       <% if @cur_node.tel_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd><%= f.text_field :tel %><%= remarks :tel %></dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column postal-code">
-    <dt>
+  <fieldset class="column postal-code">
+    <legend>
       <%= @item.class.t :postal_code %>
       <% if @cur_node.postal_code_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd>
       <%= f.text_field :postal_code %>
       <%= f.button t('member.buttons.address_search'), name: 'postal-code-search', type: :button %>
       <span class="postal-code-search-error"></span>
       <%= remarks :postal_code %>
     </dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column addr">
-    <dt>
+  <fieldset class="column addr">
+    <legend>
       <%= @item.class.t :addr %>
       <% if @cur_node.addr_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd><%= f.text_field :addr %><%= remarks :addr %></dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column sex">
-    <dt>
+  <fieldset class="column sex">
+    <legend>
       <%= @item.class.t :sex %>
       <% if @cur_node.sex_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd>
       <% @item.sex_options.each do |text, val| %>
         <%= label_tag("item_sex_#{val}", class: val) do %>
@@ -95,15 +95,15 @@
       <% end %>
       <%= remarks :sex %>
     </dd>
-  </dl>
+  </fieldset>
 
-  <dl class="column birthday">
-    <dt>
+  <fieldset class="column birthday">
+    <legend>
       <%= @item.class.t :birthday %>
       <% if @cur_node.birthday_required? %>
       <span class="required"><%= t("ss.required_field") %></span>
       <% end %>
-    </dt>
+    </legend>
     <dd>
       <%= f.fields_for :in_birth do |birth_f| %>
         <% era, year, month, day = @item.parse_in_birth %>
@@ -117,7 +117,7 @@
       <% end %>
       <%= remarks :birthday %>
     </dd>
-  </dl>
+  </fieldset>
 </div>
 
 <%= jquery do %>

--- a/app/views/member/agents/nodes/registration/_new.html.erb
+++ b/app/views/member/agents/nodes/registration/_new.html.erb
@@ -2,12 +2,12 @@
 <%= javascript_include_tag 'member/public' %>
 
 <div class="columns">
-  <dl class="colum name">
+  <dl class="column name">
     <dt><%= @item.class.t :name %><span class="required"><%= t("ss.required_field") %></span></dt>
     <dd><%= f.text_field :name %><%= remarks :name %></dd>
   </dl>
 
-  <dl class="colum email">
+  <dl class="column email">
     <dt><%= @item.class.t :email %><span class="required"><%= t("ss.required_field") %></span></dt>
     <dd><%= f.text_field :email %><%= remarks :email %></dd>
 
@@ -15,7 +15,7 @@
     <dd><%= f.text_field :email_again %><%= remarks :email_again %></dd>
   </dl>
 
-  <dl class="colum kana">
+  <dl class="column kana">
     <dt>
       <%= @item.class.t :kana %>
       <% if @cur_node.kana_required? %>
@@ -25,7 +25,7 @@
     <dd><%= f.text_field :kana %><%= remarks :kana %></dd>
   </dl>
 
-  <dl class="colum organization-name">
+  <dl class="column organization-name">
     <dt>
       <%= @item.class.t :organization_name %>
       <% if @cur_node.organization_name_required? %>
@@ -35,7 +35,7 @@
     <dd><%= f.text_field :organization_name %><%= remarks :organization_name %></dd>
   </dl>
 
-  <dl class="colum job">
+  <dl class="column job">
     <dt>
       <%= @item.class.t :job %>
       <% if @cur_node.job_required? %>
@@ -45,7 +45,7 @@
     <dd><%= f.text_field :job %><%= remarks :job %></dd>
   </dl>
 
-  <dl class="colum tel">
+  <dl class="column tel">
     <dt>
       <%= @item.class.t :tel %>
       <% if @cur_node.tel_required? %>
@@ -55,7 +55,7 @@
     <dd><%= f.text_field :tel %><%= remarks :tel %></dd>
   </dl>
 
-  <dl class="colum postal-code">
+  <dl class="column postal-code">
     <dt>
       <%= @item.class.t :postal_code %>
       <% if @cur_node.postal_code_required? %>
@@ -70,7 +70,7 @@
     </dd>
   </dl>
 
-  <dl class="colum addr">
+  <dl class="column addr">
     <dt>
       <%= @item.class.t :addr %>
       <% if @cur_node.addr_required? %>
@@ -80,7 +80,7 @@
     <dd><%= f.text_field :addr %><%= remarks :addr %></dd>
   </dl>
 
-  <dl class="colum sex">
+  <dl class="column sex">
     <dt>
       <%= @item.class.t :sex %>
       <% if @cur_node.sex_required? %>
@@ -97,7 +97,7 @@
     </dd>
   </dl>
 
-  <dl class="colum birthday">
+  <dl class="column birthday">
     <dt>
       <%= @item.class.t :birthday %>
       <% if @cur_node.birthday_required? %>

--- a/app/views/member/agents/nodes/registration/_reset_password.html.erb
+++ b/app/views/member/agents/nodes/registration/_reset_password.html.erb
@@ -1,5 +1,5 @@
 <div class="columns">
-  <dl class="colum">
+  <dl class="column">
     <dt><%= @item.class.t :email %></dt>
     <dd><%= f.text_field :email %></dd>
   </dl>

--- a/app/views/member/agents/nodes/registration/_send_again.html.erb
+++ b/app/views/member/agents/nodes/registration/_send_again.html.erb
@@ -1,7 +1,6 @@
 <div class="columns">
-  <dl class="colum">
+  <dl class="column">
     <dt><%= @item.class.t :email %><span class="required"><%= t("ss.required_field") %></span></dt>
     <dd><%= f.text_field :email %></dd>
   </dl>
 </div>
-

--- a/app/views/member/agents/nodes/registration/_verify.html.erb
+++ b/app/views/member/agents/nodes/registration/_verify.html.erb
@@ -4,17 +4,17 @@
 <%= f.hidden_field_tag("token", params[:token]) %>
 <%= f.hidden_field_tag("group", params[:group]) if params[:group].present? %>
 
-<dl class="colum name">
+<dl class="column name">
   <dt><%= @item.class.t :name %><span class="required"><%= t("ss.required_field") %></span></dt>
   <dd><%= f.text_field :name %><%= remarks :name %></dd>
 </dl>
 
-<dl class="colum email">
+<dl class="column email">
   <dt><%= @item.class.t :email %></dt>
   <dd><%= @item.email %></dd>
 </dl>
 
-<dl class="colum password">
+<dl class="column password">
   <dt><%= @item.t :in_password %><span class="required"><%= t("ss.required_field") %></span></dt>
   <dd><%= f.password_field :in_password %><%= remarks :in_password %></dd>
 
@@ -22,7 +22,7 @@
   <dd><%= f.password_field :in_password_again %><%= remarks :in_password_again %></dd>
 </dl>
 
-<dl class="colum kana">
+<dl class="column kana">
   <dt>
     <%= @item.class.t :kana %>
     <% if @cur_node.kana_required? %>
@@ -32,7 +32,7 @@
   <dd><%= f.text_field :kana %><%= remarks :kana %></dd>
 </dl>
 
-<dl class="colum organization-name">
+<dl class="column organization-name">
   <dt>
     <%= @item.class.t :organization_name %>
     <% if @cur_node.organization_name_required? %>
@@ -42,7 +42,7 @@
   <dd><%= f.text_field :organization_name %><%= remarks :organization_name %></dd>
 </dl>
 
-<dl class="colum job">
+<dl class="column job">
   <dt>
     <%= @item.class.t :job %>
     <% if @cur_node.job_required? %>
@@ -52,7 +52,7 @@
   <dd><%= f.text_field :job %><%= remarks :job %></dd>
 </dl>
 
-<dl class="colum tel">
+<dl class="column tel">
   <dt>
     <%= @item.class.t :tel %>
     <% if @cur_node.tel_required? %>
@@ -62,7 +62,7 @@
   <dd><%= f.text_field :tel %><%= remarks :tel %></dd>
 </dl>
 
-<dl class="colum postal-code">
+<dl class="column postal-code">
   <dt>
     <%= @item.class.t :postal_code %>
     <% if @cur_node.postal_code_required? %>
@@ -77,7 +77,7 @@
   </dd>
 </dl>
 
-<dl class="colum addr">
+<dl class="column addr">
   <dt>
     <%= @item.class.t :addr %>
     <% if @cur_node.addr_required? %>
@@ -87,7 +87,7 @@
   <dd><%= f.text_field :addr %><%= remarks :addr %></dd>
 </dl>
 
-<dl class="colum sex">
+<dl class="column sex">
   <dt>
     <%= @item.class.t :sex %>
     <% if @cur_node.sex_required? %>
@@ -104,7 +104,7 @@
   </dd>
 </dl>
 
-<dl class="colum birthday">
+<dl class="column birthday">
   <dt>
     <%= @item.class.t :birthday %>
     <% if @cur_node.birthday_required? %>


### PR DESCRIPTION
## Issue
https://github.com/shirasagi/shirasagi/issues/3784

## 変更内容
- `column`が`colum`となっていたので、そのタイポ修正
- メンバー登録ではフィールド毎にフィールドのクラス名が割り当てられていたが、メンバー編集では無かったので統一するためにフィールドのクラス名を追加。
- `fieldset`/`legend`要素が使用されていなかったので、`dl`/`dt`要素を`fieldset`/`legend`要素に変更。