### PR TITLE
[modify] task log improvements

### DIFF
--- a/app/controllers/cms/apis/preview/inplace_edit/pages_controller.rb
+++ b/app/controllers/cms/apis/preview/inplace_edit/pages_controller.rb
@@ -71,8 +71,10 @@ class Cms::Apis::Preview::InplaceEdit::PagesController < ApplicationController
       path_params = { path: copy.filename, anchor: "inplace" }
       path_params[:preview_date] = params[:preview_date].to_s if params[:preview_date].present?
       location = cms_preview_path(path_params)
+      task.log "created #{copy.filename}(#{copy.id})"
     elsif copy && copy.errors.present?
       SS::Model.copy_errors(copy, @item)
+      task.log "failed\n#{copy.errors.full_messages.join("\n")}"
     end
 
     render_save_as_branch result, location

--- a/app/controllers/cms/apis/preview/pages_controller.rb
+++ b/app/controllers/cms/apis/preview/pages_controller.rb
@@ -45,6 +45,8 @@ class Cms::Apis::Preview::PagesController < ApplicationController
       guard = ->(&block) do
         task.run_with(rejected: rejected) do
           task.log "# #{I18n.t("workflow.branch_page")} #{I18n.t("ss.buttons.publish_save")}"
+          task.log "master: #{@item.master.filename}(#{@item.master_id})"
+          task.log "branch: #{@item.filename}(#{@item.id})"
           block.call
         end
       end
@@ -58,8 +60,11 @@ class Cms::Apis::Preview::PagesController < ApplicationController
       result = @item.save
     end
 
-    if !result
+    if result
+      task.log "succeeded" if task
+    else
       render json: @item.errors.full_messages, status: :unprocessable_entity
+      task.log "failed\n#{@item.errors.full_messages.join("\n")}" if task
       return
     end
 

--- a/app/controllers/concerns/cms/page_filter.rb
+++ b/app/controllers/concerns/cms/page_filter.rb
@@ -160,6 +160,12 @@ module Cms::PageFilter
         copy = @item.new_clone
         copy.master = @item
         result = copy.save
+        if result
+          task.log "created #{copy.filename}(#{copy.id})"
+        else
+          task.log "failed\n#{copy.errors.full_messages.join("\n")}"
+        end
+        result
       end
     end
 
@@ -303,7 +309,14 @@ module Cms::PageFilter
 
     task.run_with(rejected: rejected) do
       task.log "# #{I18n.t("ss.buttons.move")}"
-      render_update @item.move(destination), location: location, render: { template: "move" }, notice: t('ss.notice.moved')
+      task.log "#{@item.filename}(#{@item.id})"
+      result = @item.move(destination)
+      render_update result, location: location, render: { template: "move" }, notice: t('ss.notice.moved')
+      if result
+        task.log "moved to #{destination}"
+      else
+        task.log "failed\n#{@item.errors.full_messages.join("\n")}"
+      end
     end
   end
 
@@ -326,7 +339,14 @@ module Cms::PageFilter
 
       @item.attributes = get_params
       @copy = @item.new_clone
-      render_update @copy.save, location: { action: :index }, render: { template: "copy" }
+      result = @copy.save
+      render_update result, location: { action: :index }, render: { template: "copy" }
+
+      if result
+        task.log "created #{@copy.filename}(#{@copy.id})"
+      else
+        task.log "failed\n#{@copy.errors.full_messages.join("\n")}"
+      end
     end
   end
 

--- a/app/controllers/concerns/job/tasks_filter.rb
+++ b/app/controllers/concerns/job/tasks_filter.rb
@@ -70,15 +70,29 @@ module Job::TasksFilter
 
   def download
     set_item
-    raise '404' if !::File.exist?(@item.log_file_path)
-    send_file @item.log_file_path, type: 'text/plain', filename: "#{@item.id}.log",
+
+    if params.key?(:log_sequence) && params[:log_sequence].numeric?
+      log_item = SS::Task::LogItem.new(task: @item, log_sequence: params[:log_sequence].to_i)
+    else
+      log_item = SS::Task::LogItem.new(task: @item, log_sequence: nil)
+    end
+
+    raise '404' if !::File.exist?(log_item.log_file_path)
+    send_file log_item.log_file_path, type: 'text/plain', filename: "#{@item.id}.log",
               disposition: :attachment, x_sendfile: true
   end
 
   def download_perf
     set_item
