### PR TITLE
[fix]issue-5448-map-script

### DIFF
--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -144,7 +144,7 @@ this.Googlemaps_Map = (function () {
       if (value['html']) {
         markerHtml = value['html'];
       } else if (value['name'] || value['text']) {
-        markerHtml = '<div class="marker-info">';
+        markerHtml = '<div class=" marker marker-info">';
         if (value['name']) {
           markerHtml += `<p class="marker-name">${value['name']}</p>`;
         }

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -315,8 +315,8 @@ this.Googlemaps_Map = (function () {
   };
 
   Googlemaps_Map.getMapsSearchHtml = function(lat, lng) {
-    var url = Googlemaps_Map.mapsSearchUrl + lat + "," + lng;
-    return '<p class="marker-link"><a href="' + url + '">' + <%= I18n.t("map.links.google_maps_search").to_json %> + '</a></p>';
+    const url = `${Googlemaps_Map.mapsSearchUrl}${lat},${lng}`;
+    return `<p class="marker-link"><a href="${url}"><%= I18n.t("map.links.google_maps_search") %></a></p>`;
   };
 
   return Googlemaps_Map;

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -160,12 +160,12 @@ this.Googlemaps_Map = (function () {
           markerHtml += '<p class="marker__name">' + name + '</p>';
         }
         if (text) {
-          markerHtml = '<div class="marker__explanation">';
+          markerHtml += '<div class="marker__explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              return markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
+              markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
             } else {
-              return markerHtml += '<p>' + this + '</p>';
+              markerHtml += '<p>' + this + '</p>';
             }
           });
           markerHtml += '</div>';

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -157,16 +157,18 @@ this.Googlemaps_Map = (function () {
       } else if (name || text) {
         markerHtml = '<div class="marker-info">';
         if (name) {
-          markerHtml += '<p>' + name + '</p>';
+          markerHtml += '<p class="marker__name">' + name + '</p>';
         }
         if (text) {
+          markerHtml = '<div class="marker__explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              return markerHtml += '<p><a href="' + this + '">' + this + '</a></p>';
+              return markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
             } else {
               return markerHtml += '<p>' + this + '</p>';
             }
           });
+          markerHtml += '</div>';
         }
         markerHtml += '</div>';
       }

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -131,6 +131,7 @@ this.Googlemaps_Map = (function () {
     var markerBounds;
     Googlemaps_Map.markers = markers;
     markerBounds = new google.maps.LatLngBounds();
+
     $.each(Googlemaps_Map.markers, function (id, value) {
       var name, text, html, markerHtml, pos, opts;
 
@@ -163,8 +164,6 @@ this.Googlemaps_Map = (function () {
           markerHtml += '<div class="marker__explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
-            } else {
               markerHtml += '<p>' + this + '</p>';
             }
           });
@@ -180,9 +179,6 @@ this.Googlemaps_Map = (function () {
         markerHtml += '</div>';
       }
 
-      if (Googlemaps_Map.showGoogleMapsSearch) {
-        markerHtml += Googlemaps_Map.getMapsSearchHtml(pos[1], pos[0]);
-      }
       if (markerHtml) {
         Googlemaps_Map.markers[id]["window"] = new google.maps.InfoWindow({
           content: markerHtml,

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -170,6 +170,13 @@ this.Googlemaps_Map = (function () {
           });
           markerHtml += '</div>';
         }
+      // Google マップのリンクをここで追加
+        if (Googlemaps_Map.showGoogleMapsSearch) {
+          markerHtml += '<p class="marker__link">' +
+                        '<a href="' + Googlemaps_Map.getMapsSearchHtml(pos[1], pos[0]) + '">' +
+                        'Googleマップで見る</a></p>';
+        }
+
         markerHtml += '</div>';
       }
 

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -124,49 +124,37 @@ this.Googlemaps_Map = (function () {
     }
   };
 
-  Googlemaps_Map.setMarkers = function (markers, opts) {
-    if (!opts) {
-      opts = {};
-    }
-    var markerBounds;
+  Googlemaps_Map.setMarkers = function (markers, opts = {}) {
+    let markerBounds;
     Googlemaps_Map.markers = markers;
     markerBounds = new google.maps.LatLngBounds();
 
-    $.each(Googlemaps_Map.markers, function (id, value) {
-      var name, text, html, markerHtml, pos, opts;
-
-      opts = {
-        position: new google.maps.LatLng(value["loc"][1], value["loc"][0]),
-        map: Googlemaps_Map.map
+    Object.entries(Googlemaps_Map.markers).forEach(([id, value]) => {
+      const position = new google.maps.LatLng(value["loc"][1], value["loc"][0]);
+      const markerOpts = {
+        position: position,
+        map: Googlemaps_Map.map,
+        icon: value["image"] || Googlemaps_Map.markerIcon
       };
-      if (value["image"]) {
-        opts["icon"] = value["image"];
-      } else {
-        opts["icon"] = Googlemaps_Map.markerIcon;
-      }
-      Googlemaps_Map.markers[id]["marker"] = new google.maps.Marker(opts);
-      markerBounds.extend(new google.maps.LatLng(value["loc"][1], value["loc"][0]));
 
-      name = value['name'];
-      text = value['text'];
-      html = value['html'];
-      pos = [value['loc'][0], value['loc'][1]];
+      Googlemaps_Map.markers[id]["marker"] = new google.maps.Marker(markerOpts);
+      markerBounds.extend(position);
 
-      markerHtml = "";
-      if (html) {
-        markerHtml = html;
-      } else if (name || text) {
+      let markerHtml = "";
+      if (value['html']) {
+        markerHtml = value['html'];
+      } else if (value['name'] || value['text']) {
         markerHtml = '<div class="marker-info">';
-        if (name) {
-          markerHtml += '<p class="marker-name">' + name + '</p>';
+        if (value['name']) {
+          markerHtml += `<p class="marker-name">${value['name']}</p>`;
         }
-        if (text) {
+        if (value['text']) {
           markerHtml += '<div class="marker-explanation">';
-          $.each(text.split(/[\r\n]+/), function () {
-            if (this.match(/^https?:\/\//)) {
-              markerHtml += '<p class="marker-link"><a href="' + this + '">' + this + '</a></p>';
+          value['text'].split(/[\r\n]+/).forEach(line => {
+            if (/^https?:\/\//.test(line)) {
+              markerHtml += `<p class="marker-link"><a href="${line}">${line}</a></p>`;
             } else {
-              markerHtml += '<p>' + this + '</p>';
+              markerHtml += `<p>${line}</p>`;
             }
           });
           markerHtml += '</div>';
@@ -175,7 +163,7 @@ this.Googlemaps_Map = (function () {
       }
 
       if (Googlemaps_Map.showGoogleMapsSearch) {
-        markerHtml += Googlemaps_Map.getMapsSearchHtml(pos[1], pos[0]);
+        markerHtml += Googlemaps_Map.getMapsSearchHtml(value['loc'][1], value['loc'][0]);
       }
 
       if (markerHtml) {
@@ -190,13 +178,11 @@ this.Googlemaps_Map = (function () {
     if (opts['markerCluster']) {
       Googlemaps_Map.renderMarkerCluster();
     }
-    Googlemaps_Map.adjustMarkerBounds(Googlemaps_Map.markers.length, markerBounds);
+    Googlemaps_Map.adjustMarkerBounds(Object.keys(Googlemaps_Map.markers).length, markerBounds);
   };
 
   Googlemaps_Map.renderMarkerCluster = function () {
-    var clusterMarkers = $.map(Googlemaps_Map.markers, function(data) {
-      return data.marker;
-    });
+    const clusterMarkers = Object.values(Googlemaps_Map.markers).map(data => data.marker);
     Googlemaps_Map.markerClusterer = new MarkerClusterer(Googlemaps_Map.map, clusterMarkers, {
       // averageCenter: true,
       ignoreHiddenMarkers: true,
@@ -204,24 +190,21 @@ this.Googlemaps_Map = (function () {
       // zoomOnClick: false,
     });
 
-    google.maps.event.addListener(Googlemaps_Map.map, 'zoom_changed', function() {
+    google.maps.event.addListener(Googlemaps_Map.map, 'zoom_changed', () => {
       Googlemaps_Map.closeMarkerClusterInfo();
     });
 
     ClusterIcon.prototype.triggerClusterClick = function(event) {
-      var cluster = this.cluster_;
-      var markers = cluster.getMarkers();
-      var positions = markers.map(function(marker) {
-        return marker.position.toUrlValue();
-      });
-      var clusterMarkers = Googlemaps_Map.markers.filter(function(marker) {
-        return positions.indexOf([marker.loc[1], marker.loc[0]].toString()) !== -1;
-      });
-      var contents = clusterMarkers.map(function(marker){
-        return marker.html;
-      });
-      var infoWindow = new google.maps.InfoWindow({
-        content: '<div class="marker-cluster-info">' + contents.join('') + '</div>',
+      const cluster = this.cluster_;
+      const markers = cluster.getMarkers();
+      const positions = markers.map(marker => marker.position.toUrlValue());
+
+      const clusterMarkers = Object.values(Googlemaps_Map.markers).filter(marker =>
+        positions.includes([marker.loc[1], marker.loc[0]].toString())
+      );
+      const contents = clusterMarkers.map(marker => marker.html || "");
+      const infoWindow = new google.maps.InfoWindow({
+        content: `<div class="marker-cluster-info">${contents.join('')}</div>`,
         position: markers[0].position,
         pixelOffset: new google.maps.Size(0, -15),
         markerType: 'cluster', // custom parameter

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -164,19 +164,18 @@ this.Googlemaps_Map = (function () {
           markerHtml += '<div class="marker__explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
+              markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
+            } else {
               markerHtml += '<p>' + this + '</p>';
             }
           });
           markerHtml += '</div>';
         }
-      // Google マップのリンクをここで追加
-        if (Googlemaps_Map.showGoogleMapsSearch) {
-          markerHtml += '<p class="marker__link">' +
-                        '<a href="' + Googlemaps_Map.getMapsSearchHtml(pos[1], pos[0]) + '">' +
-                        'Googleマップで見る</a></p>';
-        }
-
         markerHtml += '</div>';
+      }
+
+      if (Googlemaps_Map.showGoogleMapsSearch) {
+        markerHtml += Googlemaps_Map.getMapsSearchHtml(pos[1], pos[0]);
       }
 
       if (markerHtml) {

--- a/app/assets/javascripts/map/googlemaps/map.js.erb
+++ b/app/assets/javascripts/map/googlemaps/map.js.erb
@@ -158,13 +158,13 @@ this.Googlemaps_Map = (function () {
       } else if (name || text) {
         markerHtml = '<div class="marker-info">';
         if (name) {
-          markerHtml += '<p class="marker__name">' + name + '</p>';
+          markerHtml += '<p class="marker-name">' + name + '</p>';
         }
         if (text) {
-          markerHtml += '<div class="marker__explanation">';
+          markerHtml += '<div class="marker-explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
+              markerHtml += '<p class="marker-link"><a href="' + this + '">' + this + '</a></p>';
             } else {
               markerHtml += '<p>' + this + '</p>';
             }
@@ -333,7 +333,7 @@ this.Googlemaps_Map = (function () {
 
   Googlemaps_Map.getMapsSearchHtml = function(lat, lng) {
     var url = Googlemaps_Map.mapsSearchUrl + lat + "," + lng;
-    return '<p><a href="' + url + '">' + <%= I18n.t("map.links.google_maps_search").to_json %> + '</a></p>';
+    return '<p class="marker-link"><a href="' + url + '">' + <%= I18n.t("map.links.google_maps_search").to_json %> + '</a></p>';
   };
 
   return Googlemaps_Map;

--- a/app/assets/javascripts/map/openlayers/map.js.erb
+++ b/app/assets/javascripts/map/openlayers/map.js.erb
@@ -105,7 +105,7 @@ this.Openlayers_Map = (function () {
   };
 
   Openlayers_Map.prototype.initPopup = function () {
-    $("body").append('<div id="marker-popup"><div class="closer"></div><div class="content"></div></div>');
+    $("body").append('<div id="marker-popup"><div class="closer"></div><div class="content marker"></div></div>');
     this.popup = $('#marker-popup');
     this.popup.hide();
     this.popupOverlay = new ol.Overlay({
@@ -265,7 +265,6 @@ this.Openlayers_Map = (function () {
         markerHtml = html;
       } else if (name || text) {
         markerHtml = `
-          <div class="content marker">
             ${name ? `<p class="marker-name">${name}</p>` : ''}
             ${text ? renderMarkerExplanation(text) : ''}
         `;

--- a/app/assets/javascripts/map/openlayers/map.js.erb
+++ b/app/assets/javascripts/map/openlayers/map.js.erb
@@ -251,60 +251,62 @@ this.Openlayers_Map = (function () {
   };
 
   Openlayers_Map.prototype.renderMarkers = function (markers) {
-    var feature, iconSrc, id, marker, markerHtml, name, pos, style, text, html;
+    markers.forEach(marker => {
+    const iconSrc = marker['image'] || this.markerIcon || '/assets/img/openlayers/marker1.png';
+    const style = this.createMarkerStyle(iconSrc);
 
-    for (id = 0; id < markers.length; id++) {
-      marker = markers[id];
-      iconSrc = marker['image'] || this.markerIcon || '/assets/img/openlayers/marker1.png';
-      style = this.createMarkerStyle(iconSrc);
+    const name = marker['name'];
+    const text = marker['text'];
+    const html = marker['html'];
+    const pos = [marker['loc'][0], marker['loc'][1]];
 
-      name = marker['name'];
-      text = marker['text'];
-      html = marker['html'];
-      pos = [marker['loc'][0], marker['loc'][1]];
-
-      markerHtml = "";
+    let markerHtml = "";
       if (html) {
         markerHtml = html;
       } else if (name || text) {
-        markerHtml = '<div class="content marker">';
-        if (name) {
-          markerHtml += '<p class="marker-name">' + name + '</p>';
-        }
-        if (text) {
-          markerHtml += '<div class="marker-explanation">';
-          $.each(text.split(/[\r\n]+/), function () {
-            if (this.match(/^https?:\/\//)) {
-              markerHtml += '<p class="marker-link"><a href="' + this + '">' + this + '</a></p>';
-            } else {
-              markerHtml += '<p>' + this + '</p>';
-            }
-          });
-          markerHtml += '</div>';
-        }
+        markerHtml = `
+          <div class="content marker">
+            ${name ? `<p class="marker-name">${name}</p>` : ''}
+            ${text ? renderMarkerExplanation(text) : ''}
+        `;
       }
       if (this.showGoogleMapsSearch) {
         markerHtml += Googlemaps_Map.getMapsSearchHtml(pos[1], pos[0]);
       }
 
-      feature = new ol.Feature({
+      const feature = new ol.Feature({
         geometry: new ol.geom.Point(ol.proj.transform(pos, "EPSG:4326", "EPSG:3857")),
         markerId: marker['id'],
         markerHtml: markerHtml,
         iconSrc: iconSrc,
         category: marker['category']
       });
+
       feature.setStyle(style);
+
       if (!this.markerLayer) {
         this.markerLayer = new ol.layer.Vector({
           source: new ol.source.Vector()
         });
-        this.map.addLayer(this.markerLayer)
+        this.map.addLayer(this.markerLayer);
       }
-      this.markerLayer.getSource().addFeature(feature)
-    }
-    markerHtml += '</div>';
+      this.markerLayer.getSource().addFeature(feature);
+    });
   };
+
+  function renderMarkerExplanation(text) {
+    return `
+      <div class="marker-explanation">
+        ${text.split(/[\r\n]+/).map(line => {
+          if (/^https?:\/\//.test(line)) {
+            return `<p class="marker-link"><a href="${line}">${line}</a></p>`;
+          } else {
+            return `<p>${line}</p>`;
+          }
+        }).join('')}
+      </div>
+    `;
+  }
 
   Openlayers_Map.prototype.resize = function () {
     if (!this.markerLayer) {

--- a/app/assets/javascripts/map/openlayers/map.js.erb
+++ b/app/assets/javascripts/map/openlayers/map.js.erb
@@ -267,17 +267,20 @@ this.Openlayers_Map = (function () {
       if (html) {
         markerHtml = html;
       } else if (name || text) {
+        markerHtml = '<div class="marker-info">';
         if (name) {
-          markerHtml += '<p>' + name + '</p>';
+          markerHtml += '<p class="marker__name">' + name + '</p>';
         }
         if (text) {
+          markerHtml += '<div class="marker__explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              markerHtml += '<p><a href="' + this + '">' + this + '</a></p>';
+              markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
             } else {
               markerHtml += '<p>' + this + '</p>';
             }
           });
+          markerHtml += '</div>';
         }
       }
       if (this.showGoogleMapsSearch) {
@@ -300,6 +303,7 @@ this.Openlayers_Map = (function () {
       }
       this.markerLayer.getSource().addFeature(feature)
     }
+    markerHtml += '</div>';
   };
 
   Openlayers_Map.prototype.resize = function () {

--- a/app/assets/javascripts/map/openlayers/map.js.erb
+++ b/app/assets/javascripts/map/openlayers/map.js.erb
@@ -267,15 +267,15 @@ this.Openlayers_Map = (function () {
       if (html) {
         markerHtml = html;
       } else if (name || text) {
-        markerHtml = '<div class="marker-info">';
+        markerHtml = '<div class="content marker">';
         if (name) {
-          markerHtml += '<p class="marker__name">' + name + '</p>';
+          markerHtml += '<p class="marker-name">' + name + '</p>';
         }
         if (text) {
-          markerHtml += '<div class="marker__explanation">';
+          markerHtml += '<div class="marker-explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
+              markerHtml += '<p class="marker-link"><a href="' + this + '">' + this + '</a></p>';
             } else {
               markerHtml += '<p>' + this + '</p>';
             }

--- a/public/assets/map/googlemaps/map.js
+++ b/public/assets/map/googlemaps/map.js
@@ -157,14 +157,15 @@ this.Googlemaps_Map = (function () {
       } else if (name || text) {
         markerHtml = '<div class="marker-info">';
         if (name) {
-          markerHtml += '<p>' + name + '</p>';
+          markerHtml += '<p class="marker__name">' + name + '</p>';
         }
         if (text) {
-          $.each(text.split(/[\r\n]+/), function () {
-            if (this.match(/^https?:\/\//)) {
-              return markerHtml += '<p><a href="' + this + '">' + this + '</a></p>';
+          markerHtml += '<div class="marker__explanation">';
+          text.split(/[\r\n]+/).forEach(function (line) {
+            if (line.match(/^https?:\/\//)) {
+              markerHtml += '<p><a href="' + line + '">' + line + '</a></p>';
             } else {
-              return markerHtml += '<p>' + this + '</p>';
+              markerHtml += '<p>' + line + '</p>';
             }
           });
         }

--- a/public/assets/map/googlemaps/map.js
+++ b/public/assets/map/googlemaps/map.js
@@ -157,13 +157,12 @@ this.Googlemaps_Map = (function () {
       } else if (name || text) {
         markerHtml = '<div class="marker-info">';
         if (name) {
-          markerHtml += '<p class=marker__name>' + name + '</p>';
+          markerHtml += '<p>' + name + '</p>';
         }
         if (text) {
-          markerHtml = '<div class="marker__explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              return markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
+              return markerHtml += '<p><a href="' + this + '">' + this + '</a></p>';
             } else {
               return markerHtml += '<p>' + this + '</p>';
             }

--- a/public/assets/map/googlemaps/map.js
+++ b/public/assets/map/googlemaps/map.js
@@ -157,16 +157,18 @@ this.Googlemaps_Map = (function () {
       } else if (name || text) {
         markerHtml = '<div class="marker-info">';
         if (name) {
-          markerHtml += '<p>' + name + '</p>';
+          markerHtml += '<p class=marker__name>' + name + '</p>';
         }
         if (text) {
+          markerHtml = '<div class="marker__explanation">';
           $.each(text.split(/[\r\n]+/), function () {
             if (this.match(/^https?:\/\//)) {
-              return markerHtml += '<p><a href="' + this + '">' + this + '</a></p>';
+              return markerHtml += '<p class="marker__link"><a href="' + this + '">' + this + '</a></p>';
             } else {
               return markerHtml += '<p>' + this + '</p>';
             }
           });
+          markerHtml += '</div>';
         }
         markerHtml += '</div>';
       }

--- a/public/assets/map/googlemaps/map.js
+++ b/public/assets/map/googlemaps/map.js
@@ -157,24 +157,17 @@ this.Googlemaps_Map = (function () {
       } else if (name || text) {
         markerHtml = '<div class="marker-info">';
         if (name) {
-          markerHtml += '<p class="marker__name">' + name + '</p>';
+          markerHtml += '<p>' + name + '</p>';
         }
         if (text) {
-          markerHtml += '<div class="marker__explanation">';
-          text.split(/[\r\n]+/).forEach(function (line) {
-            if (line.match(/^https?:\/\//)) {
-              markerHtml += '<p><a href="' + line + '">' + line + '</a></p>';
+          $.each(text.split(/[\r\n]+/), function () {
+            if (this.match(/^https?:\/\//)) {
+              return markerHtml += '<p><a href="' + this + '">' + this + '</a></p>';
             } else {
-              markerHtml += '<p>' + line + '</p>';
+              return markerHtml += '<p>' + this + '</p>';
             }
           });
-          markerHtml += '</div>';
         }
-        // Googleマップリンク
-        markerHtml += '<p class="marker__link">';
-        markerHtml += '<a href="https://www.google.co.jp/maps/search/' + pos[1] + ',' + pos[0] + '">Googleマップで見る</a>';
-        markerHtml += '</p>';
-
         markerHtml += '</div>';
       }
 

--- a/public/assets/map/googlemaps/map.js
+++ b/public/assets/map/googlemaps/map.js
@@ -167,7 +167,6 @@ this.Googlemaps_Map = (function () {
               return markerHtml += '<p>' + this + '</p>';
             }
           });
-          markerHtml += '</div>';
         }
         markerHtml += '</div>';
       }

--- a/public/assets/map/googlemaps/map.js
+++ b/public/assets/map/googlemaps/map.js
@@ -168,7 +168,13 @@ this.Googlemaps_Map = (function () {
               markerHtml += '<p>' + line + '</p>';
             }
           });
+          markerHtml += '</div>';
         }
+        // Googleマップリンク
+        markerHtml += '<p class="marker__link">';
+        markerHtml += '<a href="https://www.google.co.jp/maps/search/' + pos[1] + ',' + pos[0] + '">Googleマップで見る</a>';
+        markerHtml += '</p>';
+
         markerHtml += '</div>';
       }
 


### PR DESCRIPTION
issue: #5448 

## 概要
【CMS】記事詳細の地図のスポットアイコンクリック時のポップアップ内HTML構造の変更

## 変更内容
以下の表示になるようにHTML構造を変更

- Googleマップ
```html
<div class=" marker marker-info">
  <p class="marker-name">マーカー名マーカー名マーカー名マーカー名</p>
  <div class="marker-explanation">
    <p>説明説明説明説明説明</p>
    <p>説明説明説明説明説明説明説明説明説明説明説明説明説明</p>
    <p>説明説明説明</p>
  </div>
</div>
<p class="marker-link"><a href="https://www.google.co.jp/maps/search/35.400709,135.104301">Googleマップで見る</a></p>
```
![スクリーンショット 2024-12-19 15 12 14（2）](https://github.com/user-attachments/assets/f05d34f3-9333-4202-9833-729bf48ffcd4)



- Openlayers
```html
<div class="content marker">
  <p class="marker-name">マーカー名マーカー名マーカー名マーカー名</p>
  <div class="marker-explanation">
    <p>説明説明説明説明説明</p>
    <p>説明説明説明説明説明説明説明説明説明説明説明説明説明</p>
    <p>説明説明説明</p>
  </div>
  <p class="marker-link"><a href="https://www.google.co.jp/maps/search/35.400709,135.104301">Googleマップで見る</a></p>
</div>
```
![スクリーンショット 2024-12-19 14 48 08（2）](https://github.com/user-attachments/assets/c32072f8-d972-45f9-873b-df9be573c1b0)

## 注意点
- "marker__link"要素の配置がマップの形式によって異なる
　- Googleマップ："marker marker-info"クラスの**外**
　- Openlayers："content marker"クラス**内**
- google.maps.Marker から google.maps.marker.AdvancedMarkerElement への移行予定であるが今回は既存コードへの影響を考慮し、google.maps.Markerで実装