### PR TITLE
【CMS】validate url

### DIFF
--- a/app/models/ads/banner.rb
+++ b/app/models/ads/banner.rb
@@ -18,6 +18,7 @@ class Ads::Banner
   belongs_to_file :file
 
   validates :link_url, presence: true
+  validates :link_url, url: true, if: -> { link_url.present? }
   validate :validate_link_url
   #validates :file_id, presence: true
 

--- a/app/models/ads/banner.rb
+++ b/app/models/ads/banner.rb
@@ -17,8 +17,7 @@ class Ads::Banner
 
   belongs_to_file :file
 
-  validates :link_url, presence: true
-  validates :link_url, url: true, if: -> { link_url.present? }
+  validates :link_url, presence: true, url: { absolute_path: true }
   validate :validate_link_url
   #validates :file_id, presence: true
 

--- a/app/models/cms/column/value/url_field2.rb
+++ b/app/models/cms/column/value/url_field2.rb
@@ -9,6 +9,7 @@ class Cms::Column::Value::UrlField2 < Cms::Column::Value::Base
 
   permit_values :link_url, :link_label, :link_target
 
+  validates :link_url, url: true, if: -> { link_url.present? }
   validate :validate_link_url
   validates :link_url, "sys/trusted_url" => true, if: ->{ Sys::TrustedUrlValidator.url_restricted? }
 

--- a/app/models/cms/column/value/url_field2.rb
+++ b/app/models/cms/column/value/url_field2.rb
@@ -11,7 +11,6 @@ class Cms::Column::Value::UrlField2 < Cms::Column::Value::Base
 
   validates :link_url, url: { absolute_path: true }, if: -> { link_url.present? }
   validate :validate_link_url
-
   validates :link_url, "sys/trusted_url" => true, if: ->{ Sys::TrustedUrlValidator.url_restricted? }
 
   before_validation :set_link_item, unless: ->{ @new_clone }

--- a/app/models/cms/column/value/url_field2.rb
+++ b/app/models/cms/column/value/url_field2.rb
@@ -9,8 +9,9 @@ class Cms::Column::Value::UrlField2 < Cms::Column::Value::Base
 
   permit_values :link_url, :link_label, :link_target
 
-  validates :link_url, url: true, if: -> { link_url.present? }
+  validates :link_url, url: { trusted_url: true }, if: -> { link_url.present? }
   validate :validate_link_url
+
   validates :link_url, "sys/trusted_url" => true, if: ->{ Sys::TrustedUrlValidator.url_restricted? }
 
   before_validation :set_link_item, unless: ->{ @new_clone }

--- a/app/models/cms/column/value/url_field2.rb
+++ b/app/models/cms/column/value/url_field2.rb
@@ -9,7 +9,7 @@ class Cms::Column::Value::UrlField2 < Cms::Column::Value::Base
 
   permit_values :link_url, :link_label, :link_target
 
-  validates :link_url, url: { absolute_path: true }, if: -> { link_url.present? }
+  validates :link_url, url: { absolute_path: true, allow_blank: true }
   validate :validate_link_url
   validates :link_url, "sys/trusted_url" => true, if: ->{ Sys::TrustedUrlValidator.url_restricted? }
 

--- a/app/models/cms/column/value/url_field2.rb
+++ b/app/models/cms/column/value/url_field2.rb
@@ -9,7 +9,7 @@ class Cms::Column::Value::UrlField2 < Cms::Column::Value::Base
 
   permit_values :link_url, :link_label, :link_target
 
-  validates :link_url, url: { trusted_url: true }, if: -> { link_url.present? }
+  validates :link_url, url: { absolute_path: true }, if: -> { link_url.present? }
   validate :validate_link_url
 
   validates :link_url, "sys/trusted_url" => true, if: ->{ Sys::TrustedUrlValidator.url_restricted? }
@@ -166,7 +166,7 @@ class Cms::Column::Value::UrlField2 < Cms::Column::Value::Base
 
     if link_url.present? && column.link_max_length.present? && column.link_max_length > 0
       if link_url.length > column.link_max_length
-        self.errors.add(:link_url, :too_long, count: column.link_max_length) 
+        self.errors.add(:link_url, :too_long, count: column.link_max_length)
       end
     end
   end

