### PR TITLE
[fixup] ワンタイムパスワード（多要素認証の一つとして）

### DIFF
--- a/app/assets/stylesheets/ss/_login.scss
+++ b/app/assets/stylesheets/ss/_login.scss
@@ -206,8 +206,8 @@
     }
 
     .otp-setup-qrcode {
-      width: 150px;
-      height: 150px;
+      width: 200px;
+      height: 200px;
     }
 
     .otp-setup-registration-instruction {


### PR DESCRIPTION
QRコードを読み取りずらいのでQRコードの画像サイズを大きく