### PR TITLE
[fix][gws] スケジュールのカレンダーのヘッダーに曜日が表示されない問題の修正

### DIFF
--- a/app/assets/javascripts/gws/notice/lib/calendar.js
+++ b/app/assets/javascripts/gws/notice/lib/calendar.js
@@ -102,9 +102,13 @@ SS.ready(function() {
         slotLabelFormat: 'HH:mm',
         startParam: 's[start]',
         timeFormat: 'HH:mm',
+        // '(' と ')' とで囲むと「2025年 1月 26日（日） — 2025年 2月 1日（土）」のような表示になり、
+        // '(' と ')' とで囲まない場合、共通部分が collapse され「2025年 1月 26日（日） — 2月 1日（土）」のような表示になる。
+        // しかし、日本語の場合、FullCalendarの formatRange バグ（？）で、うまく collapse されないので、week の場合は collapse 禁止、それ以外は collapse 許可。
+        // 参考: https://fullcalendar.io/docs/v3/formatRange
         titleFormat: {
           month: SS.convertDateTimeFormat(i18next.t('gws/schedule.calendar.titleFormat.month')),
-          week: SS.convertDateTimeFormat(i18next.t('gws/schedule.calendar.titleFormat.week'))
+          week: '(' + SS.convertDateTimeFormat(i18next.t('gws/schedule.calendar.titleFormat.week')) + ')'
         },
         loading: function (isLoading, _view) {
           var target = $(selector).hasClass("fc-list-format") ? $(this).find('.fc-view') : $(this).find('.fc-widget-content').eq(0)

--- a/app/assets/javascripts/gws/schedule/lib/calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/calendar.js
@@ -134,9 +134,13 @@ SS.ready(function() {
         slotLabelFormat: 'HH:mm',
         startParam: 's[start]',
         timeFormat: 'HH:mm',
+        // '(' と ')' とで囲むと「2025年 1月 26日（日） — 2025年 2月 1日（土）」のような表示になり、
+        // '(' と ')' とで囲まない場合、共通部分が collapse され「2025年 1月 26日（日） — 2月 1日（土）」のような表示になる。
+        // しかし、日本語の場合、FullCalendarの formatRange バグ（？）で、うまく collapse されないので、week の場合は collapse 禁止、それ以外は collapse 許可。
+        // 参考: https://fullcalendar.io/docs/v3/formatRange
         titleFormat: {
           month: SS.convertDateTimeFormat(i18next.t('gws/schedule.calendar.titleFormat.month')),
-          week: SS.convertDateTimeFormat(i18next.t('gws/schedule.calendar.titleFormat.week')),
+          week: '(' + SS.convertDateTimeFormat(i18next.t('gws/schedule.calendar.titleFormat.week')) + ')',
           day: SS.convertDateTimeFormat(i18next.t('gws/schedule.calendar.titleFormat.day'))
         },
         loading: function (isLoading, _view) {

--- a/app/assets/javascripts/ss/lib/base.js.erb
+++ b/app/assets/javascripts/ss/lib/base.js.erb
@@ -598,10 +598,10 @@ this.SS = (function () {
         format = "default"
       }
       format = i18next.t("time.formats." + format, format);
-      format = SS.convertDateTimeFormat(format);
     } else {
       format = SS.DEFAULT_TIME_FORMAT;
     }
+    format = SS.convertDateTimeFormat(format);
 
     return moment(time).format(format);
   };
@@ -615,10 +615,10 @@ this.SS = (function () {
         format = "default"
       }
       format = i18next.t("date.formats." + format, format);
-      format = SS.convertDateTimeFormat(format);
     } else {
       format = SS.DEFAULT_DATE_FORMAT;
     }
+    format = SS.convertDateTimeFormat(format);
 
     return moment(date).format(format);
   };

--- a/app/assets/javascripts/ss/lib/base.js.erb
+++ b/app/assets/javascripts/ss/lib/base.js.erb
@@ -573,6 +573,10 @@ this.SS = (function () {
       from = new RegExp(from, "g");
       format = format.replace(from, to);
     });
+
+    // "(" のような文字をエスケープする（moment のエスケープはエスケープしたい文字列を "[" と "]" で囲む）
+    format = format.replaceAll(/[^A-Za-z ,/:]+/g, function(match) { return "[" + match + "]"; });
+
     return format;
   };
 

--- a/config/locales/gws/schedule/en.yml
+++ b/config/locales/gws/schedule/en.yml
@@ -36,7 +36,7 @@ en:
         withAbsence: Absence
       titleFormat:
         month: "%m/%Y"
-        week: "(%a, %m/%d/%Y)"
+        week: "%a, %m/%d/%Y"
         day: "%a, %m/%d/%Y"
       columnFormat:
         month: "%a"

--- a/config/locales/gws/schedule/ja.yml
+++ b/config/locales/gws/schedule/ja.yml
@@ -36,7 +36,7 @@ ja:
         withAbsence: 欠席表示
       titleFormat:
         month: "%Y年 %1m月"
-        week: "(%Y年 %1m月 %1d日（%a）)"
+        week: "%Y年 %1m月 %1d日（%a）"
         day: "%Y年 %1m月 %1d日（%a）"
       columnFormat:
         month: "%a"

--- a/spec/features/ss/js_date_time_format_spec.rb
+++ b/spec/features/ss/js_date_time_format_spec.rb
@@ -11,6 +11,7 @@ describe "js_date_time_format", type: :feature, dbscope: :example, js: true, loc
 
     it do
       visit sns_login_path
+      wait_for_js_ready
 
       '%Y-%1m-%1d (%a)'.tap do |format|
         val = page.evaluate_script(script, now.iso8601, format)
@@ -62,6 +63,7 @@ describe "js_date_time_format", type: :feature, dbscope: :example, js: true, loc
 
     it do
       visit sns_login_path
+      wait_for_js_ready
 
       val = page.evaluate_script(script, time)
       expect(val).to eq I18n.l(time.in_time_zone)
@@ -104,6 +106,7 @@ describe "js_date_time_format", type: :feature, dbscope: :example, js: true, loc
 
     it do
       visit sns_login_path
+      wait_for_js_ready
 
       val = page.evaluate_script(script, time)
       expect(val).to eq I18n.l(time.in_time_zone.to_date)


### PR DESCRIPTION
issue: n/a

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

スケジュールのカレンダーのヘッダーに、かつて曜日が表示されていた。
ロケールの定義を確認しても曜日が表示されるように設定されている。
にもかかわらず、現在は曜日が表示されない。

## 変更内容

曜日が表示されるように修正した。

## その他

SS.formatTime / SS.formatDate に不具合があったので、ついでに修正した。