### PR TITLE
[modify] gws/memo_notice : edit_gws_memo_notice_user_setting permission

### DIFF
--- a/app/controllers/gws/memo/notice_user_settings_controller.rb
+++ b/app/controllers/gws/memo/notice_user_settings_controller.rb
@@ -13,7 +13,18 @@ class Gws::Memo::NoticeUserSettingsController < ApplicationController
     fields << :send_notice_mail_addresses
   end
 
+  def show
+    raise "403" if !@cur_user.gws_role_permit_any?(@cur_site, :edit_gws_memo_notice_user_setting)
+    render
+  end
+
+  def edit
+    raise "403" if !@cur_user.gws_role_permit_any?(@cur_site, :edit_gws_memo_notice_user_setting)
+    render
+  end
+
   def update
+    raise "403" if !@cur_user.gws_role_permit_any?(@cur_site, :edit_gws_memo_notice_user_setting)
     @item.attributes = get_params
     render_update @item.save
   end

--- a/app/models/gws/initializer.rb
+++ b/app/models/gws/initializer.rb
@@ -43,6 +43,7 @@ module Gws
 
     Gws::Role.permission :edit_gws_user_profile, module_name: 'gws/user_profile'
     Gws::Role.permission :edit_password_gws_user_profile, module_name: 'gws/user_profile'
+    Gws::Role.permission :edit_gws_memo_notice_user_setting, module_name: 'gws/user_profile'
 
     SS::File.model "gws/file", Gws::File
     SS::File.model "share/file", Gws::Share::File

--- a/app/views/gws/user_settings/_navi.html.erb
+++ b/app/views/gws/user_settings/_navi.html.erb
@@ -11,7 +11,9 @@
     <h3><%= link_to @cur_site.menu_presence_label || t('mongoid.models.gws/presence'), gws_presence_user_setting_path %></h3>
   <% end %>
 
-  <h3><%= link_to t('modules.addons.gws/system/notice_setting'), gws_memo_notice_user_settings_path %></h3>
+  <% if @cur_user.gws_role_permit_any?(@cur_site, :edit_gws_memo_notice_user_setting) %>
+    <h3><%= link_to t('modules.addons.gws/system/notice_setting'), gws_memo_notice_user_settings_path %></h3>
+  <% end %>
 
   <h3><%= link_to t('modules.addons.ss/locale_setting'), gws_user_locale_setting_path %></h3>
 </nav>

--- a/config/locales/gws/en.yml
+++ b/config/locales/gws/en.yml
@@ -150,6 +150,7 @@ en:
     edit_gws_personal_addresses: Use of personal address books
     edit_gws_user_profile: Edit user profile
     edit_password_gws_user_profile: Edit password of user profile
+    edit_gws_memo_notice_user_setting: Use notice settings of user profile
 
   modules:
     gws: Standard

--- a/config/locales/gws/ja.yml
+++ b/config/locales/gws/ja.yml
@@ -150,6 +150,7 @@ ja:
     edit_gws_personal_addresses: 個人アドレス帳の利用
     edit_gws_user_profile: プロフィールの編集
     edit_password_gws_user_profile: プロフィールのパスワード変更
+    edit_gws_memo_notice_user_setting: プロフィールの通知設定の利用
 
   modules:
     gws: 標準機能

--- a/lib/migrations/gws/20250124000000_memo_notice_user_setting_permissions.rb
+++ b/lib/migrations/gws/20250124000000_memo_notice_user_setting_permissions.rb
@@ -1,0 +1,14 @@
+class SS::Migration20250124000000
+  include SS::Migration::Base
+
+  def change
+    Gws::Role.each do |item|
+      permissions = item.permissions.to_a
+      next if permissions.include?("edit_gws_memo_notice_user_setting")
+
+      permissions << "edit_gws_memo_notice_user_setting"
+      item.permissions = permissions
+      item.update
+    end
+  end
+end

--- a/spec/features/gws/memo/notice_user_settings/basic_spec.rb
+++ b/spec/features/gws/memo/notice_user_settings/basic_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'gws_memo_notice_user_settings', type: :feature, dbscope: :example do
+describe 'gws_memo_notice_user_settings', type: :feature, dbscope: :example, js: true do
   context "basic crud" do
     let!(:site) { gws_site }
     let!(:show_path) { gws_memo_notice_user_settings_path site }
@@ -23,6 +23,48 @@ describe 'gws_memo_notice_user_settings', type: :feature, dbscope: :example do
       expect(current_path).to eq show_path
       wait_for_notice I18n.t('ss.notice.saved')
       expect(page).to have_content(gws_user.email)
+    end
+  end
+
+  context "permissions" do
+    let!(:site) { gws_site }
+    let!(:user1) { gws_user }
+    let!(:user2) { create :gws_user, group_ids: user1.group_ids }
+
+    context "gws_user" do
+      before { login_user(user1) }
+
+      it "#show" do
+        visit gws_user_profile_path(site)
+        within "#navi" do
+          expect(page).to have_link I18n.t('sns.profile')
+          expect(page).to have_link I18n.t('modules.addons.gws/system/notice_setting')
+        end
+
+        visit gws_memo_notice_user_settings_path(site)
+        expect(page).to have_no_title("403")
+
+        visit edit_gws_memo_notice_user_settings_path(site)
+        expect(page).to have_no_title("403")
+      end
+    end
+
+    context "user2" do
+      before { login_user(user2) }
+
+      it "#show" do
+        visit gws_user_profile_path(site)
+        within "#navi" do
+          expect(page).to have_link I18n.t('sns.profile')
+          expect(page).to have_no_link I18n.t('modules.addons.gws/system/notice_setting')
+        end
+
+        visit gws_memo_notice_user_settings_path(site)
+        expect(page).to have_title("403")
+
+        visit edit_gws_memo_notice_user_settings_path(site)
+        expect(page).to have_title("403")
+      end
     end
   end
 end

--- a/spec/lib/migrations/gws/20250124000000_memo_notice_user_setting_permissions_spec.rb
+++ b/spec/lib/migrations/gws/20250124000000_memo_notice_user_setting_permissions_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require Rails.root.join("lib/migrations/gws/20250124000000_memo_notice_user_setting_permissions.rb")
+
+RSpec.describe SS::Migration20250124000000, dbscope: :example do
+  let!(:site) { gws_site }
+  let!(:user) { gws_user }
+
+  let!(:role1) { gws_user.gws_roles.first }
+  let!(:role2) { create :gws_role, permissions: [] }
+
+  let!(:role1_permissions) { role1.permissions }
+  let!(:role2_permissions) { %w(edit_gws_memo_notice_user_setting) }
+
+  it do
+    expect(role1.permissions).to eq role1_permissions
+    expect(role2.permissions).to eq []
+
+    described_class.new.change
+
+    role1.reload
+    role2.reload
+
+    expect(role1.permissions).to eq role1_permissions
+    expect(role2.permissions).to eq role2_permissions
+  end
+end


### PR DESCRIPTION
issue: n/a

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

GWSプロフィールの左ナビにある通知設定を非表示にできるようにする為の修正
権限「プロフィールの通知設定の利用」edit_gws_memo_notice_user_setting を追加
この権限を追加するマイグレーションを作成
