### PR TITLE
【CMS不具合】フォルダー：メンバー/安否　現在地の取得

### DIFF
--- a/app/assets/javascripts/board/lib/map.js
+++ b/app/assets/javascripts/board/lib/map.js
@@ -233,3 +233,4 @@ this.Board_Map = (function () {
   return Board_Map;
 
 })();
+

--- a/app/assets/javascripts/board/lib/map.js
+++ b/app/assets/javascripts/board/lib/map.js
@@ -47,7 +47,7 @@ this.Board_Map = (function () {
     }
     if (this.opts['marker']) {
       this.setMarker(this.opts['marker']);
-
+      this.setCenter(this.opts['marker']);
     }
     if (this.opts['popup']) {
       this.initPopup();
@@ -64,7 +64,8 @@ this.Board_Map = (function () {
           while (pos[0] > 180) {
             pos[0] -= 360;
           }
-          return _this.setMarker(pos);
+          _this.setMarker(pos);
+          _this.setCenter(pos);
         };
       })(this));
     }
@@ -126,6 +127,10 @@ this.Board_Map = (function () {
     this.popup.find('.content').html($("#marker-html-" + markerId).html());
     this.popup.show();
     return this.popupOverlay.setPosition(evt.coordinate);
+  };
+
+  Board_Map.prototype.setCenter = function (position) {
+    this.map.getView().setCenter(ol.proj.transform([position[0], position[1]], "EPSG:4326", "EPSG:3857"));
   };
 
   Board_Map.prototype.setMarker = function (position, opts) {
@@ -216,9 +221,10 @@ this.Board_Map = (function () {
     if (!navigator.geolocation) {
       return;
     }
-    return navigator.geolocation.getCurrentPosition((function (_this) {
+    navigator.geolocation.getCurrentPosition((function (_this) {
       return function (position) {
-        return _this.setMarker([position.coords.longitude, position.coords.latitude]);
+        _this.setMarker([position.coords.longitude, position.coords.latitude]);
+        _this.setCenter([position.coords.longitude, position.coords.latitude]);
       };
     })(this));
   };
@@ -226,4 +232,3 @@ this.Board_Map = (function () {
   return Board_Map;
 
 })();
-

--- a/app/assets/javascripts/board/lib/map.js
+++ b/app/assets/javascripts/board/lib/map.js
@@ -47,7 +47,6 @@ this.Board_Map = (function () {
     }
     if (this.opts['marker']) {
       this.setMarker(this.opts['marker']);
-      this.setCenter(this.opts['marker']);
     }
     if (this.opts['popup']) {
       this.initPopup();
@@ -65,7 +64,6 @@ this.Board_Map = (function () {
             pos[0] -= 360;
           }
           _this.setMarker(pos);
-          _this.setCenter(pos);
         };
       })(this));
     }
@@ -131,7 +129,7 @@ this.Board_Map = (function () {
 
   Board_Map.prototype.setCenter = function (position) {
     this.map.getView().setCenter(ol.proj.transform([position[0], position[1]], "EPSG:4326", "EPSG:3857"));
-    this.map.getView().setZoom(11);
+    this.map.getView().setZoom(16);
   };
 
   Board_Map.prototype.setMarker = function (position, opts) {
@@ -233,4 +231,3 @@ this.Board_Map = (function () {
   return Board_Map;
 
 })();
-

--- a/app/assets/javascripts/board/lib/map.js
+++ b/app/assets/javascripts/board/lib/map.js
@@ -131,6 +131,7 @@ this.Board_Map = (function () {
 
   Board_Map.prototype.setCenter = function (position) {
     this.map.getView().setCenter(ol.proj.transform([position[0], position[1]], "EPSG:4326", "EPSG:3857"));
+    this.map.getView().setZoom(11);
   };
 
   Board_Map.prototype.setMarker = function (position, opts) {


### PR DESCRIPTION
## backlog
K03012-359 【CMS不具合】フォルダー：メンバー/安否

## 不具合内容
「現在地取得」を押すと現在地を取得はできているが、画面が現在地へと移動しないから現在地が取得できているのか分かりづらい。

## 修正内容
- setCenterメソッドを追加し、「現在地取得」と同じタイミングで現在地を画面中央に表示させた
- 画面中央に遷移する際に、ズームレベルを初期値に合わして設定した。