--- a/app/models/concerns/facility/addon/body.rb
+++ b/app/models/concerns/facility/addon/body.rb
@@ -12,6 +12,8 @@ module Facility::Addon
       field :related_url, type: String
 
       permit_params :kana, :postcode, :address, :tel, :fax, :related_url
+
+      validates :related_url, url: true, if: -> { related_url.present? }
     end
   end
 end

--- a/app/models/concerns/facility/addon/body.rb
+++ b/app/models/concerns/facility/addon/body.rb
@@ -13,7 +13,7 @@ module Facility::Addon
 
       permit_params :kana, :postcode, :address, :tel, :fax, :related_url
 
-      validates :related_url, url: true, if: -> { related_url.present? }
+      validates :related_url, url: { absolute_path: true }, if: -> { related_url.present? }
     end
   end
 end

--- a/app/models/concerns/facility/addon/body.rb
+++ b/app/models/concerns/facility/addon/body.rb
@@ -13,7 +13,7 @@ module Facility::Addon
 
       permit_params :kana, :postcode, :address, :tel, :fax, :related_url
 
-      validates :related_url, url: { absolute_path: true }, if: -> { related_url.present? }
+      validates :related_url, url: { absolute_path: true, allow_blank: true }
     end
   end
 end

--- a/app/models/key_visual/image.rb
+++ b/app/models/key_visual/image.rb
@@ -17,6 +17,7 @@ class KeyVisual::Image
   belongs_to_file :file
 
   validates :file_id, presence: true
+  validates :link_url, url: true, if: -> { link_url.present? }
   validates :display_remarks, inclusion: { in: I18n.t("key_visual.options.display_remarks").keys.map(&:to_s) },
     if: -> { display_remarks.present? }
 

--- a/app/models/key_visual/image.rb
+++ b/app/models/key_visual/image.rb
@@ -17,7 +17,7 @@ class KeyVisual::Image
   belongs_to_file :file
 
   validates :file_id, presence: true
-  validates :link_url, url: true, if: -> { link_url.present? }
+  validates :link_url, url: { absolute_path: true }, if: -> { link_url.present? }
   validates :display_remarks, inclusion: { in: I18n.t("key_visual.options.display_remarks").keys.map(&:to_s) },
     if: -> { display_remarks.present? }
 

--- a/app/models/key_visual/image.rb
+++ b/app/models/key_visual/image.rb
@@ -17,7 +17,7 @@ class KeyVisual::Image
   belongs_to_file :file
 
   validates :file_id, presence: true
-  validates :link_url, url: { absolute_path: true }, if: -> { link_url.present? }
+  validates :link_url, url: { absolute_path: true, allow_blank: true }
   validates :display_remarks, inclusion: { in: I18n.t("key_visual.options.display_remarks").keys.map(&:to_s) },
     if: -> { display_remarks.present? }
 

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -6,22 +6,20 @@ class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    begin
-      uri = ::Addressable::URI.parse(value)
+    uri = ::Addressable::URI.parse(value)
 
-      # 絶対パスの場合の検証
-      if options[:absolute_path] && uri.scheme.blank? && value.start_with?("/")
-        return
-      end
-
-      # URLスキームの検証
-      allowed_schemes = options[:scheme].try { |scheme| Array[scheme].flatten.map(&:to_s) } || ALLOWED_SCHEMES
-      if !allowed_schemes.include?(uri.scheme)
-        record.errors.add(attribute, options[:message] || :url)
-        return
-      end
-    rescue
-      record.errors.add(attribute, options[:message] || :url)
+    # 絶対パスの場合の検証
+    if options[:absolute_path] && uri.scheme.blank? && value.start_with?("/")
+      return
     end
+
+    # URLスキームの検証
+    allowed_schemes = options[:scheme].try { |scheme| Array[scheme].flatten.map(&:to_s) } || ALLOWED_SCHEMES
+    if !allowed_schemes.include?(uri.scheme)
+      record.errors.add(attribute, options[:message] || :url)
+      return
+    end
+  rescue
+    record.errors.add(attribute, options[:message] || :url)
   end
 end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -14,6 +14,11 @@ class UrlValidator < ActiveModel::EachValidator
     begin
       uri = ::Addressable::URI.parse(value)
 