-    raise '404' if !::File.exist?(@item.perf_log_file_path)
-    send_file @item.perf_log_file_path, type: 'application/gzip', filename: "#{@item.id}-performance.log.gz",
+
+    if params.key?(:log_sequence) && params[:log_sequence].numeric?
+      log_item = SS::Task::LogItem.new(task: @item, log_sequence: params[:log_sequence].to_i)
+    else
+      log_item = SS::Task::LogItem.new(task: @item, log_sequence: nil)
+    end
+
+    raise '404' if !::File.exist?(log_item.perf_log_file_path)
+    send_file log_item.perf_log_file_path, type: 'application/gzip', filename: "#{@item.id}-performance.log.gz",
               disposition: :attachment, x_sendfile: true
   end
 end

--- a/app/controllers/workflow/pages_controller.rb
+++ b/app/controllers/workflow/pages_controller.rb
@@ -217,6 +217,8 @@ class Workflow::PagesController < ApplicationController
       guard = ->(&block) do
         task.run_with(rejected: rejected) do
           task.log "# #{I18n.t("workflow.branch_page")} #{I18n.t("ss.buttons.publish_save")}"
+          task.log "master: #{@item.master.filename}(#{@item.master_id})"
+          task.log "branch: #{@item.filename}(#{@item.id})"
           block.call
         end
       end
@@ -230,8 +232,11 @@ class Workflow::PagesController < ApplicationController
       result = @item.save
     end
 
-    if !result
+    if result
+      task.log "succeeded" if task
+    else
       render json: @item.errors.full_messages, status: :unprocessable_entity
+      task.log "failed\n#{@item.errors.full_messages.join("\n")}" if task
       return
     end
 

--- a/app/models/concerns/ss/model/task.rb
+++ b/app/models/concerns/ss/model/task.rb
@@ -33,6 +33,7 @@ module SS::Model::Task
     field :total_count, type: Integer, default: 0
     field :current_count, type: Integer, default: 0
     field :segment, type: String
+    field :log_sequence, type: Integer, default: 0
 
     validates :name, presence: true
     validates :state, presence: true
@@ -226,6 +227,10 @@ module SS::Model::Task
     self.unset(:logs) if self[:logs].present?
 
     ::FileUtils.rm_f(log_file_path) if log_file_path && ::File.exist?(log_file_path)
+
+    if rand(100) < 20
+      purge_old_logs
+    end
   end
 
   def base_dir
@@ -235,7 +240,7 @@ module SS::Model::Task
 
   def log_file_path
     return if new_record?
-    @log_file_path ||= "#{base_dir}/#{id}.log"
+    "#{base_dir}/#{log_sequence}_#{id}.log"
   end
 
   def perf_log_file_path
@@ -263,6 +268,10 @@ module SS::Model::Task
   end
 
   def log(msg)
+    if !File.exist?(log_file_path) || File.empty?(log_file_path)
+      write_meta
+    end
+
     logger.info msg
     Rails.logger.info msg
   end
@@ -284,6 +293,65 @@ module SS::Model::Task
     @performance ||= SS::Task::PerformanceCollector.new(self)
   end
 
