### PR TITLE
[Ruby 3.1 準備] use method "PLAIN" to log-in to dovecot

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,10 +31,12 @@ jobs:
         run: |
           sudo locale-gen ja_JP
           sudo update-locale LANG=ja_JP.UTF-8
-      - name: Docker Login
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-          docker info
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
         with:
@@ -43,12 +45,12 @@ jobs:
         run: docker pull osixia/openldap
       - name: Start Shirasagi Mail
         run: |
-          docker pull shirasagi/mail
+          docker pull ghcr.io/shirasagi/mail
           docker run --name test_mail -d -p 10143:143 -p 10587:587 shirasagi/mail
       - name: Prepare Michecker
-        run: docker pull shirasagi/michecker
+        run: docker pull ghcr.io/shirasagi/michecker
       - name: Prepare Elasticsearch
-        run: docker pull shirasagi/elasticsearch
+        run: docker pull ghcr.io/shirasagi/elasticsearch
       - name: Launch Elasticsearch
         id: elasticsearch
         run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,12 +45,17 @@ jobs:
         run: docker pull osixia/openldap
       - name: Start Shirasagi Mail
         run: |
-          docker pull ghcr.io/shirasagi/mail
+          docker pull ghcr.io/shirasagi/mail:latest
+          docker tag ghcr.io/shirasagi/mail:latest shirasagi/mail:latest
           docker run --name test_mail -d -p 10143:143 -p 10587:587 shirasagi/mail
       - name: Prepare Michecker
-        run: docker pull ghcr.io/shirasagi/michecker
+        run: |
+          docker pull ghcr.io/shirasagi/michecker:latest
+          docker tag ghcr.io/shirasagi/michecker:latest shirasagi/michecker:latest
       - name: Prepare Elasticsearch
-        run: docker pull ghcr.io/shirasagi/elasticsearch
+        run: |
+          docker pull ghcr.io/shirasagi/elasticsearch:latest
+          docker tag ghcr.io/shirasagi/elasticsearch:latest shirasagi/elasticsearch:latest
       - name: Launch Elasticsearch
         id: elasticsearch
         run: |

--- a/spec/support/webmail/init.rb
+++ b/spec/support/webmail/init.rb
@@ -32,7 +32,7 @@ module SS::WebmailSupport
 
   def docker_conf_auth_type
     @docker_conf_imap_auth_type ||= begin
-      SS::WebmailSupport.docker_conf["auth_type"].presence || "CRAM-MD5"
+      SS::WebmailSupport.docker_conf["auth_type"].presence || "PLAIN"
     end
   end
 


### PR DESCRIPTION
because CRAM-MD5 is deprecated on Ruby 3.1 or later