+      # trusted_urlの検証
+      if options[:trusted_url] && Sys::TrustedUrlValidator.trusted_url?(value)
+        return
+      end
+
       # 絶対パスの場合の検証
       if options[:absolute_path] && uri.scheme.blank? && value.start_with?("/")
         return

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -6,11 +6,6 @@ class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    # # 関連するファイルが存在する場合、任意のパスを許可
-    # if record.respond_to?(:file) && record.file.present?
-    #   return if value.start_with?("/")
-    # end
-
     begin
       uri = ::Addressable::URI.parse(value)
 

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -6,10 +6,10 @@ class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    # 関連するファイルが存在する場合、任意のパスを許可
-    if record.respond_to?(:file) && record.file.present?
-      return if value.start_with?("/")
-    end
+    # # 関連するファイルが存在する場合、任意のパスを許可
+    # if record.respond_to?(:file) && record.file.present?
+    #   return if value.start_with?("/")
+    # end
 
     begin
       uri = ::Addressable::URI.parse(value)

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -6,14 +6,27 @@ class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    uri = ::Addressable::URI.parse(value)
-
-    allowed_schemes = options[:scheme].try { |scheme| Array[scheme].flatten.map(&:to_s) } || ALLOWED_SCHEMES
-    if !allowed_schemes.include?(uri.scheme)
-      record.errors.add(attribute, options[:message] || :url)
-      return
+    # 関連するファイルが存在する場合、任意のパスを許可
+    if record.respond_to?(:file) && record.file.present?
+      return if value.start_with?("/")
     end
-  rescue
-    record.errors.add(attribute, options[:message] || :url)
+
+    begin
+      uri = ::Addressable::URI.parse(value)
+
+      # 絶対パスの場合の検証
+      if options[:absolute_path] && uri.scheme.blank? && value.start_with?("/")
+        return
+      end
+
+      # URLスキームの検証
+      allowed_schemes = options[:scheme].try { |scheme| Array[scheme].flatten.map(&:to_s) } || ALLOWED_SCHEMES
+      if !allowed_schemes.include?(uri.scheme)
+        record.errors.add(attribute, options[:message] || :url)
+        return
+      end
+    rescue
+      record.errors.add(attribute, options[:message] || :url)
+    end
   end
 end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -14,11 +14,6 @@ class UrlValidator < ActiveModel::EachValidator
     begin
       uri = ::Addressable::URI.parse(value)
 
-      # trusted_urlの検証
-      if options[:trusted_url] && Sys::TrustedUrlValidator.trusted_url?(value)
-        return
-      end
-
       # 絶対パスの場合の検証
       if options[:absolute_path] && uri.scheme.blank? && value.start_with?("/")
         return

--- a/spec/features/workflow/save_as_branch_spec.rb
+++ b/spec/features/workflow/save_as_branch_spec.rb
@@ -129,17 +129,7 @@ describe "close_confirmation", type: :feature, dbscope: :example, js: true do
         before do
           item1.form = form
           item1.column_values = column_values1
-          puts "=== デバッグ情報 ==="
-          puts "item1: #{item1.inspect}"
-          puts "column_values1: #{column_values1.inspect}"
-          puts "form: #{form.inspect}"
-          puts "=== バリデーション前 ==="
-          puts "item1.valid?: #{item1.valid?}"
-          puts "item1.errors.full_messages: #{item1.errors.full_messages}"
           item1.save!
-          puts "=== バリデーション後 ==="
-          puts "item1.valid?: #{item1.valid?}"
-          puts "item1.errors.full_messages: #{item1.errors.full_messages}"
           item1.reload
 
           item2.form = form

