### PR TITLE
[fix][gws] 必須の「その他」を持つラジオボタンの動作不良の修正

### DIFF
--- a/app/javascript/controllers/gws/column/radio_controller.js
+++ b/app/javascript/controllers/gws/column/radio_controller.js
@@ -14,7 +14,10 @@ export default class extends Controller {
 
     // prepare
     $el.find('input[data-section-id]').each(function () {
-      ids.push($(this).attr('data-section-id'));
+      var sectionId = $(this).attr('data-section-id');
+      if (sectionId && !ids.includes(sectionId)) {
+        ids.push(sectionId);
+      }
     });
 
     // change
@@ -28,14 +31,16 @@ export default class extends Controller {
           $(`.section-${id} *`).prop('disabled', true);
         });
 
-        // set
-        $(`.section-${sectionId}`).removeClass("hide");
-        $(`.section-${sectionId} *`).prop('disabled', false);
+        if (sectionId) {
+          // set
+          $(`.section-${sectionId}`).removeClass("hide");
+          $(`.section-${sectionId} *`).prop('disabled', false);
 
-        if (sectionId === 'other') {
-          $el.find("input[type='text']").prop('disabled', false);
-        } else {
-          $el.find("input[type='text']").prop('disabled', true);
+          if (sectionId === 'other') {
+            $el.find("input[type='text']").prop('disabled', false);
+          } else {
+            $el.find("input[type='text']").prop('disabled', true);
+          }
         }
 
         $this.trigger("column:sectionChanged");

--- a/app/views/gws/agents/columns/radio_button/_column_form.html.erb
+++ b/app/views/gws/agents/columns/radio_button/_column_form.html.erb
@@ -2,7 +2,7 @@
 <%= render 'gws/agents/columns/main/common_label', column: column %>
 <%
   data = {}
-  data[:controller] = "gws--column--radio" if column.branch_section_ids.compact.reject(&:empty?).present?
+  data[:controller] = "gws--column--radio"
   data[:column_id] = column.id.to_s
 %>
 <%= tag.dd(class: [ @section_id, "radio-button-#{column.id}" ], data: data) do %>

--- a/spec/features/gws/survey/required_radio_spec.rb
+++ b/spec/features/gws/survey/required_radio_spec.rb
@@ -13,7 +13,12 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
   end
 
   context "required radio without other option" do
-    let!(:form) { create :gws_survey_form, cur_site: site, readable_setting_range: "public", readable_group_ids: [], readable_member_ids: [], state: "public" }
+    let!(:form) do
+      create(
+        :gws_survey_form, cur_site: site, state: "public",
+        readable_setting_range: "public", readable_group_ids: [], readable_member_ids: []
+      )
+    end
     let!(:column1) { create :gws_column_radio_button, cur_site: site, form: form, order: 10, required: "required" }
 
     context "without any answers" do
@@ -64,7 +69,12 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
   end
 
   context "required radio with required others" do
-    let!(:form) { create :gws_survey_form, cur_site: site, readable_setting_range: "public", readable_group_ids: [], readable_member_ids: [], state: "public" }
+    let!(:form) do
+      create(
+        :gws_survey_form, cur_site: site, state: "public",
+        readable_setting_range: "public", readable_group_ids: [], readable_member_ids: []
+      )
+    end
     let!(:column1) do
       create(
         :gws_column_radio_button, cur_site: site, form: form, order: 10, required: "required",

--- a/spec/features/gws/survey/required_radio_spec.rb
+++ b/spec/features/gws/survey/required_radio_spec.rb
@@ -12,7 +12,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
     site.save!
   end
 
-  context "required radio" do
+  context "required radio without other option" do
     let!(:form) { create :gws_survey_form, cur_site: site, readable_setting_range: "public", readable_group_ids: [], readable_member_ids: [], state: "public" }
     let!(:column1) { create :gws_column_radio_button, cur_site: site, form: form, order: 10, required: "required" }
 
@@ -31,13 +31,15 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
     end
 
     context "with answer" do
+      let(:answer_value) { column1.select_options.sample }
+
       it do
         login_gws_user
 
         visit gws_survey_main_path(site: site)
         click_on form.name
         within "form#item-form" do
-          find("input[value='#{column1.select_options.sample}']").set(true)
+          find("input[value='#{answer_value}']").set(true)
           click_on I18n.t("ss.buttons.answer")
         end
         wait_for_notice I18n.t('ss.notice.answered')
@@ -53,8 +55,83 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
             expect(column_value).to be_a(Gws::Column::Value::RadioButton)
             expect(column_value.name).to eq column1.name
             expect(column_value.order).to eq column1.order
+            expect(column_value.value).to eq answer_value
+            expect(column_value.other_value).to be_blank
+          end
+        end
+      end
+    end
+  end
+
+  context "required radio with required others" do
+    let!(:form) { create :gws_survey_form, cur_site: site, readable_setting_range: "public", readable_group_ids: [], readable_member_ids: [], state: "public" }
+    let!(:column1) do
+      create(
+        :gws_column_radio_button, cur_site: site, form: form, order: 10, required: "required",
+        other_state: "enabled", other_required: "required")
+    end
+
+    context "when answering with one of select_options" do
+      let(:answer_value) { column1.select_options.sample }
+
+      it do
+        login_gws_user
+
+        visit gws_survey_main_path(site: site)
+        click_on form.name
+        within "form#item-form" do
+          find("input[value='#{answer_value}']").set(true)
+          click_on I18n.t("ss.buttons.answer")
+        end
+        wait_for_notice I18n.t('ss.notice.answered')
+
+        expect(Gws::Survey::File.all).to have(1).items
+        Gws::Survey::File.all.first.tap do |answer|
+          expect(answer.form_id).to eq form.id
+          expect(answer.user_id).to eq gws_user.id
+          expect(answer.name).to include(form.name)
+          expect(answer.anonymous_state).to eq form.anonymous_state
+          expect(answer.column_values).to have(1).items
+          answer.column_values.first.tap do |column_value|
+            expect(column_value).to be_a(Gws::Column::Value::RadioButton)
+            expect(column_value.name).to eq column1.name
             expect(column_value.order).to eq column1.order
-            expect(column_value.value).to be_present
+            expect(column_value.value).to eq answer_value
+            expect(column_value.other_value).to be_blank
+          end
+        end
+      end
+    end
+
+    context "when answering with other" do
+      let(:other_value) { "other-#{unique_id}" }
+
+      it do
+        login_gws_user
+
+        visit gws_survey_main_path(site: site)
+        click_on form.name
+        within "form#item-form" do
+          find("input[data-section-id='other']").set(true)
+          fill_in "custom[#{column1.id}_other_value]", with: other_value
+
+          click_on I18n.t("ss.buttons.answer")
+        end
+        wait_for_notice I18n.t('ss.notice.answered')
+
+        expect(Gws::Survey::File.all).to have(1).items
+        Gws::Survey::File.all.first.tap do |answer|
+          expect(answer.form_id).to eq form.id
+          expect(answer.user_id).to eq gws_user.id
+          expect(answer.name).to include(form.name)
+          expect(answer.anonymous_state).to eq form.anonymous_state
+          expect(answer.column_values).to have(1).items
+          answer.column_values.first.tap do |column_value|
+            expect(column_value).to be_a(Gws::Column::Value::RadioButton)
+            expect(column_value.name).to eq column1.name
+            expect(column_value.order).to eq column1.order
+            expect(column_value.value).to eq "$other_value$"
+            expect(column_value.other_value).to eq other_value
           end
         end
       end


### PR DESCRIPTION
issue: n/a

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

ラジオボタンを必須にし、さらに「その他」も必須にした場合、そのラジオボタンでその他以外の選択肢に回答しようとすると「その他」への入力を求められる不具合の修正