### PR TITLE
[modify] CI復旧: imagemagick を明示的にインストール

### DIFF
--- a/.github/workflows/ruby-3.1.yml
+++ b/.github/workflows/ruby-3.1.yml
@@ -78,8 +78,8 @@ jobs:
           echo "CONTAINER_ID=$container_id" >> $GITHUB_OUTPUT
       - name: Install pre requisites
         run: |
-          sudo apt-get update
-          sudo apt-get -y install libmagick++-dev sox libsox-dev lame libmp3lame-dev mecab libmecab-dev mecab-ipadic-utf8 open-jtalk open-jtalk-mecab-naist-jdic graphicsmagick
+          sudo apt update
+          sudo apt -y install imagemagick libmagick++-dev sox libsox-dev lame libmp3lame-dev mecab libmecab-dev mecab-ipadic-utf8 open-jtalk open-jtalk-mecab-naist-jdic graphicsmagick
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -80,8 +80,8 @@ jobs:
           echo "CONTAINER_ID=$container_id" >> $GITHUB_OUTPUT
       - name: Install pre requisites
         run: |
-          sudo apt-get update
-          sudo apt-get -y install libmagick++-dev sox libsox-dev lame libmp3lame-dev mecab libmecab-dev mecab-ipadic-utf8 open-jtalk open-jtalk-mecab-naist-jdic graphicsmagick
+          sudo apt update
+          sudo apt -y install imagemagick libmagick++-dev sox libsox-dev lame libmp3lame-dev mecab libmecab-dev mecab-ipadic-utf8 open-jtalk open-jtalk-mecab-naist-jdic graphicsmagick
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
issue: n/a

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

captcha 系のテストが失敗するようになったので修正

## 変更内容

mini_magick は convert コマンドを実行するが、ubuntu 24.04 から convert コマンドが標準でインストールされなくなった。
明示的にインストールするように修正。