--- a/spec/features/workflow/save_as_branch_spec.rb
+++ b/spec/features/workflow/save_as_branch_spec.rb
@@ -93,7 +93,7 @@ describe "close_confirmation", type: :feature, dbscope: :example, js: true do
           [
             column1.value_type.new(column: column1, value: unique_id),
             column2.value_type.new(column: column2, date: Time.zone.now),
-            column3.value_type.new(column: column3, link_url: unique_id),
+            column3.value_type.new(column: column3, link_url: "https://example.jp/#{unique_id}"),
             column4.value_type.new(column: column4, value: unique_id),
             column5.value_type.new(column: column5, value: column5.select_options.sample),
             column6.value_type.new(column: column6, value: column6.select_options.sample),
@@ -111,7 +111,7 @@ describe "close_confirmation", type: :feature, dbscope: :example, js: true do
           [
             column1.value_type.new(column: column1, value: unique_id),
             column2.value_type.new(column: column2, date: Time.zone.now),
-            column3.value_type.new(column: column3, link_url: unique_id),
+            column3.value_type.new(column: column3, link_url: "https://example.jp/#{unique_id}"),
             column4.value_type.new(column: column4, value: unique_id),
             column5.value_type.new(column: column5, value: column5.select_options.sample),
             column6.value_type.new(column: column6, value: column6.select_options.sample),
@@ -129,7 +129,17 @@ describe "close_confirmation", type: :feature, dbscope: :example, js: true do
         before do
           item1.form = form
           item1.column_values = column_values1
+          puts "=== デバッグ情報 ==="
+          puts "item1: #{item1.inspect}"
+          puts "column_values1: #{column_values1.inspect}"
+          puts "form: #{form.inspect}"
+          puts "=== バリデーション前 ==="
+          puts "item1.valid?: #{item1.valid?}"
+          puts "item1.errors.full_messages: #{item1.errors.full_messages}"
           item1.save!
+          puts "=== バリデーション後 ==="
+          puts "item1.valid?: #{item1.valid?}"
+          puts "item1.errors.full_messages: #{item1.errors.full_messages}"
           item1.reload
 
           item2.form = form
@@ -302,6 +312,7 @@ describe "close_confirmation", type: :feature, dbscope: :example, js: true do
             wait_for_cbox_closed { click_on I18n.t("workflow.links.continue_to_edit_master") }
           end
 
+          expect(page).to have_css("[type='reset']", text: I18n.t("ss.buttons.cancel"))
           expect(page).to have_no_css(".save")
           expect(page).to have_no_css(".branch_save")
           expect(page).to have_no_css(".publish_save")
@@ -318,6 +329,7 @@ describe "close_confirmation", type: :feature, dbscope: :example, js: true do
           end
 
           expect(page).to have_css(".save[value='#{I18n.t("ss.buttons.save")}']")
+          expect(page).to have_css("[type='reset']", text: I18n.t("ss.buttons.cancel"))
           expect(page).to have_no_css(".branch_save")
           expect(page).to have_no_css(".publish_save")
         end

--- a/spec/lib/migrations/cms/20220215000000_fix_contains_urls_spec.rb
+++ b/spec/lib/migrations/cms/20220215000000_fix_contains_urls_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe SS::Migration20220215000000, dbscope: :example do
       [
         column1.value_type.new(column: column1, value: "<a href=\" value1 \">value1</a>"),
         column2.value_type.new(column: column2, value: " value2 , value2 "),
-        column3.value_type.new(column: column3, link_url: " value3 "),
-        column4.value_type.new(column: column4, link_url: " value4 ")
+        column3.value_type.new(column: column3, link_url: "https://example.jp/value3"),
+        column4.value_type.new(column: column4, link_url: "https://example.jp/value4")
       ]
     end
     let(:page) { create :article_page, cur_site: site, cur_node: node, form: form, column_values: column_values }

--- a/spec/models/ads/banner_spec.rb
+++ b/spec/models/ads/banner_spec.rb
@@ -31,6 +31,7 @@ describe Ads::Banner do
     let(:valid_url2) { "https://example.jp/" }
     let(:valid_url3) { "/docs/page1.html" }
     let(:valid_url4) { "/docs/" }
+    let(:valid_url5) { "//www.example.jp/docs/3481.html" }
 
     let(:invalid_url1) { "http://example.jp /" }
     let(:invalid_url2) { "https://example.jp /" }
@@ -63,6 +64,11 @@ describe Ads::Banner do
 
     it "valid_url4" do
       item = build_banner(valid_url4)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url5" do
+      item = build_banner(valid_url5)
       expect(item.valid?).to be_truthy
     end
 

--- a/spec/models/ads/banner_spec.rb
+++ b/spec/models/ads/banner_spec.rb
@@ -21,4 +21,101 @@ describe Ads::Banner do
     it { expect(item.private_show_path).to eq show_path }
     it { expect(item.count_url).not_to eq nil }
   end
+
+  describe "validation" do
+    let(:site) { cms_site }
+    let(:node) { create :ads_node_banner, cur_site: site }
+    let(:file) { create :ss_file, site_id: site.id }
+
+    let(:valid_url1) { "http://example.jp/" }
+    let(:valid_url2) { "https://example.jp/" }
+    let(:valid_url3) { "/docs/page1.html" }
+    let(:valid_url4) { "/docs/" }
+
+    let(:invalid_url1) { "http://example.jp /" }
+    let(:invalid_url2) { "https://example.jp /" }
+    let(:invalid_url3) { "javascript:alert('test')" }
+    let(:invalid_url4) { "javascript:void(0)" }
+    let(:invalid_url5) { "#" }
+
+    def build_banner(url)
+      build(
+        :ads_banner, cur_site: site, cur_node: node,
+        file_id: file.id,
+        link_url: url
+      )
+    end
+
+    it "valid_url1" do
+      item = build_banner(valid_url1)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url2" do
+      item = build_banner(valid_url2)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url3" do
+      item = build_banner(valid_url3)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url4" do
+      item = build_banner(valid_url4)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "invalid_url1" do
+      item = build_banner(invalid_url1)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url2" do
+      item = build_banner(invalid_url2)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url3" do
+      item = build_banner(invalid_url3)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url4" do
+      item = build_banner(invalid_url4)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url5" do
+      item = build_banner(invalid_url5)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    context "when file is not present" do
+      it "valid_url1" do
+        item = build(:ads_banner, cur_site: site, cur_node: node, link_url: valid_url1)
+        expect(item.valid?).to be_truthy
+      end
+
+      it "valid_url2" do
+        item = build(:ads_banner, cur_site: site, cur_node: node, link_url: valid_url2)
+        expect(item.valid?).to be_truthy
+      end
+
+      it "valid_url3" do
+        item = build(:ads_banner, cur_site: site, cur_node: node, link_url: valid_url3)
+        expect(item.valid?).to be_truthy
+      end
+
+      it "valid_url4" do
+        item = build(:ads_banner, cur_site: site, cur_node: node, link_url: valid_url4)
+        expect(item.valid?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/cms/column/value/url_field2_spec.rb
+++ b/spec/models/cms/column/value/url_field2_spec.rb
@@ -65,6 +65,7 @@ describe Cms::Column::Value::UrlField2, type: :model, dbscope: :example do
     let(:valid_url18) { "/docs" }
     let(:valid_url19) { "/docs/" }
     let(:valid_url20) { "/シラサギプロジェクト" }
+    let(:valid_url21) { "//www.example.jp/docs/3481.html" }
 
     let(:invalid_url1) { "http://#{domain} /" }
     let(:invalid_url2) { "https://#{domain} /" }
@@ -248,6 +249,14 @@ describe Cms::Column::Value::UrlField2, type: :model, dbscope: :example do
 
     it "valid_url20" do
       item = build_page(valid_url20)
+      expect(item.valid?).to be_truthy
+
+      expect(item.column_values.first.link_item_type).to be_nil
+      expect(item.column_values.first.link_item_id).to be_nil
+    end
+
+    it "valid_url21" do
+      item = build_page(valid_url21)
       expect(item.valid?).to be_truthy
 
       expect(item.column_values.first.link_item_type).to be_nil

--- a/spec/models/cms/column/value/url_field2_spec.rb
+++ b/spec/models/cms/column/value/url_field2_spec.rb
@@ -68,6 +68,8 @@ describe Cms::Column::Value::UrlField2, type: :model, dbscope: :example do
 
     let(:invalid_url1) { "http://#{domain} /" }
     let(:invalid_url2) { "https://#{domain} /" }
+    let(:invalid_url3) { "javascript:alert('test')" }
+    let(:invalid_url4) { "javascript:void(0)" }
 
     before do
       request = OpenStruct.new(url: "http://#{domain}/#{unique_id}/")
@@ -263,6 +265,24 @@ describe Cms::Column::Value::UrlField2, type: :model, dbscope: :example do
     it "invalid_url2" do
       item = build_page(invalid_url2)
       expect(item.valid?).to be_falsey
+
+      expect(item.column_values.first.link_item_type).to be_nil
+      expect(item.column_values.first.link_item_id).to be_nil
+    end
+
+    it "invalid_url3" do
+      item = build_page(invalid_url3)
+      expect(item.valid?).to be_falsey
+      expect(item.column_values.first.errors[:link_url]).to be_present
+
+      expect(item.column_values.first.link_item_type).to be_nil
+      expect(item.column_values.first.link_item_id).to be_nil
+    end
+
+    it "invalid_url4" do
+      item = build_page(invalid_url4)
+      expect(item.valid?).to be_falsey
+      expect(item.column_values.first.errors[:link_url]).to be_present
 
       expect(item.column_values.first.link_item_type).to be_nil
       expect(item.column_values.first.link_item_id).to be_nil

--- a/spec/models/cms/elasticsearch/page_converter_spec.rb
+++ b/spec/models/cms/elasticsearch/page_converter_spec.rb
@@ -95,7 +95,7 @@ describe Cms::Elasticsearch::PageConverter, type: :model, dbscope: :example do
       [
         column1.value_type.new(column: column1, value: unique_id),
         column2.value_type.new(column: column2, date: Time.zone.now),
-        column3.value_type.new(column: column3, link_url: unique_id),
+        column3.value_type.new(column: column3, link_url: "https://example.jp/#{unique_id}"),
         column4.value_type.new(column: column4, value: unique_id),
         column5.value_type.new(column: column5, value: column5.select_options.sample),
         column6.value_type.new(column: column6, value: column6.select_options.sample),

--- a/spec/models/facility/addon/body_spec.rb
+++ b/spec/models/facility/addon/body_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Facility::Addon::Body do
+  let(:site) { cms_site }
+  let(:node) { create :facility_node_page, cur_site: site }
+  let(:item) { create :facility_node_page, cur_site: site, cur_node: node }
+
+  describe "validation" do
+    let(:valid_url1) { "http://example.jp/" }
+    let(:valid_url2) { "https://example.jp/" }
+    let(:valid_url3) { "/docs/page1.html" }
+    let(:valid_url4) { "/docs/" }
+
+    let(:invalid_url1) { "http://example.jp /" }
+    let(:invalid_url2) { "https://example.jp /" }
+    let(:invalid_url3) { "javascript:alert('test')" }
+    let(:invalid_url4) { "javascript:void(0)" }
+    let(:invalid_url5) { "#" }
+
+    def build_item(url)
+      build(
+        :facility_node_page, cur_site: site, cur_node: node,
+        related_url: url
+      )
+    end
+
+    it "valid_url1" do
+      item = build_item(valid_url1)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url2" do
+      item = build_item(valid_url2)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url3" do
+      item = build_item(valid_url3)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url4" do
+      item = build_item(valid_url4)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "invalid_url1" do
+      item = build_item(invalid_url1)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:related_url]).to be_present
+    end
+
+    it "invalid_url2" do
+      item = build_item(invalid_url2)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:related_url]).to be_present
+    end
+
+    it "invalid_url3" do
+      item = build_item(invalid_url3)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:related_url]).to be_present
+    end
+
+    it "invalid_url4" do
+      item = build_item(invalid_url4)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:related_url]).to be_present
+    end
+
+    it "invalid_url5" do
+      item = build_item(invalid_url5)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:related_url]).to be_present
+    end
+  end
+end

