### PR TITLE
[fix]gws/facility-items-export-error

### DIFF
--- a/config/locales/gws/facility/en.yml
+++ b/config/locales/gws/facility/en.yml
@@ -78,7 +78,7 @@ en:
       type_datas:
         plain: Text format
         markdown: Markdown format
-
+        cke: Formatted format
       columns:
         id: "Additional input %{n} ID"
         type: "Additional input %{n} Input items"

--- a/config/locales/gws/facility/en.yml
+++ b/config/locales/gws/facility/en.yml
@@ -79,6 +79,7 @@ en:
         plain: Text format
         markdown: Markdown format
         cke: Formatted format
+
       columns:
         id: "Additional input %{n} ID"
         type: "Additional input %{n} Input items"

--- a/config/locales/gws/facility/en.yml
+++ b/config/locales/gws/facility/en.yml
@@ -78,7 +78,7 @@ en:
       type_datas:
         plain: Text format
         markdown: Markdown format
-        cke: Formatted format
+        cke: Formatted
 
       columns:
         id: "Additional input %{n} ID"

--- a/config/locales/gws/facility/ja.yml
+++ b/config/locales/gws/facility/ja.yml
@@ -78,6 +78,7 @@ ja:
       type_datas:
         plain: テキスト形式
         markdown: Markdown形式
+        cke: 書式編集
 
       columns:
         id: "追加入力%{n}ID"


### PR DESCRIPTION
issue: #xxxx

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
GWS > スケジュール > 設備設定 のエクスポート機能
書式編集 = `Translation missing: ja.gws/facility/item.csv.type_datas.cke`エラーの修正

[gws_items_1738633770.csv](https://github.com/user-attachments/files/18702092/gws_items_1738633770.csv)

## 変更内容
下記ファイルにロケールを追加
`config/locales/gws/facility/en.yml`
`config/locales/gws/facility/ja.yml`
