### PR TITLE
[CMS]  承認申請時の更新履歴と操作履歴の改善

### DIFF
--- a/app/controllers/workflow/pages_controller.rb
+++ b/app/controllers/workflow/pages_controller.rb
@@ -3,8 +3,10 @@ class Workflow::PagesController < ApplicationController
   include Cms::CrudFilter
 
   before_action :set_item, only: %i[request_update restart_update approve_update pull_up_update remand_update branch_create]
-  after_action :create_history_log, only: %i[request_update restart_update approve_update pull_up_update remand_update
-   request_cancel branch_update]
+
+  %i[request_update restart_update approve_update pull_up_update remand_update request_cancel branch_update].tap do |names|
+    after_action :create_history_log, only: names
+  end
 
   private
 

--- a/app/controllers/workflow/pages_controller.rb
+++ b/app/controllers/workflow/pages_controller.rb
@@ -3,6 +3,8 @@ class Workflow::PagesController < ApplicationController
   include Cms::CrudFilter
 
   before_action :set_item, only: %i[request_update restart_update approve_update pull_up_update remand_update branch_create]
+  after_action :create_history_log, only: %i[request_update restart_update approve_update pull_up_update remand_update
+   request_cancel branch_update]
 
   private
 
@@ -18,6 +20,15 @@ class Workflow::PagesController < ApplicationController
 
   def fix_params
     { cur_user: @cur_user, cur_site: @cur_site, cur_node: false }
+  end
+
+  def create_history_log
+    # レスポンスの status コードが 200 か 422 の場合、操作履歴が作られないので、手動で作成
+    self.class.log_class.create_log!(
+      request, response,
+      controller: params[:controller], action: params[:action],
+      cur_site: @cur_site, cur_user: @cur_user, item: @item
+    ) rescue nil
   end
 
   def request_approval

--- a/app/controllers/workflow/pages_controller.rb
+++ b/app/controllers/workflow/pages_controller.rb
@@ -31,7 +31,8 @@ class Workflow::PagesController < ApplicationController
 
     @item.set_workflow_approver_state_to_request
     @item.record_timestamps = false
-    @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
+    # 更新履歴が作成されるように変更する
+    # @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
     @item.save
   end
 
@@ -97,6 +98,7 @@ class Workflow::PagesController < ApplicationController
     end
 
     @item.record_timestamps = false
+    # 一時保存のため、履歴を作成しないようにする（履歴に記録したい保存は request_approval で行われる）
     @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
     @item.approved = nil
     @item.workflow_user_id = @cur_user.id
@@ -109,8 +111,10 @@ class Workflow::PagesController < ApplicationController
     @item.workflow_required_counts = params[:workflow_required_counts]
     @item.workflow_current_circulation_level = 0
     @item.workflow_circulations = params[:workflow_circulations]
+    result = @item.save
+    @item.skip_history_backup = false if @item.respond_to?(:skip_history_backup)
 
-    if @item.save
+    if result
       request_approval
       render json: create_success_response
     else
@@ -122,6 +126,7 @@ class Workflow::PagesController < ApplicationController
     raise "403" unless @item.allowed?(:edit, @cur_user)
 
     @item.record_timestamps = false
+    # 一時保存のため、履歴を作成しないようにする（履歴に記録したい保存は request_approval で行われる）
     @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
     @item.approved = nil
     @item.workflow_user_id = @cur_user.id
@@ -142,8 +147,10 @@ class Workflow::PagesController < ApplicationController
       circulation[:comment] = ''
     end
     @item.workflow_circulations = Workflow::Extensions::WorkflowCirculations.new(copy)
+    result = @item.save
+    @item.skip_history_backup = false if @item.respond_to?(:skip_history_backup)
 
-    if @item.save
+    if result
       request_approval
       render json: create_success_response
     else
@@ -169,7 +176,8 @@ class Workflow::PagesController < ApplicationController
     end
 
     @item.record_timestamps = false
-    @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
+    # 更新履歴が作成されるように変更する
+    # @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
     if @item.finish_workflow?
       @item.approved = Time.zone.now
       @item.workflow_state = @model::WORKFLOW_STATE_APPROVE
