### PR TITLE
[fix] able to watch preview for mobile

### DIFF
--- a/app/models/concerns/cms/model/node.rb
+++ b/app/models/concerns/cms/model/node.rb
@@ -97,7 +97,7 @@ module Cms::Model::Node
   end
 
   def mobile_preview_path
-    ::File.join((site.subdir ? site.subdir : ""), site.mobile_location, filename, "/")
+    ::File.join((site.subdir ? site.subdir : ""), site.mobile_location, filename, "/").gsub(/^\//, '')
   end
 
   def parents

--- a/app/models/concerns/cms/model/page.rb
+++ b/app/models/concerns/cms/model/page.rb
@@ -50,7 +50,7 @@ module Cms::Model::Page
   end
 
   def mobile_preview_path
-    ::File.join((site.subdir ? site.subdir : ""), site.mobile_location, filename)
+    ::File.join((site.subdir ? site.subdir : ""), site.mobile_location, filename).gsub(/^\//, '')
   end
 
   def generate_file(opts = {})


### PR DESCRIPTION
## 修正内容
携帯プレビューのURLが`https://demo.ss-proj.org/.s1/preview//mobile/docs/page32.html`のように`//mobile`とスラッシュが２つできていたので、スラッシュが１つになるように修正