### PR TITLE
[fix][gws] calendar

### DIFF
--- a/app/assets/javascripts/gws/schedule/lib/calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/calendar.js
@@ -205,9 +205,9 @@ SS.ready(function() {
           attendance = $('.fc .fc-withAbsence-button');
           if (attendance.length) {
             if (attendance.hasClass('fc-state-active')) {
-              $('.fc .fc-event-user-attendance-absence').removeClass('hide').show();
+              $('.fc .fc-event-user-attendance-absence').removeClass('hide');
             } else {
-              $('.fc .fc-event-user-attendance-absence').addClass('hide').hide();
+              $('.fc .fc-event-user-attendance-absence').addClass('hide');
             }
           }
           Gws_Schedule_Calendar.updateNoPlanVisibility(view.el.closest(".fc"));

--- a/app/assets/javascripts/gws/schedule/lib/calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/calendar.js
@@ -205,7 +205,9 @@ SS.ready(function() {
           attendance = $('.fc .fc-withAbsence-button');
           if (attendance.length) {
             if (attendance.hasClass('fc-state-active')) {
-              $('.fc .fc-event-user-attendance-absence').removeClass("hide")
+              $('.fc .fc-event-user-attendance-absence').removeClass('hide').show();
+            } else {
+              $('.fc .fc-event-user-attendance-absence').addClass('hide').hide();
             }
           }
           Gws_Schedule_Calendar.updateNoPlanVisibility(view.el.closest(".fc"));

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -83,9 +83,10 @@ module Gws::Schedule::CalendarFormat
     data[:className] += " fc-event-user-attendance-#{attendance_state}"
 
     if attendance_state == "absence"
-      return nil if cur_user.id != attendance_user_id
-
-      data[:className] += ' hide'
+      if cur_user.id != attendance_user_id && !facilities.any? { |f| f.manager_ids.include?(cur_user.id) }
+        return nil
+      end
+      data[:className] += ' fc-event-user-attendance-absence hide'
     end
 
     data

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -83,7 +83,7 @@ module Gws::Schedule::CalendarFormat
     data[:className] += " fc-event-user-attendance-#{attendance_state}"
 
     if attendance_state == "absence"
-      if cur_user.id != attendance_user_id && facilities.none? { |f| f.manager_ids.include?(cur_user.id) }
+      if cur_user.id != attendance_user_id
         return nil
       end
       data[:className] += ' hide'

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -83,7 +83,7 @@ module Gws::Schedule::CalendarFormat
     data[:className] += " fc-event-user-attendance-#{attendance_state}"
 
     if attendance_state == "absence"
-      if cur_user.id != attendance_user_id && !facilities.any? { |f| f.manager_ids.include?(cur_user.id) }
+      if cur_user.id != attendance_user_id && facilities.any? { |f| f.manager_ids.include?(cur_user.id) }
         return nil
       end
       data[:className] += ' fc-event-user-attendance-absence hide'

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -83,10 +83,10 @@ module Gws::Schedule::CalendarFormat
     data[:className] += " fc-event-user-attendance-#{attendance_state}"
 
     if attendance_state == "absence"
-      if cur_user.id != attendance_user_id && facilities.any? { |f| f.manager_ids.include?(cur_user.id) }
+      if cur_user.id != attendance_user_id && !facilities.any? { |f| f.manager_ids.include?(cur_user.id) }
         return nil
       end
-      data[:className] += ' hide'
+      data[:className] += ' fc-event-user-attendance-absence hide'
     end
 
     data

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -83,9 +83,8 @@ module Gws::Schedule::CalendarFormat
     data[:className] += " fc-event-user-attendance-#{attendance_state}"
 
     if attendance_state == "absence"
-      if cur_user.id != attendance_user_id
-        return nil
-      end
+      return nil if cur_user.id != attendance_user_id
+
       data[:className] += ' hide'
     end
 

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -83,7 +83,7 @@ module Gws::Schedule::CalendarFormat
     data[:className] += " fc-event-user-attendance-#{attendance_state}"
 
     if attendance_state == "absence"
-      if cur_user.id != attendance_user_id && !facilities.any? { |f| f.manager_ids.include?(cur_user.id) }
+      if cur_user.id != attendance_user_id && facilities.none? { |f| f.manager_ids.include?(cur_user.id) }
         return nil
       end
       data[:className] += ' fc-event-user-attendance-absence hide'

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -86,7 +86,7 @@ module Gws::Schedule::CalendarFormat
       if cur_user.id != attendance_user_id && facilities.none? { |f| f.manager_ids.include?(cur_user.id) }
         return nil
       end
-      data[:className] += ' fc-event-user-attendance-absence hide'
+      data[:className] += ' hide'
     end
 
     data

--- a/app/models/concerns/gws/schedule/calendar_format.rb
+++ b/app/models/concerns/gws/schedule/calendar_format.rb
@@ -86,7 +86,7 @@ module Gws::Schedule::CalendarFormat
       if cur_user.id != attendance_user_id && facilities.any? { |f| f.manager_ids.include?(cur_user.id) }
         return nil
       end
-      data[:className] += ' fc-event-user-attendance-absence hide'
+      data[:className] += ' hide'
     end
 
     data

--- a/spec/features/gws/schedule/plans/attendance_and_comment_spec.rb
+++ b/spec/features/gws/schedule/plans/attendance_and_comment_spec.rb
@@ -45,6 +45,56 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
     end
   end
 
+  context "facility manager attendance" do
+    let!(:facility) { create(:gws_facility_item, cur_user: user) }
+    let!(:plan) do
+      create(:gws_schedule_plan,
+        cur_user: user,
+        member_ids: [user.id],
+        facility_ids: [facility.id],
+        attendance_check_state: "enabled"
+      )
+    end
+
+    it "handles absence display correctly" do
+      login_user user
+      visit gws_schedule_plan_path(site: site, id: plan)
+
+      # 欠席に設定
+      within "#addon-gws-agents-addons-schedule-attendance" do
+        wait_for_cbox_opened do
+          first("span.attendances[data-member-id='#{user.id}'] input[value='absence']").click
+        end
+      end
+
+      within_cbox do
+        within "#ajax-box #item-form" do
+          fill_in "comment[text]", with: "欠席します"
+          click_on I18n.t("ss.buttons.save")
+        end
+      end
+      wait_for_notice I18n.t("ss.notice.saved")
+
+      # カレンダー画面に移動
+      visit gws_schedule_plans_path(site: site)
+
+      # 欠席表示ボタンがオフの状態でも予定が表示されることを確認
+      expect(page).to have_css(".fc-event")
+
+      # 欠席表示ボタンをオンにする
+      find(".fc-withAbsence-button").click
+
+      # 予定が表示されていることを確認
+      expect(page).to have_css(".fc-event")
+
+      # 欠席表示ボタンをオフにする
+      find(".fc-withAbsence-button").click
+
+      # 予定が表示されていることを確認
+      expect(page).to have_css(".fc-event")
+    end
+  end
+
   context "comment crud" do
     it do
       login_user user, to: gws_schedule_plan_path(site: site, id: item)

--- a/spec/features/gws/schedule/plans/attendance_and_comment_spec.rb
+++ b/spec/features/gws/schedule/plans/attendance_and_comment_spec.rb
@@ -78,20 +78,26 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
       # カレンダー画面に移動
       visit gws_schedule_plans_path(site: site)
 
-      # 欠席表示ボタンがオフの状態でも予定が表示されることを確認
-      expect(page).to have_css(".fc-event")
+      # 不参加にした予定が非表示であることを確認
+      expect(page).to have_css(".fc-event.fc-event-user-attendance-absence.hide")
+      # 他の予定は表示されていることを確認
+      expect(page).to have_css(".fc-event:not(.fc-event-user-attendance-absence)")
 
       # 欠席表示ボタンをオンにする
       find(".fc-withAbsence-button").click
 
-      # 予定が表示されていることを確認
-      expect(page).to have_css(".fc-event")
+      # 不参加にした予定が表示されていることを確認
+      expect(page).to have_css(".fc-event.fc-event-user-attendance-absence:not(.hide)")
+      # 他の予定も引き続き表示されていることを確認
+      expect(page).to have_css(".fc-event:not(.fc-event-user-attendance-absence)")
 
       # 欠席表示ボタンをオフにする
       find(".fc-withAbsence-button").click
 
-      # 予定が表示されていることを確認
-      expect(page).to have_css(".fc-event")
+      # 不参加にした予定が再び非表示になったことを確認
+      expect(page).to have_css(".fc-event.fc-event-user-attendance-absence.hide")
+      # 他の予定は引き続き表示されていることを確認
+      expect(page).to have_css(".fc-event:not(.fc-event-user-attendance-absence)")
     end
   end
 


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
スケジュールの欠席表示機能の不具合を修正。

### 前提条件
- スケジュールの参加ユーザーは設備管理者１人のみ
- 出欠確認で「不参加」を設定

### 修正前の問題
1. 設備管理者が不参加を選択した場合：
   - 欠席表示オフでも予定が表示される
   - 欠席表示オンで予定が消える
   - 欠席表示オフに戻しても予定が表示されない
2. ブラウザリロードでのみ予定が再表示される状態

## 変更内容
- 欠席表示ボタンの状態に応じた表示制御を改善

## その他

### 動作確認済み項目
- [x]  設備管理者が不参加を選択した場合の予定表示
- [x]  欠席表示ボタンのオン/オフ切り替え時の動作
- [x]  ブラウザリロード後の表示状態
- [x] 設備を設定せずに予定を作成し不参加にした際の動作