@@ -180,7 +188,7 @@ class Workflow::PagesController < ApplicationController
         @item.state = 'public'
       end
       @item.record_timestamps = true
-      @item.skip_history_backup = false if @item.respond_to?(:skip_history_backup)
+      # @item.skip_history_backup = false if @item.respond_to?(:skip_history_backup)
 
       if @item.respond_to?(:release_date)
         if @item.release_date
@@ -257,7 +265,8 @@ class Workflow::PagesController < ApplicationController
 
     @item.remand_workflow_approver_state(@cur_user, comment: params[:remand_comment])
     @item.record_timestamps = false
-    @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
+    # 更新履歴が作成されるように変更する
+    # @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
     if !@item.save
       render json: @item.errors.full_messages, status: :unprocessable_entity
       return
@@ -292,7 +301,8 @@ class Workflow::PagesController < ApplicationController
     @item.workflow_state = @model::WORKFLOW_STATE_CANCELLED
 
     @item.record_timestamps = false
-    @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
+    # 更新履歴が作成されるように変更する
+    # @item.skip_history_backup = true if @item.respond_to?(:skip_history_backup)
     if @item.save
       render json: { notice: t('workflow.notice.request_cancelled') }
     else

--- a/spec/features/workflow/close_page_spec.rb
+++ b/spec/features/workflow/close_page_spec.rb
@@ -62,8 +62,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
       expect(item.workflow_approvers.count).to eq 1
       expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
       expect(item.released).to eq item.first_released
-      # no backups are created while requesting approve
-      expect(item.backups.count).to eq 1
+      expect(item.backups.count).to eq 2
 
       expect(Sys::MailLog.count).to eq 1
       expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -101,7 +100,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         })
       expect(item.released).to eq item.first_released
       # backup is created
-      expect(item.backups.count).to eq 2
+      expect(item.backups.count).to eq 3
 
       expect(Sys::MailLog.count).to eq 2
       expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count

--- a/spec/features/workflow/edit_requested_page_spec.rb
+++ b/spec/features/workflow/edit_requested_page_spec.rb
@@ -60,8 +60,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
         expect(item.workflow_comment).to eq workflow_comment
         expect(item.workflow_approvers.count).to eq 1
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 2
 
         #
         # user1: edit requested page
@@ -83,8 +82,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
         expect(item.workflow_comment).to eq workflow_comment
         expect(item.workflow_approvers.count).to eq 1
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 2
+        expect(item.backups.count).to eq 3
       end
     end
   end

--- a/spec/features/workflow/multi_stage_spec.rb
+++ b/spec/features/workflow/multi_stage_spec.rb
@@ -85,8 +85,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           }
           expect(workflow_approver).to eq(expected)
         end
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 2
 
         expect(Sys::MailLog.count).to eq 1
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -135,8 +134,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           }
           expect(workflow_approver).to eq(expected)
         end
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 4
 
         expect(Sys::MailLog.count).to eq 2
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -186,8 +184,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           }
           expect(workflow_approver).to eq(expected)
         end
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 6
 
         expect(Sys::MailLog.count).to eq 3
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -238,8 +235,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           }
           expect(workflow_approver).to include(expected)
         end
-        # backup is created because page is in public
-        expect(item.backups.count).to eq 2
+        expect(item.backups.count).to eq 7
 
         expect(Sys::MailLog.count).to eq 4
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count

--- a/spec/features/workflow/my_group_spec.rb
+++ b/spec/features/workflow/my_group_spec.rb
@@ -63,8 +63,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(item.workflow_approvers.count).to eq 2
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
         expect(item.workflow_approvers).to include({level: 1, user_id: user2.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 2
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq cms_user.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "request"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'request'),
+            include(level: 1, user_id: user2.id, state: 'request')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 2
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -109,8 +121,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             created: be_within(30.seconds).of(Time.zone.now)
           })
         expect(item.workflow_approvers).to include({level: 1, user_id: user2.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 3
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq user1.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "request"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'approve'),
+            include(level: 1, user_id: user2.id, state: 'request')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 2
 
@@ -141,7 +165,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             created: be_within(30.seconds).of(Time.zone.now)
           })
         # backup is created because page is in public