+  class LogItem
+    include ActiveModel::Model
+
+    attr_accessor :task, :log_sequence
+
+    def log_file_path
+      if log_sequence
+        "#{task.base_dir}/#{log_sequence}_#{task.id}.log"
+      else
+        "#{task.base_dir}/#{task.id}.log"
+      end
+    end
+
+    def head_logs(num_logs)
+      Fs.head_lines(log_file_path, limit: num_logs)
+    end
+
+    def perf_log_file_path
+      return if log_file_path.blank?
+      log_file_path.sub(".log", "") + "-performance.log.gz"
+    end
+
+    def meta_path
+      return if log_file_path.blank?
+      log_file_path.sub(".log", "") + "-meta.json"
+    end
+
+    def meta
+      @meta ||= begin
+        path = meta_path
+        if path && File.exist?(path)
+          JSON.parse(File.read(path))
+        end
+      end
+    end
+  end
+
+  def log_items
+    ret = []
+
+    sequence = log_sequence
+    while sequence >= 0
+      path = "#{base_dir}/#{sequence}_#{id}.log"
+      if File.exist?(path)
+        ret << LogItem.new(task: self, log_sequence: sequence)
+      end
+
+      sequence -= 1
+    end
+
+    # backward compatibilities
+    path = "#{base_dir}/#{id}.log"
+    if File.exist?(path)
+      ret << LogItem.new(task: self, log_sequence: nil)
+    end
+
+    ret
+  end
+
   private
 
   def change_state(state, attrs = {})
@@ -298,7 +366,7 @@ module SS::Model::Task
     ]
     updates = {
       state: state, started: attrs[:started].try { |time| time.in_time_zone.utc }, closed: nil, interrupt: nil,
-      total_count: 0, current_count: 0
+      total_count: 0, current_count: 0, log_sequence: log_sequence + 1
     }
 
     criteria = self.class.where(id: id, "$and" => [{ "$or" => cond }])
@@ -309,5 +377,52 @@ module SS::Model::Task
     clear_log
 
     true
+  end
+
+  def write_meta
+    meta = {
+      hostname: Rails.application.hostname,
+      ip_address: Rails.application.ip_address,
+      process_id: Process.pid
+    }
+    if Rails.application.current_request
+      meta[:session_id] = Rails.application.current_session_id
+      meta[:request_id] = Rails.application.current_request_id
+      meta[:method] = Rails.application.current_request.method
+      meta[:controller] = Rails.application.current_request.params[:controller]
+      meta[:action] = Rails.application.current_request.params[:action]
+    end
+    if SS.current_site
+      meta[:site_id] = SS.current_site.id
+    end
+    if SS.current_user
+      meta[:user_id] = SS.current_user.id
+    end
+
+    FileUtils.mkdir_p(base_dir)
+
+    meta_path = log_file_path.sub(".log", "") + "-meta.json"
+    File.open(meta_path, "wt") do |f|
+      f.puts meta.to_json
+    end
+  end
+
+  def purge_old_logs(now: nil)
+    keep_logs = ::SS.config.job.keep_logs
+    return if keep_logs.nil? || keep_logs <= 0
+
+    now ||= Time.zone.now
+    modified = now - keep_logs
+
+    Dir.glob("*_#{id}.log", base: base_dir).each do |relative_path|
+      full_path = File.expand_path(relative_path, base_dir)
+      next if File.mtime(full_path).in_time_zone > modified
+
+      sequence, = relative_path.split("_", 2)
+
+      remove_file_paths = Dir.glob("#{sequence}_#{id}*.*", base: base_dir)
+      remove_file_paths.map! { File.expand_path(_1, base_dir) }
+      FileUtils.rm_f(remove_file_paths)
+    end
   end
 end

--- a/app/models/workflow/branch_creation_service.rb
+++ b/app/models/workflow/branch_creation_service.rb
@@ -29,6 +29,7 @@ class Workflow::BranchCreationService
       if item.branches.present?
         item.error.add :base, :branch_is_already_existed
         result = false
+        task.log "failed\n#{item.full_messages.join("\n")}"
       else
         copy = item.new_clone
         copy.master = item
@@ -36,8 +37,10 @@ class Workflow::BranchCreationService
 
         if result
           @new_branch = copy
+          task.log "created #{@new_branch.filename}(#{@new_branch.id})"
         elsif copy.errors.any?
           SS::Model.copy_errors(copy, item)
+          task.log "failed\n#{copy.full_messages.join("\n")}"
         end
       end
     end

--- a/app/views/job/cms/tasks/_show.html.erb
+++ b/app/views/job/cms/tasks/_show.html.erb
@@ -33,6 +33,9 @@
   <dt><%= @model.t :segment %></dt>
   <dd><%= @item.segment %></dd>
 
