### PR TITLE
[fix][設備予約] クエリパラメータで指定した日時のカレンダーを表示できない問題の修正

### DIFF
--- a/app/assets/javascripts/gws/schedule/lib/calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/calendar.js
@@ -26,6 +26,9 @@ SS.ready(function() {
         opts.eventSources[i]['error'] = function() { $(selector).data('resource-error', true); }
       }
       $.extend(true, params, opts);
+      if (init && init["date"]) {
+        params["defaultDate"] = init["date"];
+      }
       $(selector).fullCalendar(params);
       this.renderInitialize(selector, init);
       this.overrideAddLink(selector);

--- a/app/assets/javascripts/gws/schedule/lib/multiple_calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/multiple_calendar.js
@@ -24,6 +24,9 @@ SS.ready(function() {
       $.extend(true, params, this.defaultParams(selector, opts));
       $.extend(true, params, this.contentParams(selector, opts));
       $.extend(true, params, opts);
+      if (init && init["date"]) {
+        params["defaultDate"] = init["date"];
+      }
       // To render gridster and/or other frames first, all fullCalendar initializations is delayed.
       // And a calendar is individually rendered from top to bottom.
       setTimeout(function () {
@@ -150,6 +153,9 @@ SS.ready(function() {
       $.extend(true, params, this.defaultParams(selector, opts));
       $.extend(true, params, this.controllerParams(selector, opts));
       $.extend(true, params, opts);
+      if (init && init["date"]) {
+        params["defaultDate"] = init["date"];
+      }
       $(selector).fullCalendar(params);
       Gws_Schedule_Calendar.renderInitialize(selector, init);
       Gws_Schedule_Calendar.overrideAddLink(selector);

--- a/app/views/gws/schedule/facilities/index.html.erb
+++ b/app/views/gws/schedule/facilities/index.html.erb
@@ -14,7 +14,7 @@
 %>
 <%= jquery do %>
   $(document).on("gws:calendarInitialized", function() {
-    Gws_Schedule_Multiple_Calendar.renderController('#calendar-controller', <%== calendar_options.to_json %>, <%== init_options.to_json.to_json %>);
+    Gws_Schedule_Multiple_Calendar.renderController('#calendar-controller', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
   });
 <% end %>
 


### PR DESCRIPTION
1. 現在日ではない設備の明細を表示。
2. 一覧へ戻るをクリック。
3. クエリパラメータで表示日を指定しているが、効いていないので、現在日が表示される。