-        expect(item.backups.count).to eq 2
+        expect(item.backups.count).to eq 4
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq user2.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "approve"
+          expect(backup.data["state"]).to eq "public"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'approve'),
+            include(level: 1, user_id: user2.id, state: 'approve')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 3
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -190,8 +227,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(item.workflow_approvers.count).to eq 2
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
         expect(item.workflow_approvers).to include({level: 1, user_id: user2.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 2
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq cms_user.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "request"
+          expect(backup.data["state"]).to eq "closed"
+        end
 
         expect(Sys::MailLog.count).to eq 2
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -237,8 +282,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           })
         expect(item.workflow_approvers).to \
           include({level: 1, user_id: user2.id, editable: '', state: 'other_remanded', comment: ''})
-        # no backups are created
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 3
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq user1.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "remand"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'remand'),
+            include(level: 1, user_id: user2.id, state: 'other_remanded')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 3
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -289,8 +346,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(item.workflow_approvers.count).to eq 2
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
         expect(item.workflow_approvers).to include({level: 1, user_id: user2.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 2
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq cms_user.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "request"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'request'),
+            include(level: 1, user_id: user2.id, state: 'request')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 2
 
@@ -316,8 +385,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             created: be_within(30.seconds).of(Time.zone.now)
           })
         expect(item.workflow_approvers).to include({level: 1, user_id: user2.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 3
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq user1.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "request"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'approve'),
+            include(level: 1, user_id: user2.id, state: 'request')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 2
 
@@ -347,8 +428,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             level: 1, user_id: user2.id, editable: '', state: 'remand', comment: remand_comment2,
             created: be_within(30.seconds).of(Time.zone.now)
           })
-        # no backups are created
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 4
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq user2.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "remand"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'approve'),
+            include(level: 1, user_id: user2.id, state: 'remand')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 3
         ActionMailer::Base.deliveries.last.tap do |mail|
@@ -398,8 +491,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(item.workflow_approvers.count).to eq 2
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
         expect(item.workflow_approvers).to include({level: 1, user_id: user2.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 2
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq cms_user.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "request"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'request'),
+            include(level: 1, user_id: user2.id, state: 'request')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 2
 
@@ -423,8 +528,20 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(item.state).to eq "closed"
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
         expect(item.workflow_approvers).to include({level: 1, user_id: user2.id, editable: '', state: 'request', comment: ''})
-        # no backups are created
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 3
+        item.backups.first.tap do |backup|
+          expect(backup.user_id).to eq cms_user.id
+          expect(backup.member_id).to be_blank
+          expect(backup.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(backup.ref_id).to eq item.id
+          expect(backup.ref_class).to eq item.class.name
+          expect(backup.data["workflow_state"]).to eq "cancelled"
+          expect(backup.data["state"]).to eq "closed"
+          expect(backup.data["workflow_approvers"]).to include(
+            include(level: 1, user_id: user1.id, state: 'request'),
+            include(level: 1, user_id: user2.id, state: 'request')
+          )
+        end
 
         expect(Sys::MailLog.count).to eq 2
       end

--- a/spec/features/workflow/my_group_spec.rb
+++ b/spec/features/workflow/my_group_spec.rb
@@ -99,6 +99,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.body.raw_source).to include(workflow_comment)
         end
 
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq cms_user.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "request_update"
+        end
+
         #
         # user1: approve request
         #
@@ -137,6 +147,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         end
 
         expect(Sys::MailLog.count).to eq 2
+
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq user1.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "approve_update"
+        end
 
         #
         # user2: approve request
@@ -188,6 +208,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(item.name)
+        end
+
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq user2.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "approve_update"
         end
       end
     end
@@ -259,6 +289,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.body.raw_source).to include(workflow_comment)
         end
 
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq cms_user.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "request_update"
+        end
+
         #
         # user1: remand request
         #
