### PR TITLE
[modify] gws/notice : default_comment_state

### DIFF
--- a/app/models/concerns/gws/addon/notice/comment_setting.rb
+++ b/app/models/concerns/gws/addon/notice/comment_setting.rb
@@ -3,7 +3,7 @@ module Gws::Addon::Notice::CommentSetting
   extend SS::Addon
 
   included do
-    field :comment_state, type: String
+    field :comment_state, type: String, default: ->{ self.class.default_comment_state }
     permit_params :comment_state
     validates :comment_state, inclusion: { in: %w(disabled enabled), allow_blank: true }
   end
@@ -16,5 +16,11 @@ module Gws::Addon::Notice::CommentSetting
 
   def comment_state_enabled?
     comment_state == 'enabled'
+  end
+
+  module ClassMethods
+    def default_comment_state
+      SS.config.gws.notice_comment_setting["comment_state"]
+    end
   end
 end

--- a/config/defaults/gws.yml
+++ b/config/defaults/gws.yml
@@ -255,6 +255,9 @@ production: &production
     #  - "Gws::Schedule::Plan"
     #  - "Gws::Schedule::Todo"
 
+  notice_comment_setting:
+    comment_state: disabled
+
   aggregation:
     first_activation_date: "2000/1/1"
 

--- a/spec/features/gws/notices/comment_state_spec.rb
+++ b/spec/features/gws/notices/comment_state_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe "gws_notices", type: :feature, dbscope: :example, js: true do
+  let(:site) { gws_site }
+  let(:folder) { create(:gws_notice_folder) }
+  let(:admin_index_path) { gws_notice_editables_path(site: site, folder_id: folder, category_id: '-') }
+
+  before { login_gws_user }
+
+  context "comment_state disabled" do
+    it "#new" do
+      visit admin_index_path
+      within "#menu" do
+        click_on I18n.t("ss.links.new")
+      end
+      within "form#item-form" do
+        fill_in "item[name]", with: unique_id
+        click_button I18n.t('ss.buttons.save')
+      end
+      wait_for_notice I18n.t("ss.notice.saved")
+
+      within "#addon-gws-agents-addons-notice-comment_setting" do
+        expect(page).to have_css("dd", text: I18n.t("ss.options.state.disabled"))
+      end
+    end
+  end
+
+  context "comment_state enabled" do
+    before do
+      @notice_comment_setting = SS.config.gws.notice_comment_setting
+      SS.config.replace_value_at(:gws, :notice_comment_setting, { "comment_state" => "enabled" })
+    end
+
+    after do
+      SS.config.replace_value_at(:gws, :notice_comment_setting, @notice_comment_setting)
+    end
+
+    it "#new" do
+      visit admin_index_path
+      within "#menu" do
+        click_on I18n.t("ss.links.new")
+      end
+      within "form#item-form" do
+        fill_in "item[name]", with: unique_id
+        click_button I18n.t('ss.buttons.save')
+      end
+      wait_for_notice I18n.t("ss.notice.saved")
+
+      within "#addon-gws-agents-addons-notice-comment_setting" do
+        expect(page).to have_css("dd", text: I18n.t("ss.options.state.enabled"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
issue: n/a

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

グループウェアお知らせの投稿作成時にコメント投稿をデフォルトで有効できるように。
yml に設定を追加。