### PR TITLE
[fixes] add release addon to pagelist by group #3809

### DIFF
--- a/app/models/cms/node.rb
+++ b/app/models/cms/node.rb
@@ -81,6 +81,7 @@ class Cms::Node
     include Cms::Addon::PageGroupList
     include ::Cms::ChildList
     include History::Addon::Backup
+    include Cms::Addon::Release
 
     def child_items
       child_pages


### PR DESCRIPTION
## Issue
「グループ別ページリスト」非公開化でできない　https://github.com/shirasagi/shirasagi/issues/3809

## 修正内容
`Cms::Node::GroupPage`に`include Cms::Addon::Release`を追加。