@@ -307,6 +347,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
           expect(mail.body.raw_source).to include(remand_comment1)
+        end
+
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq user1.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "remand_update"
         end
       end
     end
@@ -363,6 +413,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
 
         expect(Sys::MailLog.count).to eq 2
 
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq cms_user.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "request_update"
+        end
+
         #
         # user1: approve request
         #
@@ -401,6 +461,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         end
 
         expect(Sys::MailLog.count).to eq 2
+
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq user1.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "approve_update"
+        end
 
         #
         # user2: remand request
@@ -452,6 +522,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
           expect(mail.body.raw_source).to include(remand_comment2)
+        end
+
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq user2.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "remand_update"
         end
       end
     end
@@ -508,6 +588,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
 
         expect(Sys::MailLog.count).to eq 2
 
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq cms_user.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "request_update"
+        end
+
         #
         # admin: cancel request
         #
@@ -544,6 +634,16 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         end
 
         expect(Sys::MailLog.count).to eq 2
+
+        History::Log.unscoped.reorder(_id: -1).first.tap do |log|
+          expect(log.site_id).to eq site.id
+          expect(log.user_id).to eq cms_user.id
+          expect(log.ref_coll).to eq Cms::Page.collection_name.to_s
+          expect(log.target_class).to eq item.class.name
+          expect(log.target_id).to eq item.id.to_s
+          expect(log.controller).to eq "workflow/pages"
+          expect(log.action).to eq "request_cancel"
+        end
       end
     end
   end

--- a/spec/features/workflow/release_page_spec.rb
+++ b/spec/features/workflow/release_page_spec.rb
@@ -60,8 +60,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(item.workflow_comment).to eq workflow_comment
         expect(item.workflow_approvers.count).to eq 1
         expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
-        # no backups are created while requesting approve
-        expect(item.backups.count).to eq 1
+        expect(item.backups.count).to eq 2
 
         expect(Sys::MailLog.count).to eq 1
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -97,8 +96,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             level: 1, user_id: user1.id, editable: '', state: 'approve', comment: approve_comment1, file_ids: nil,
             created: be_within(30.seconds).of(Time.zone.now)
           })
-        # backup is created
-        expect(item.backups.count).to eq 2
+        expect(item.backups.count).to eq 3
 
         expect(Sys::MailLog.count).to eq 2
         expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -123,8 +121,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           { level: 1, user_id: user1.id, editable: '', state: 'approve', comment: approve_comment1, file_ids: nil,
             created: be_within(30.seconds).of(Time.zone.now) }
         )
-        # backup is created
-        expect(item.backups.count).to eq 2
+        expect(item.backups.count).to eq 3
       end
     end
 
@@ -163,8 +160,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(item.release_date).to eq release_date
           expect(item.workflow_approvers.count).to eq 1
           expect(item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request', comment: ''})
-          # no backups are created while requesting approve
-          expect(item.backups.count).to eq 1
+          expect(item.backups.count).to eq 2
 
           expect(Sys::MailLog.count).to eq 1
           expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -200,8 +196,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
               level: 1, user_id: user1.id, editable: '', state: 'approve', comment: approve_comment1, file_ids: nil,
               created: be_within(30.seconds).of(Time.zone.now)
             })
-          # backup is created
-          expect(item.backups.count).to eq 2
+          expect(item.backups.count).to eq 3
 
           expect(Sys::MailLog.count).to eq 2
           expect(ActionMailer::Base.deliveries.length).to eq Sys::MailLog.count
@@ -226,8 +221,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             { level: 1, user_id: user1.id, editable: '', state: 'approve', comment: approve_comment1, file_ids: nil,
               created: be_within(30.seconds).of(Time.zone.now) }
           )
-          # backup is created
-          expect(item.backups.count).to eq 3
+          expect(item.backups.count).to eq 4
         end
       end
     end


### PR DESCRIPTION
issue: n/a

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

承認申請時に操作履歴と更新履歴の両方ともが作成されていなかった。
作成されるようにした。
