### PR TITLE
[modify] unset `config.assets.js_compressor`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Compress using a preprocessor.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   config.assets.css_compressor = :sass
 
   # other assets configurations

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress using a preprocessor.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## size 比較

| config.assets.js_compressor | size              |
|-----------------------------|-------------------|
| nil                         | 2.2M              |
| :uglifier                   | 1.4M              |
| Uglifier.new(harmony: true) | 1.4M              |

size は次のコマンドで計測: `find public/assets -name '*.js.gz' | xargs du -ch`

## harmony について

ES6 を ES6 のまま uglify できるようになるオプション。
IE11 は ES6 を（直接）実行できないので、「構文エラーです。」や「未定義または NULL 参照のプロパティ `fn' は取得できません。」などというエラーが発生する。