--- a/spec/models/facility/addon/body_spec.rb
+++ b/spec/models/facility/addon/body_spec.rb
@@ -10,6 +10,7 @@ describe Facility::Addon::Body do
     let(:valid_url2) { "https://example.jp/" }
     let(:valid_url3) { "/docs/page1.html" }
     let(:valid_url4) { "/docs/" }
+    let(:valid_url5) { "//www.example.jp/docs/3481.html" }
 
     let(:invalid_url1) { "http://example.jp /" }
     let(:invalid_url2) { "https://example.jp /" }
@@ -41,6 +42,11 @@ describe Facility::Addon::Body do
 
     it "valid_url4" do
       item = build_item(valid_url4)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url5" do
+      item = build_item(valid_url5)
       expect(item.valid?).to be_truthy
     end
 

--- a/spec/models/key_visual/image_spec.rb
+++ b/spec/models/key_visual/image_spec.rb
@@ -17,4 +17,74 @@ describe KeyVisual::Image, dbscope: :example do
     it { expect(subject.parent).to eq node }
     it { expect(subject.private_show_path).to eq show_path }
   end
+
+  describe "validation" do
+    let(:valid_url1) { "http://example.jp/" }
+    let(:valid_url2) { "https://example.jp/" }
+    let(:valid_url3) { "/docs/page1.html" }
+    let(:valid_url4) { "/docs/" }
+
+    let(:invalid_url1) { "http://example.jp /" }
+    let(:invalid_url2) { "https://example.jp /" }
+    let(:invalid_url3) { "javascript:alert('test')" }
+    let(:invalid_url4) { "javascript:void(0)" }
+    let(:invalid_url5) { "#" }
+
+    def build_item(url)
+      build(
+        :key_visual_image, cur_site: site, cur_node: node,
+        link_url: url
+      )
+    end
+
+    it "valid_url1" do
+      item = build_item(valid_url1)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url2" do
+      item = build_item(valid_url2)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url3" do
+      item = build_item(valid_url3)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url4" do
+      item = build_item(valid_url4)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "invalid_url1" do
+      item = build_item(invalid_url1)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url2" do
+      item = build_item(invalid_url2)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url3" do
+      item = build_item(invalid_url3)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url4" do
+      item = build_item(invalid_url4)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+
+    it "invalid_url5" do
+      item = build_item(invalid_url5)
+      expect(item.valid?).to be_falsey
+      expect(item.errors[:link_url]).to be_present
+    end
+  end
 end

