### PR TITLE
[modify] remove gem 'ruby-debug-ide'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,7 +140,6 @@ group :development, :test do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rspec', require: false
   gem 'rubocop-rails', '2.11.3', require: false
-  gem 'ruby-debug-ide', require: false
   gem 'scss_lint', require: false
   gem 'selenium-webdriver', '~> 4.11', require: false
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,8 +600,6 @@ GEM
     rubocop-rspec (2.4.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
-    ruby-debug-ide (0.7.3)
-      rake (>= 0.8.1)
     ruby-progressbar (1.13.0)
     ruby-saml (1.15.0)
       nokogiri (>= 1.13.10)
@@ -842,7 +840,6 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails (= 2.11.3)
   rubocop-rspec
-  ruby-debug-ide
   ruby-saml
   rubyzip (~> 2.3.0)
   sass


### PR DESCRIPTION
because its installation sometimes succeeds, sometimes fails on CI