### PR TITLE
[fix] remove tree-item class from content-navi-refresh

### DIFF
--- a/app/assets/javascripts/ss/lib/tree_navi.js
+++ b/app/assets/javascripts/ss/lib/tree_navi.js
@@ -89,7 +89,7 @@ SS_TreeNavi.prototype.renderItems = function(data, roots) {
       return false;
     });
 
-    ret.push($("<div />", { class: "tree-item content-navi-refresh" }).html($refresh));
+    ret.push($("<div />", { class: "content-navi-refresh" }).html($refresh));
   }
 
   return ret;

--- a/spec/features/workflow/branch_spec.rb
+++ b/spec/features/workflow/branch_spec.rb
@@ -62,7 +62,7 @@ describe "workflow_branch", type: :feature, dbscope: :example, js: true do
 
     if item.route == "cms/page"
       within "#content-navi" do
-        expect(page).to have_css(".tree-item", text: "refresh")
+        expect(page).to have_css(".material-icons", text: "refresh")
       end
     end
 


### PR DESCRIPTION
## 【シラサギ問い合わせ　CMS　無償】フォルダーの表示がおかしい
https://web-tips.backlog.jp/view/K03012-678