### PR TITLE
[modify]add timeline min-width on calendar

### DIFF
--- a/app/assets/stylesheets/gws/schedule/_gws.scss
+++ b/app/assets/stylesheets/gws/schedule/_gws.scss
@@ -579,6 +579,7 @@
     border-bottom: 1px solid #d8d8d8;
   }
   .fc-timeline-event {
+    min-width: calc(1em + 5px);
     background: #2eb0f2;
     color: $black;
   }


### PR DESCRIPTION
# 問題点
グループウェアのスケジュールにおいて10分の予定を作成すると、
グループのスケジュールの日表示時に予定の表示領域が狭くなるため文字が見切れてしまう。

# 実装内容
最低でも１文字分の横幅を確保した。