### PR TITLE
[fix][cms] ".and_public" returns "ready" contents in non-preview mode

### DIFF
--- a/spec/features/article/agents/parts/page_spec.rb
+++ b/spec/features/article/agents/parts/page_spec.rb
@@ -145,4 +145,49 @@ describe "article_agents_parts_page", type: :feature, dbscope: :example do
       expect(page).to have_selector(".current")
     end
   end
+
+  context "with さまざまな公開予約" do
+    let!(:item0) { create :article_page, cur_site: site, cur_node: node, layout: layout, state: "public" }
+    let!(:item1) { create :article_page, cur_site: site, cur_node: node, layout: layout, state: "closed" }
+    let!(:item2) { create :article_page, cur_site: site, cur_node: node, layout: layout, state: "public" }
+    let!(:item3) { create :article_page, cur_site: site, cur_node: node, layout: layout, state: "closed" }
+    let(:now) { Time.zone.now.change(sec: 0) }
+
+    before do
+      # item1: 公開開始前
+      item1.release_date = now + 1.day
+      item1.state = "ready"
+      item1.save!
+
+      # item2: 公開終了日が過ぎているがシステム障害により公開タスクが実行されないのでpublicのまま
+      item2.set(close_date: (now - 1.day).utc)
+
+      # item3: 公開開始日が過ぎているがシステム障害により公開タスクが実行されないのでreadyのまま
+      item3.set(release_date: (now - 1.day).utc, state: "ready")
+
+      expect(item0.state).to eq "public"
+      expect(item1.state).to eq "ready"
+      expect(item2.state).to eq "public"
+      expect(item3.state).to eq "ready"
+
+      ::FileUtils.rm_rf(item0.path)
+      ::FileUtils.rm_rf(item1.path)
+      ::FileUtils.rm_rf(item2.path)
+      ::FileUtils.rm_rf(item3.path)
+
+      part.upper_html = '<div class="parts">'
+      part.lower_html = '</div>'
+      part.save!
+    end
+
+    it do
+      visit "#{node.full_url}/index.html"
+      within ".parts" do
+        expect(page).to have_css("article", count: 1)
+        within ".item-#{::File.basename(item0.basename, ".*")}" do
+          expect(page).to have_link(item0.name, href: item0.url)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Those aren't accessible in non-preview mode.