+  <dt><%= @model.t :log_sequence %></dt>
+  <dd><%= @item.log_sequence %></dd>
+
   <dt><%= @model.t :state %></dt>
   <dd>
     <span class="state"><%= @item.state %></span>
@@ -64,6 +67,7 @@
   <dt><%= @model.t :current_count %></dt>
   <dd><%= @item.current_count %></dd>
 
+  <% if false %>
   <dt><%= @model.t :logs %></dt>
   <dd>
     <%= t('job.log_notice', count: limit) %>
@@ -81,6 +85,68 @@
         <% end %>
       <% end %>
     <% end %>
+  </dd>
+  <% end %>
+</dl>
+
+<dl class="see">
+  <dt class="wide"></dt>
+  <dd class="wide">
+    <table class="index" style="display: grid; grid-template-columns: auto 1fr auto;">
+      <tbody style="display: contents;">
+      <% @item.log_items.each_with_index do |log, index| %>
+        <tr data-sequence="<%= log.log_sequence %>" style="display: contents;">
+          <td>
+            <%= index + 1 %>
+          </td>
+          <td>
+            <details<% if index == 0 %> open<% end %>>
+              <summary><%= @model.t :logs %></summary>
+              <div>
+              <%= t('job.log_notice', count: limit) %>
+              <%= text_area_tag :logs, safe_join(log.head_logs(limit), "\n"), readonly: true, style: "height: 100px" %>
+              <%=
+                if ::File.exist?(log.log_file_path)
+                  link_to(t('job.download_log'), { action: :download, log_sequence: log.log_sequence }, { class: :btn })
+                end
+              %>
+              <%=
+                if ::File.exist?(log.perf_log_file_path)
+                  link = link_to(t('job.download_perf_log'), { action: :download_perf, log_sequence: log.log_sequence }, { class: [ "btn", Rails.env.development? ? nil : "hide" ] }) rescue nil
+                  if link
+                    link
+                  end
+                end
+              %>
+              </div>
+            </details>
+          </td>
+          <td>
+            <%=
+              if log.meta && log.meta["process_id"]
+                "#{log.meta["process_id"]} @ #{log.meta["hostname"]}(#{log.meta["ip_address"]})"
+              end
+            %>
+            <%=
+              if log.meta && log.meta["session_id"]
+                tag.div do
+                  output_buffer << tag.span(log.meta["session_id"], data: { session_id: log.meta["session_id"] })
+                  output_buffer << tag.br
+                  output_buffer << tag.span(log.meta["request_id"], data: { request_id: log.meta["request_id"] })
+                  if log.meta["method"]
+                    output_buffer << tag.br
+                    controller_action = "#{log.meta["method"]} #{log.meta["controller"]}##{log.meta["action"]}"
+                    output_buffer << tag.span(controller_action, data: { method: log.meta["method"], controller: log.meta["controller"], action: log.meta["action"] })
+                  end
+                end
+              end
+            %>
+            <div><%= ss_time_tag ::File.mtime(log.log_file_path).in_time_zone rescue nil %></div>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
   </dd>
 </dl>
 

--- a/config/locales/ss/en.yml
+++ b/config/locales/ss/en.yml
@@ -851,6 +851,7 @@ en:
         current_count: No. of actions
         logs: Log
         segment: Segment
+        log_sequence: Sequence
       ss/model/file:
         in_file: File
         in_files: File

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -851,6 +851,7 @@ ja:
         current_count: 処理件数
         logs: ログ
         segment: セグメント
+        log_sequence: シーケンス
       ss/model/file:
         in_file: ファイル
         in_files: ファイル


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

- タスクのログについて何世代かを保存できるようにした
- タスクのログについて、2週間（既定）を過ぎたものを削除するようにした。
- タスクのログについて、メタ情報として実行プロセスID、実行ホスト名、セッションID、リクエストID、コントローラーとアクションなどの情報を保存するようにした。
- ページ操作時、もう少し詳細な情報をタスクのログに記録するようにした。
