### PR TITLE
[fix] issue 5298

### DIFF
--- a/app/models/concerns/article/addon/form_export.rb
+++ b/app/models/concerns/article/addon/form_export.rb
@@ -57,21 +57,23 @@ module Article::Addon
 
     def pages_to_json(pages)
       columns = export_columns.presence || form.columns.order(order: 1).map(&:name)
-      # 記事URLを含むかどうかを判定
-      include_article_url = columns.include?("article_url")
+      # # 記事URLを含むかどうかを判定
+      # include_article_url = columns.include?("article_url")
       article_url_label = I18n.t("cms.export.article_url")
-      if include_article_url
-        data = [ [resolve_page_name ] + columns + [article_url_label] ]
-      else
-        data = [ [resolve_page_name ] + columns ]
-      end
+      data = [ [resolve_page_name ] + columns + [article_url_label] ]
+      # if include_article_url
+      #   data = [ [resolve_page_name ] + columns + [article_url_label] ]
+      # else
+      #   data = [ [resolve_page_name ] + columns ]
+      # end
 
       pages.each do |page|
         column_values_hash = page.column_values.map { |cv| [cv.name, cv.export_csv_cell] }.to_h
         values = columns.map { |col| column_values_hash[col].to_s }
-        row = [page.name] + values
-        row << page.full_url if include_article_url
-        data << row
+        data << [page.name] + values + [page.full_url]
+        # row = [page.name] + values
+        # row << page.full_url if include_article_url
+        # data << row
       end
 
       data

--- a/app/models/concerns/article/addon/form_export.rb
+++ b/app/models/concerns/article/addon/form_export.rb
@@ -57,7 +57,7 @@ module Article::Addon
 
     def pages_to_json(pages)
       columns = export_columns.presence || form.columns.order(order: 1).map(&:name)
-      data = [[resolve_page_name] + columns]
+      data = [[resolve_page_name, "URL"] + columns]
 
       pages.each do |page|
         column_values_hash = page.column_values.map { |cv| [cv.name, cv.export_csv_cell] }.to_h

--- a/app/models/concerns/article/addon/form_export.rb
+++ b/app/models/concerns/article/addon/form_export.rb
@@ -62,7 +62,7 @@ module Article::Addon
       pages.each do |page|
         column_values_hash = page.column_values.map { |cv| [cv.name, cv.export_csv_cell] }.to_h
         values = columns.map { |col| column_values_hash[col].to_s }
-        data << [page.name] + values
+        data << [page.name, page.full_url] + values
       end
 
       data

--- a/app/models/concerns/article/addon/form_export.rb
+++ b/app/models/concerns/article/addon/form_export.rb
@@ -58,7 +58,7 @@ module Article::Addon
     def pages_to_json(pages)
       columns = export_columns.presence || form.columns.order(order: 1).map(&:name)
 
-      article_url_label = I18n.t("cms.export.article_url")
+      article_url_label = I18n.t("mongoid.attributes.cms/model/page.full_url")
       data = [ [resolve_page_name ] + columns + [article_url_label] ]
 
       pages.each do |page|

--- a/app/models/concerns/article/addon/form_export.rb
+++ b/app/models/concerns/article/addon/form_export.rb
@@ -57,23 +57,15 @@ module Article::Addon
 
     def pages_to_json(pages)
       columns = export_columns.presence || form.columns.order(order: 1).map(&:name)
-      # # 記事URLを含むかどうかを判定
-      # include_article_url = columns.include?("article_url")
+
       article_url_label = I18n.t("cms.export.article_url")
       data = [ [resolve_page_name ] + columns + [article_url_label] ]
-      # if include_article_url
-      #   data = [ [resolve_page_name ] + columns + [article_url_label] ]
-      # else
-      #   data = [ [resolve_page_name ] + columns ]
-      # end
 
       pages.each do |page|
         column_values_hash = page.column_values.map { |cv| [cv.name, cv.export_csv_cell] }.to_h
         values = columns.map { |col| column_values_hash[col].to_s }
-        data << [page.name] + values + [page.full_url]
-        # row = [page.name] + values
-        # row << page.full_url if include_article_url
-        # data << row
+        article_url_value = page.full_url || ""
+        data << [page.name] + values + [article_url_value]
       end
 
       data

--- a/app/models/concerns/article/addon/form_export.rb
+++ b/app/models/concerns/article/addon/form_export.rb
@@ -57,12 +57,21 @@ module Article::Addon
 
     def pages_to_json(pages)
       columns = export_columns.presence || form.columns.order(order: 1).map(&:name)
-      data = [[resolve_page_name, "URL"] + columns]
+      # 記事URLを含むかどうかを判定
+      include_article_url = columns.include?("article_url")
+      article_url_label = I18n.t("cms.export.article_url")
+      if include_article_url
+        data = [ [resolve_page_name ] + columns + [article_url_label] ]
+      else
+        data = [ [resolve_page_name ] + columns ]
+      end
 
       pages.each do |page|
         column_values_hash = page.column_values.map { |cv| [cv.name, cv.export_csv_cell] }.to_h
         values = columns.map { |col| column_values_hash[col].to_s }
-        data << [page.name, page.full_url] + values
+        row = [page.name] + values
+        row << page.full_url if include_article_url
+        data << row
       end
 
       data

--- a/config/locales/article/ja.yml
+++ b/config/locales/article/ja.yml
@@ -31,6 +31,8 @@ ja:
       article/page: 記事リスト
       article/page_navi: 記事ナビゲーション
       article/search: 記事検索
+    export:
+      article_url: 記事URL
 
   cms_role:
     read_other_article_pages: ページの閲覧（全て）

--- a/config/locales/article/ja.yml
+++ b/config/locales/article/ja.yml
@@ -31,8 +31,6 @@ ja:
       article/page: 記事リスト
       article/page_navi: 記事ナビゲーション
       article/search: 記事検索
-    export:
-      article_url: 記事URL
 
   cms_role:
     read_other_article_pages: ページの閲覧（全て）


### PR DESCRIPTION
issue: #5298

## 概要
【CMS】記事/定型エクスポートのCSV、jsonの項目追加

## 変更内容
記事/定型エクスポート機能において、記事のURLをCSV形式およびJSON形式で出力できるように機能を改善

![スクリーンショット 2024-12-16 17 10 38（2）](https://github.com/user-attachments/assets/9a893f8e-a30f-477f-8eea-b9556dcf2b8f)

CSV形式
![スクリーンショット 2024-12-16 17 15 11（2）](https://github.com/user-attachments/assets/e36e2705-a524-402e-9f2b-c149bfaff702)

JSON形式
![スクリーンショット 2024-12-16 17 41 39（2）](https://github.com/user-attachments/assets/2b66ebbd-3ce0-41ef-b02e-20258e5859f0)


## その他
- 記事URLはデフォルトで表示されるので、出力の要否はサイト管理者が選択不可