### PR TITLE
Fix/title of event calendar list

### DIFF
--- a/app/controllers/event/agents/nodes/page_controller.rb
+++ b/app/controllers/event/agents/nodes/page_controller.rb
@@ -14,7 +14,7 @@ class Event::Agents::Nodes::PageController < ApplicationController
 
     disp_cur_display = I18n.t("event.options.event_display.#{@cur_display || "table"}")
     if @year_presented
-      @cur_node.window_name ||= "#{@cur_node.name} #{disp_cur_display} #{I18n.l(@date, format: :long_month)}"
+      @cur_node.window_name = "#{@cur_node.name} #{disp_cur_display} #{I18n.l(@date, format: :long_month)}"
     else
       @cur_node.window_name = "#{@cur_node.name} #{disp_cur_display}"
     end


### PR DESCRIPTION
## Issue
https://github.com/shirasagi/shirasagi/issues/3808

## 問題箇所
リスト形式を選んでもタイトルが変わらず、タイトルに年月が表示されない。
https://demo.ss-proj.org/calendar/202101/list.html

## ブラウザの表示（修正後）
![スクリーンショット 2021-01-18 19 19 05](https://user-images.githubusercontent.com/59913383/104902379-0a85cb00-59c2-11eb-9de9-80f492979e76.png)