--- a/spec/models/key_visual/image_spec.rb
+++ b/spec/models/key_visual/image_spec.rb
@@ -23,6 +23,7 @@ describe KeyVisual::Image, dbscope: :example do
     let(:valid_url2) { "https://example.jp/" }
     let(:valid_url3) { "/docs/page1.html" }
     let(:valid_url4) { "/docs/" }
+    let(:valid_url5) { "//www.example.jp/docs/3481.html" }
 
     let(:invalid_url1) { "http://example.jp /" }
     let(:invalid_url2) { "https://example.jp /" }
@@ -54,6 +55,11 @@ describe KeyVisual::Image, dbscope: :example do
 
     it "valid_url4" do
       item = build_item(valid_url4)
+      expect(item.valid?).to be_truthy
+    end
+
+    it "valid_url5" do
+      item = build_item(valid_url5)
       expect(item.valid?).to be_truthy
     end
 

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -70,4 +70,34 @@ describe UrlValidator, type: :validator do
       end
     end
   end
+
+  context "with absolute_path option" do
+    let!(:clazz) do
+      Struct.new(:url) do
+        include ActiveModel::Validations
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "temp")
+        end
+        validates :url, url: { absolute_path: true }
+      end
+    end
+
+    context 'with valid absolute path url' do
+      subject! { clazz.new("//www.example.jp/docs/3481.html") }
+
+      it do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with invalid url' do
+      subject! { clazz.new("{{{}}}") }
+
+      it do
+        expect(subject).to be_invalid
+        expect(subject.errors[:url]).to have(1).items
+        expect(subject.errors[:url]).to include(I18n.t("errors.messages.url"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
URLのバリデーション機能を追加し、セキュリティを強化しました。以下のモデルに対してURLバリデーションを実装し、テストケースを追加しました。

## 変更内容
1. バリデーションの追加
   - 広告バナー（リンクURL）
     - `Ads::Banner`モデルの`link_url`に`url: { absolute_path: true }`を追加
   - 記事（ブロック入力/リンク）
     - `Cms::Column::Value::UrlField2`モデルの`link_url`に`url: { absolute_path: true }`を追加
   - 施設情報URL
     - `Facility::Addon::Body`モジュールの`related_url`に`url: { absolute_path: true }`を追加
   - キービジュアル（リンクURL）
     - `KeyVisual::Image`モデルの`link_url`に`url: { absolute_path: true }`を追加

2. テストケースの追加
   - `spec/models/facility/addon/body_spec.rb`にバリデーションテストを追加
   - 有効なURL（http://, https://, 絶対パス,//www.example.jp/docs/3481.html）のテスト
   - 無効なURL（スペースを含むURL, JavaScriptスキーム, フラグメントのみ）のテスト
