### PR TITLE
[fixup] テストの安定化 (Google Chrome 134 対応) (#5574)

### DIFF
--- a/spec/features/article/pages/attach_file/basic_spec.rb
+++ b/spec/features/article/pages/attach_file/basic_spec.rb
@@ -143,9 +143,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
     context "with cms addon file" do
       context "when file is attached / saved on the modal dialog" do
         it do
-          login_user(user2)
-
-          visit edit_path
+          login_user(user2, to: edit_path)
           ensure_addon_opened("#addon-cms-agents-addons-file")
           within "form#item-form" do
             within "#addon-cms-agents-addons-file" do
@@ -201,8 +199,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
         end
 
         it do
-          login_user(user2)
-          visit edit_path
+          login_user(user2, to: edit_path)
           ensure_addon_opened("#addon-cms-agents-addons-file")
           within "form#item-form" do
             within "#addon-cms-agents-addons-file" do
@@ -267,9 +264,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
 
     context "with entry form" do
       it "#edit" do
-        login_user(user2)
-
-        visit edit_path
+        login_user(user2, to: edit_path)
 
         within 'form#item-form' do
           wait_for_event_fired("ss:formActivated") do

--- a/spec/features/article/pages/attach_file/basic_v2_spec.rb
+++ b/spec/features/article/pages/attach_file/basic_v2_spec.rb
@@ -157,9 +157,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
     context "with cms addon file" do
       context "when file is attached / saved on the modal dialog" do
         it do
-          login_user(cms_user)
-
-          visit edit_path
+          login_user(cms_user, to: edit_path)
           wait_for_all_ckeditors_ready
           wait_for_all_turbo_frames
           ensure_addon_opened("#addon-cms-agents-addons-file")
@@ -213,8 +211,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
 
       context "when a file uploaded by other user is attached" do
         it do
-          login_user(user2)
-          visit edit_path
+          login_user(user2, to: edit_path)
           wait_for_all_ckeditors_ready
           wait_for_all_turbo_frames
           ensure_addon_opened("#addon-cms-agents-addons-file")
@@ -288,9 +285,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
 
     context "with entry form" do
       it "#edit" do
-        login_user(user2)
-
-        visit edit_path
+        login_user(user2, to: edit_path)
         wait_for_all_ckeditors_ready
         wait_for_all_turbo_frames
 

--- a/spec/features/article/pages/category_readable_spec.rb
+++ b/spec/features/article/pages/category_readable_spec.rb
@@ -50,8 +50,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
       expect(item.category_ids).to include(category_page2.id)
       expect(item.category_ids).not_to include(category_page1.id)
 
-      login_user user1
-      visit article_pages_path(site: site, cid: node)
+      login_user user1, to: article_pages_path(site: site, cid: node)
 
       click_on item.name
       click_on I18n.t("ss.links.edit")

--- a/spec/features/article/pages/cms_form/with_entry_form_spec.rb
+++ b/spec/features/article/pages/cms_form/with_entry_form_spec.rb
@@ -987,9 +987,7 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
       let(:form2) { create :cms_form, cur_site: site, state: 'public', sub_type: 'entry', group_ids: [cms_group.id] }
 
       it do
-        login_user(user2)
-
-        visit new_article_page_path(site: site, cid: node)
+        login_user(user2, to: new_article_page_path(site: site, cid: node))
 
         within '#addon-basic' do
           expect(page).to have_no_css('select[name="in_form_id"]')
@@ -1000,9 +998,7 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
         node.st_form_ids = [ form.id, form2.id ]
         node.save!
 
-        login_user(user2)
-
-        visit new_article_page_path(site: site, cid: node)
+        login_user(user2, to: new_article_page_path(site: site, cid: node))
 
         within '#addon-basic' do
           expect(page).to have_css('select[name="in_form_id"]')
@@ -1028,10 +1024,8 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
         wait_for_notice I18n.t('ss.notice.saved')
         expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
 
-        login_user(user2)
-
         item = Article::Page.last
-        visit edit_article_page_path(site: site, cid: node, id: item)
+        login_user(user2, to: edit_article_page_path(site: site, cid: node, id: item))
 
         within '#addon-basic' do
           expect(page).to have_css('select[name="in_form_id"][disabled]')

--- a/spec/features/article/pages/expiration_spec.rb
+++ b/spec/features/article/pages/expiration_spec.rb
@@ -25,9 +25,7 @@ describe "workflow_remind", type: :feature, dbscope: :example, js: true do
       time = page1.updated + SS::Duration.parse(site.page_expiration_before)
       time = time.end_of_day.change(sec: 0)
       Timecop.freeze(time) do
-        login_cms_user
-
-        visit article_pages_path(site: site, cid: node)
+        login_cms_user to: article_pages_path(site: site, cid: node)
         expect(page).to have_css(".list-item[data-id='#{page1.id}']", text: I18n.t("ss.state.public"))
         expect(page).to have_css(".list-item[data-id='#{page2.id}']", text: I18n.t("ss.state.edit"))
 
@@ -43,9 +41,7 @@ describe "workflow_remind", type: :feature, dbscope: :example, js: true do
       time = page1.updated + SS::Duration.parse(site.page_expiration_before) + 1.day
       time = time.beginning_of_day
       Timecop.freeze(time) do
-        login_cms_user
-
-        visit article_pages_path(site: site, cid: node)
+        login_cms_user to: article_pages_path(site: site, cid: node)
         expect(page).to have_css(".list-item[data-id='#{page1.id}']", text: I18n.t("ss.state.public"))
         expect(page).to have_css(".list-item[data-id='#{page2.id}']", text: I18n.t("ss.state.edit"))
 
@@ -73,9 +69,7 @@ describe "workflow_remind", type: :feature, dbscope: :example, js: true do
       time = page1.updated + SS::Duration.parse(site.page_expiration_before)
       time = time.end_of_day.change(sec: 0)
       Timecop.freeze(time) do
-        login_cms_user
-
-        visit article_pages_path(site: site, cid: node)
+        login_cms_user to: article_pages_path(site: site, cid: node)
         expect(page).to have_css(".list-item[data-id='#{page1.id}']", text: I18n.t("ss.state.public"))
         expect(page).to have_css(".list-item[data-id='#{page2.id}']", text: I18n.t("ss.state.edit"))
 
@@ -91,9 +85,7 @@ describe "workflow_remind", type: :feature, dbscope: :example, js: true do
       time = page1.updated + SS::Duration.parse(site.page_expiration_before) + 1.day
       time = time.beginning_of_day
       Timecop.freeze(time) do
-        login_cms_user
-
-        visit article_pages_path(site: site, cid: node)
+        login_cms_user to: article_pages_path(site: site, cid: node)
         "#{I18n.t("ss.state.public")}#{I18n.t("cms.state_expired_suffix")}".tap do |text|
           expect(page).to have_css(".list-item[data-id='#{page1.id}']", text: text)
         end

--- a/spec/features/article/pages/merging_expired_branch_spec.rb
+++ b/spec/features/article/pages/merging_expired_branch_spec.rb
@@ -91,8 +91,8 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
           expect(::File.exist?(master.path)).to be_falsey
 
           # 4. 差し替えページ（2）を公開保存
-          login_cms_user # 時計を進めたのでセッションの期限が切れているはずなので、再ログイン
-          visit edit_article_page_path(site: site, cid: node, id: branch)
+          # 時計を進めたのでセッションの期限が切れているはずなので、再ログイン
+          login_cms_user to: edit_article_page_path(site: site, cid: node, id: branch)
           wait_for_all_ckeditors_ready
           expect do
             within "form#item-form" do
@@ -201,8 +201,8 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
           expect(::File.exist?(master.path)).to be_falsey
 
           # 4. 差し替えページ（2）を承認
-          login_cms_user # 時計を進めたのでセッションの期限が切れているはずなので、再ログイン
-          visit article_page_path(site: site, cid: node, id: branch)
+          # 時計を進めたのでセッションの期限が切れているはずなので、再ログイン
+          login_cms_user to: article_page_path(site: site, cid: node, id: branch)
           wait_for_turbo_frame "#workflow-branch-frame"
           expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
           within ".mod-workflow-request" do

--- a/spec/features/article/pages/publish_all_spec.rb
+++ b/spec/features/article/pages/publish_all_spec.rb
@@ -75,8 +75,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
 
   context "when master is published all" do
     it do
-      login_user user1
-      visit article_pages_path(site: site, cid: node)
+      login_user user1, to: article_pages_path(site: site, cid: node)
       wait_for_js_ready
       expect(page).to have_css(".list-item[data-id='#{item_master.id}']", text: item_master.name)
       expect(page).to have_css(".list-item[data-id='#{item_branch.id}']", text: item_branch.name)
@@ -130,8 +129,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
 
   context "when branch is published all" do
     it do
-      login_user user1
-      visit article_pages_path(site: site, cid: node)
+      login_user user1, to: article_pages_path(site: site, cid: node)
       wait_for_js_ready
       expect(page).to have_css(".list-item[data-id='#{item_master.id}']", text: item_master.name)
       expect(page).to have_css(".list-item[data-id='#{item_branch.id}']", text: item_branch.name)

--- a/spec/features/article/pages/publish_and_close_permitted_spec.rb
+++ b/spec/features/article/pages/publish_and_close_permitted_spec.rb
@@ -32,9 +32,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
 
       it do
         Timecop.freeze(now) do
-          login_cms_user
-
-          visit index_path
+          login_cms_user to: index_path
           within ".list-head" do
             wait_for_event_fired("ss:checked-all-list-items") { find('input[type="checkbox"]').set(true) }
             click_button I18n.t("ss.links.make_them_public")
@@ -73,9 +71,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
 
       it do
         Timecop.freeze(now) do
-          login_cms_user
-
-          visit index_path
+          login_cms_user to: index_path
           within ".list-head" do
             wait_for_event_fired("ss:checked-all-list-items") { find('input[type="checkbox"]').set(true) }
             click_button I18n.t('ss.links.make_them_close')

--- a/spec/features/category/nodes_quick_edit_spec.rb
+++ b/spec/features/category/nodes_quick_edit_spec.rb
@@ -62,8 +62,7 @@ describe "category_nodes_base", type: :feature, dbscope: :example, js: :true do
     it "allows only one user to save changes" do
       window1 = open_new_window
       within_window window1 do
-        login_user user1
-        visit index_path
+        login_user user1, to: index_path
         wait_for_turbo_frame "#cms-nodes-tree-frame"
         click_link "tune"
         wait_for_ajax
@@ -77,8 +76,7 @@ describe "category_nodes_base", type: :feature, dbscope: :example, js: :true do
 
       window2 = open_new_window
       within_window window2 do
-        login_user user2
-        visit index_path
+        login_user user2, to: index_path
         wait_for_turbo_frame "#cms-nodes-tree-frame"
         click_link "tune"
         wait_for_ajax

--- a/spec/features/cms/error_page_spec.rb
+++ b/spec/features/cms/error_page_spec.rb
@@ -37,8 +37,7 @@ describe "cms_users", type: :feature, dbscope: :example do
     let(:title) { "403 Forbidden | SHIRASAGI" }
 
     before do
-      login_user user
-      visit cms_users_path(site: site)
+      login_user user, to: cms_users_path(site: site)
     end
 
     include_context "shows cms error page"

--- a/spec/features/cms/ldap/import_spec.rb
+++ b/spec/features/cms/ldap/import_spec.rb
@@ -42,15 +42,13 @@ describe "ldap_import", type: :feature, dbscope: :example, ldap: true do
       end
 
       it "#index" do
-        login_user(user)
-        visit index_path
+        login_user(user, to: index_path)
         expect(status_code).to eq 200
         expect(current_path).to eq index_path
       end
 
       it "#import" do
-        login_user(user)
-        visit import_confirmation_path
+        login_user(user, to: import_confirmation_path)
         expect(current_path).to eq import_confirmation_path
         within "form#item-form" do
           click_button I18n.t('ss.buttons.import')

--- a/spec/features/cms/ldap/server_spec.rb
+++ b/spec/features/cms/ldap/server_spec.rb
@@ -57,29 +57,25 @@ describe "ldap_server", type: :feature, dbscope: :example do
 
     context "with auth" do
       it "#index" do
-        login_user(user, pass: "admin", login_path: cms_login_path(site: site))
-        visit index_path
+        login_user(user, pass: "admin", login_path: cms_login_path(site: site), to: index_path)
         expect(status_code).to eq 200
         expect(current_path).to eq index_path
       end
 
       it "#index with dn" do
-        login_user(user, pass: "admin", login_path: cms_login_path(site: site))
-        visit index2_path
+        login_user(user, pass: "admin", login_path: cms_login_path(site: site), to: index2_path)
         expect(status_code).to eq 200
         expect(current_path).to eq index2_path
       end
 
       it "#group" do
-        login_user(user, pass: "admin", login_path: cms_login_path(site: site))
-        visit group_path
+        login_user(user, pass: "admin", login_path: cms_login_path(site: site), to: group_path)
         expect(status_code).to eq 200
         expect(current_path).to eq group_path
       end
 
       it "#user" do
-        login_user(user, pass: "admin", login_path: cms_login_path(site: site))
-        visit user_path
+        login_user(user, pass: "admin", login_path: cms_login_path(site: site), to: user_path)
         expect(status_code).to eq 200
         expect(current_path).to eq user_path
       end

--- a/spec/features/cms/sns_post/line/approval_spec.rb
+++ b/spec/features/cms/sns_post/line/approval_spec.rb
@@ -70,8 +70,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -148,8 +147,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -251,8 +249,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
 
           within "#addon-workflow-agents-addons-branch" do
@@ -350,8 +347,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 1. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -438,8 +434,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 2. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -514,8 +509,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 3. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -605,8 +599,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 1. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
@@ -708,8 +701,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
@@ -799,8 +791,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name

--- a/spec/features/cms/sns_post/line/release_page_spec.rb
+++ b/spec/features/cms/sns_post/line/release_page_spec.rb
@@ -206,8 +206,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name
@@ -552,8 +551,7 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 2. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name

--- a/spec/features/cms/sns_post/twitter/approval_spec.rb
+++ b/spec/features/cms/sns_post/twitter/approval_spec.rb
@@ -79,8 +79,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -161,8 +160,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -256,8 +254,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name
@@ -341,8 +338,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 1. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -416,8 +412,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 2. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -491,8 +486,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 3. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           perform_enqueued_jobs do
             within ".mod-workflow-approve" do
@@ -578,8 +572,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 1. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name
@@ -665,8 +658,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 2. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name
@@ -752,8 +744,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 3. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name

--- a/spec/features/cms/sns_post/twitter/release_page_spec.rb
+++ b/spec/features/cms/sns_post/twitter/release_page_spec.rb
@@ -204,8 +204,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name
@@ -525,8 +524,7 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
 
           # 2. approve
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
           within "#addon-workflow-agents-addons-branch" do
             wait_for_turbo_frame "#workflow-branch-frame"
             expect(page).to have_link item.name

--- a/spec/features/gws/affair/attendance/time_card/group_spec.rb
+++ b/spec/features/gws/affair/attendance/time_card/group_spec.rb
@@ -52,8 +52,7 @@ describe "gws_attendance_time_card", type: :feature, dbscope: :example, js: true
   end
 
   it do
-    login_user(user638)
-    visit index_path
+    login_user(user638, to: index_path)
 
     within "form select" do
       user638.groups.each do |group|
@@ -64,8 +63,7 @@ describe "gws_attendance_time_card", type: :feature, dbscope: :example, js: true
       end
     end
 
-    login_user(user545)
-    visit index_path
+    login_user(user545, to: index_path)
     within "form select" do
       user638.groups.each do |group|
         expect(page).to have_css("option[value=\"#{group.id}\"]")
@@ -78,32 +76,27 @@ describe "gws_attendance_time_card", type: :feature, dbscope: :example, js: true
 
   it do
     Timecop.travel(user638_enter) do
-      login_user(user638)
-      visit gws_affair_attendance_main_path(site)
+      login_user(user638, to: gws_affair_attendance_main_path(site))
       punch_enter(user638_enter)
     end
 
     Timecop.travel(user545_enter) do
-      login_user(user545)
-      visit gws_affair_attendance_main_path(site)
+      login_user(user545, to: gws_affair_attendance_main_path(site))
       punch_enter(user545_enter)
     end
 
     Timecop.travel(user638_leave) do
-      login_user(user638)
-      visit gws_affair_attendance_main_path(site)
+      login_user(user638, to: gws_affair_attendance_main_path(site))
       punch_leave(user638_leave)
     end
 
     Timecop.travel(user545_leave) do
-      login_user(user545)
-      visit gws_affair_attendance_main_path(site)
+      login_user(user545, to: gws_affair_attendance_main_path(site))
       punch_leave(user545_leave)
     end
 
     Timecop.travel(user545_leave) do
-      login_user(user638)
-      visit index_path
+      login_user(user638, to: index_path)
       # change group
       within "form" do
         select user638_group.name, from: 'group_id'
@@ -132,8 +125,7 @@ describe "gws_attendance_time_card", type: :feature, dbscope: :example, js: true
         end
       end
 
-      login_user(user545)
-      visit index_path
+      login_user(user545, to: index_path)
       # change group
       within "form" do
         select user638_group.name, from: 'group_id'

--- a/spec/features/gws/affair/capitals/default_capital_spec.rb
+++ b/spec/features/gws/affair/capitals/default_capital_spec.rb
@@ -42,8 +42,7 @@ describe "gws_affair_capitals", type: :feature, dbscope: :example, js: true do
   context "login with user1" do
     it do
       Timecop.freeze(year1.start_date) do
-        login_user user1
-        visit new_path
+        login_user user1, to: new_path
 
         name = item1.name
         target = user1.name
@@ -53,8 +52,7 @@ describe "gws_affair_capitals", type: :feature, dbscope: :example, js: true do
 
     it do
       Timecop.freeze(year2.start_date) do
-        login_user user1
-        visit new_path
+        login_user user1, to: new_path
 
         name = I18n.t("gws/affair.views.not_set_capital")
         target = user1.name
@@ -66,8 +64,7 @@ describe "gws_affair_capitals", type: :feature, dbscope: :example, js: true do
   context "login with user2" do
     it do
       Timecop.freeze(year1.start_date) do
-        login_user user2
-        visit new_path
+        login_user user2, to: new_path
 
         name = item2.name
         target = user2.name
@@ -77,8 +74,7 @@ describe "gws_affair_capitals", type: :feature, dbscope: :example, js: true do
 
     it do
       Timecop.freeze(year2.start_date) do
-        login_user user2
-        visit new_path
+        login_user user2, to: new_path
 
         name = I18n.t("gws/affair.views.not_set_capital")
         target = user2.name
@@ -90,8 +86,7 @@ describe "gws_affair_capitals", type: :feature, dbscope: :example, js: true do
   context "login with user3" do
     it do
       Timecop.freeze(year1.start_date) do
-        login_user user3
-        visit new_path
+        login_user user3, to: new_path
 
         name = I18n.t("gws/affair.views.not_set_capital")
         target = user3.name
@@ -101,8 +96,7 @@ describe "gws_affair_capitals", type: :feature, dbscope: :example, js: true do
 
     it do
       Timecop.freeze(year2.close_date) do
-        login_user user3
-        visit new_path
+        login_user user3, to: new_path
 
         name = item3.name
         target = user3.name

--- a/spec/features/gws/affair/duty_setting/duty_notices/time_limit_spec.rb
+++ b/spec/features/gws/affair/duty_setting/duty_notices/time_limit_spec.rb
@@ -11,8 +11,7 @@ describe "gws_affair_duty_notices", type: :feature, dbscope: :example do
 
     #context "basic crud" do
     #  it "#index" do
-    #    login_user(user)
-    #    visit gws_affair_attendance_main_path(site)
+    #    login_user(user, to: gws_affair_attendance_main_path(site))
     #  end
     #end
   end

--- a/spec/features/gws/affair/leave/files/annual_leave_spec.rb
+++ b/spec/features/gws/affair/leave/files/annual_leave_spec.rb
@@ -19,8 +19,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       reason = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
 
         within "form#item-form" do
           fill_in_date "item[start_at_date]", with: start_at.to_date
@@ -48,8 +47,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       workflow_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
         wait_for_js_ready
@@ -85,8 +83,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       approve_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         wait_for_js_ready
 
@@ -111,8 +108,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       item1 = request_file(item1)
       item1 = approve_file(item1)
 
-      login_user(user545)
-      visit details_path
+      login_user(user545, to: details_path)
 
       within ".gws-attendance" do
         within "table.index" do

--- a/spec/features/gws/affair/leave/files/special_leave_spec.rb
+++ b/spec/features/gws/affair/leave/files/special_leave_spec.rb
@@ -19,8 +19,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       reason = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
         wait_for_js_ready
 
         within "form#item-form" do
@@ -63,8 +62,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       workflow_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on item.name
         wait_for_js_ready
 
@@ -99,8 +97,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       approve_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         wait_for_js_ready
 
@@ -125,8 +122,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       item1 = request_file(item1)
       item1 = approve_file(item1)
 
-      login_user(user545)
-      visit details_path
+      login_user(user545, to: details_path)
 
       within ".gws-attendance" do
         within "table.index" do

--- a/spec/features/gws/affair/leave/files/workflow/basic_spec.rb
+++ b/spec/features/gws/affair/leave/files/workflow/basic_spec.rb
@@ -19,8 +19,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       reason = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
 
         within "form#item-form" do
           fill_in_date "item[start_at_date]", with: start_at.to_date
@@ -59,8 +58,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       workflow_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
 
@@ -100,8 +98,7 @@ describe "gws_affair_leave_files", type: :feature, dbscope: :example, js: true d
       item = request_file(item)
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit approve_path
+        login_user(user545, to: approve_path)
 
         within ".list-items" do
           expect(page).to have_link item.name

--- a/spec/features/gws/affair/overtime/files/basic_crud_spec.rb
+++ b/spec/features/gws/affair/overtime/files/basic_crud_spec.rb
@@ -15,8 +15,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       name = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
 
         within "form#item-form" do
           expect(page).to have_css(".selected-capital", text: user638.effective_capital(site).name)
@@ -43,8 +42,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       workflow_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
         wait_for_js_ready
@@ -78,8 +76,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       approve_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
 
         within ".mod-workflow-approve" do
@@ -96,8 +93,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       start_at = item.start_at
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on item.name
         within "#addon-gws-agents-addons-affair-overtime_result" do
           wait_for_js_ready
@@ -120,8 +116,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       start_at = item.start_at
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on item.name
         within "#addon-gws-agents-addons-affair-overtime_result" do
           wait_for_js_ready
@@ -144,8 +139,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       start_at = item.start_at
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         within "#addon-gws-agents-addons-affair-overtime_result" do
           wait_for_js_ready

--- a/spec/features/gws/affair/overtime/files/break_time_spec.rb
+++ b/spec/features/gws/affair/overtime/files/break_time_spec.rb
@@ -15,8 +15,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       name = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
 
         within "form#item-form" do
           expect(page).to have_css(".selected-capital", text: user638.effective_capital(site).name)
@@ -42,8 +41,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       workflow_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
 
@@ -78,8 +76,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       approve_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         wait_for_js_ready
 
@@ -99,8 +96,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       start_at = item.start_at
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on item.name
         wait_for_js_ready
         within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -120,8 +116,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       start_at = item.start_at
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on item.name
         wait_for_js_ready
         within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -154,8 +149,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       start_at = item.start_at
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on item.name
         wait_for_js_ready
         within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -188,8 +182,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       start_at = item.start_at
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         wait_for_js_ready
         within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -215,8 +208,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       item1 = input_results(item1)
       item1 = close_results(item1)
 
-      login_user(user545)
-      visit index_path
+      login_user(user545, to: index_path)
       click_on item1.name
       wait_for_js_ready
       within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -242,8 +234,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       item2 = edit_results_break1(item2, break1_start_at, break1_end_at)
       item2 = close_results(item2)
 
-      login_user(user545)
-      visit index_path
+      login_user(user545, to: index_path)
       click_on item2.name
       wait_for_js_ready
       within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -273,8 +264,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       item3 = edit_results_break2(item3, break2_start_at, break2_end_at)
       item3 = close_results(item3)
 
-      login_user(user545)
-      visit index_path
+      login_user(user545, to: index_path)
       click_on item3.name
       wait_for_js_ready
       within "#addon-gws-agents-addons-affair-overtime_result" do

--- a/spec/features/gws/affair/overtime/files/compensatory/create_and_notify_spec.rb
+++ b/spec/features/gws/affair/overtime/files/compensatory/create_and_notify_spec.rb
@@ -17,8 +17,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       travel_at = start_at
 
       Timecop.freeze(travel_at) do
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
 
         within "form#item-form" do
           expect(page).to have_css(".selected-capital", text: user638.effective_capital(site).name)
@@ -51,8 +50,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       travel_at = item.start_at
 
       Timecop.travel(travel_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
         within ".nav-menu" do
@@ -97,8 +95,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       travel_at = item.start_at
 
       Timecop.travel(travel_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
         within ".nav-menu" do
@@ -147,8 +144,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       travel_at = item.start_at
 
       Timecop.travel(travel_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
         wait_for_js_ready
@@ -201,8 +197,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       workflow_comment = unique_id
 
       Timecop.freeze(travel_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
         wait_for_js_ready
@@ -238,8 +233,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       approve_comment = unique_id
 
       Timecop.freeze(travel_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         wait_for_js_ready
 
@@ -258,8 +252,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       travel_at = item.start_at
 
       Timecop.freeze(travel_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on item.name
         wait_for_js_ready
         within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -279,8 +272,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       travel_at = item.start_at
 
       Timecop.freeze(travel_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         wait_for_js_ready
         within "#addon-gws-agents-addons-affair-overtime_result" do
@@ -298,8 +290,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       travel_at = item.start_at
 
       Timecop.freeze(travel_at) do
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on item.name
         wait_for_js_ready
 

--- a/spec/features/gws/affair/overtime/files/compensatory/create_week_in_spec.rb
+++ b/spec/features/gws/affair/overtime/files/compensatory/create_week_in_spec.rb
@@ -29,8 +29,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
 
       Timecop.travel(start_at) do
         # request
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
 
         within "form#item-form" do
           expect(page).to have_css(".selected-capital", text: user638.effective_capital(site).name)
@@ -85,8 +84,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
         wait_for_js_ready
 
         # approve
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on name
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment
@@ -96,8 +94,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
         wait_for_js_ready
 
         # input results
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
         click_on name
         within "#addon-gws-agents-addons-affair-overtime_result" do
           wait_for_js_ready
@@ -127,8 +124,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
         wait_for_js_ready
 
         # close results
-        login_user(user545)
-        visit index_path
+        login_user(user545, to: index_path)
         click_on name
         within "#addon-gws-agents-addons-affair-overtime_result" do
           wait_for_js_ready

--- a/spec/features/gws/affair/overtime/files/superior_groups_spec.rb
+++ b/spec/features/gws/affair/overtime/files/superior_groups_spec.rb
@@ -45,8 +45,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
     let(:import_path) { import_gws_groups_path(site: site) }
 
     def check_superior(user, superior_group)
-      login_user(user)
-      visit new_path
+      login_user(user, to: new_path)
 
       within "form#item-form" do
         expect(page).to have_css(".selected-capital", text: user.effective_capital(site).name)
@@ -72,8 +71,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
 
     it "#new" do
       Timecop.travel("2021/3/1") do
-        login_user(user_sys)
-        visit import_path
+        login_user(user_sys, to: import_path)
 
         check_superior(user461, superior_group1)
         check_superior(user545, superior_group2)

--- a/spec/features/gws/affair/overtime/files/workflow/basic_spec.rb
+++ b/spec/features/gws/affair/overtime/files/workflow/basic_spec.rb
@@ -16,8 +16,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       name = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit new_path
+        login_user(user638, to: new_path)
 
         within "form#item-form" do
           expect(page).to have_css(".selected-capital", text: user638.effective_capital(site).name)
@@ -44,8 +43,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       workflow_comment = unique_id
 
       Timecop.freeze(start_at) do
-        login_user(user638)
-        visit index_path
+        login_user(user638, to: index_path)
 
         click_on item.name
         wait_for_js_ready
@@ -82,8 +80,7 @@ describe "gws_affair_overtime_files", type: :feature, dbscope: :example, js: tru
       item = request_file(item)
 
       Timecop.freeze(start_at) do
-        login_user(user545)
-        visit approve_path
+        login_user(user545, to: approve_path)
 
         within ".list-items" do
           expect(page).to have_link item.name

--- a/spec/features/gws/board/topics/without_auth_spec.rb
+++ b/spec/features/gws/board/topics/without_auth_spec.rb
@@ -15,8 +15,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
     let(:user) { create :gws_user, group_ids: [ site.id ] }
 
     it do
-      login_user user
-      visit index_path
+      login_user user, to: index_path
       expect(page).to have_css(".index.gws-boards")
     end
   end

--- a/spec/features/gws/circular/posts/comment_authority_spec.rb
+++ b/spec/features/gws/circular/posts/comment_authority_spec.rb
@@ -14,8 +14,7 @@ describe 'gws_circular_comment_authority', type: :feature, dbscope: :example, js
 
   context 'circular author' do
     before do
-      login_user user1
-      visit circular_show_path
+      login_user user1, to: circular_show_path
     end
 
     it do
@@ -29,8 +28,7 @@ describe 'gws_circular_comment_authority', type: :feature, dbscope: :example, js
 
   context 'commenter' do
     before do
-      login_user user2
-      visit circular_show_path
+      login_user user2, to: circular_show_path
     end
 
     it do
@@ -44,8 +42,7 @@ describe 'gws_circular_comment_authority', type: :feature, dbscope: :example, js
 
   context 'not circular author and not commenter' do
     before do
-      login_user user3
-      visit circular_show_path
+      login_user user3, to: circular_show_path
     end
 
     it do

--- a/spec/features/gws/discussion/bookmarks/basic_spec.rb
+++ b/spec/features/gws/discussion/bookmarks/basic_spec.rb
@@ -13,9 +13,7 @@ describe "gws_discussion_topics", type: :feature, dbscope: :example, js: true do
   let!(:index_path) { gws_discussion_forums_path(mode: '-', site: site) }
 
   it "bookmark from portal" do
-    login_user(user1)
-
-    visit index_path
+    login_user(user1, to: index_path)
     click_on forum.name
     within "#comment-#{topic.id}" do
       expect(page).to have_no_css(".bookmark-comment .active")
@@ -36,9 +34,7 @@ describe "gws_discussion_topics", type: :feature, dbscope: :example, js: true do
     end
     expect(page).to have_css(".gws-discussion")
 
-    login_user(user2)
-
-    visit index_path
+    login_user(user2, to: index_path)
     click_on forum.name
     within "#comment-#{topic.id}" do
       expect(page).to have_no_css(".bookmark-comment .active")
@@ -61,9 +57,7 @@ describe "gws_discussion_topics", type: :feature, dbscope: :example, js: true do
   end
 
   it "bookmark from comments" do
-    login_user(user1)
-
-    visit index_path
+    login_user(user1, to: index_path)
     click_on forum.name
     within ".gws-discussion-thread" do
       click_on topic.name
@@ -86,9 +80,7 @@ describe "gws_discussion_topics", type: :feature, dbscope: :example, js: true do
     end
     expect(page).to have_css(".gws-discussion")
 
-    login_user(user2)
-
-    visit index_path
+    login_user(user2, to: index_path)
     click_on forum.name
     within ".gws-discussion-thread" do
       click_on topic.name

--- a/spec/features/gws/error_page_spec.rb
+++ b/spec/features/gws/error_page_spec.rb
@@ -32,8 +32,7 @@ describe "gws_groups", type: :feature, dbscope: :example do
     let(:title) { "403 Forbidden | SHIRASAGI" }
 
     before do
-      login_user user
-      visit gws_groups_path(site: site)
+      login_user user, to: gws_groups_path(site: site)
     end
 
     include_context "shows gws error page"

--- a/spec/features/gws/job/user_logs_spec.rb
+++ b/spec/features/gws/job/user_logs_spec.rb
@@ -37,8 +37,7 @@ describe "gws_job_user_logs", type: :feature, dbscope: :example, js: true do
   context "basic index" do
     context "with user1" do
       it do
-        login_user user1
-        visit gws_job_user_logs_path(site: site)
+        login_user user1, to: gws_job_user_logs_path(site: site)
 
         expect(page).to have_css(".list-item .title", text: I18n.t(log1.class_name.underscore, scope: "job.models"))
         expect(page).to have_css(".list-item .title", text: I18n.t(log2.class_name.underscore, scope: "job.models"))
@@ -60,8 +59,7 @@ describe "gws_job_user_logs", type: :feature, dbscope: :example, js: true do
 
     context "with user2" do
       it do
-        login_user user2
-        visit gws_job_user_logs_path(site: site)
+        login_user user2, to: gws_job_user_logs_path(site: site)
 
         expect(page).to have_no_content(I18n.t(log1.class_name.underscore, scope: "job.models"))
         expect(page).to have_no_content(I18n.t(log2.class_name.underscore, scope: "job.models"))
@@ -80,8 +78,7 @@ describe "gws_job_user_logs", type: :feature, dbscope: :example, js: true do
     after { clear_downloads }
 
     it do
-      login_user user1
-      visit gws_job_user_logs_path(site: site)
+      login_user user1, to: gws_job_user_logs_path(site: site)
       click_on I18n.t("ss.links.download")
 
       within "form#item-form" do
@@ -126,8 +123,7 @@ describe "gws_job_user_logs", type: :feature, dbscope: :example, js: true do
 
   describe "batch destroy" do
     it do
-      login_user user1
-      visit gws_job_user_logs_path(site: site)
+      login_user user1, to: gws_job_user_logs_path(site: site)
       within ".nav-menu" do
         click_on I18n.t("ss.links.delete")
       end

--- a/spec/features/gws/job/user_reservations_spec.rb
+++ b/spec/features/gws/job/user_reservations_spec.rb
@@ -37,9 +37,7 @@ describe "gws_job_user_reservations", type: :feature, dbscope: :example, js: tru
   context "basic index" do
     context "with user1" do
       it do
-        login_user user1
-
-        visit gws_job_user_reservations_path(site: site)
+        login_user user1, to: gws_job_user_reservations_path(site: site)
         expect(page).to have_css(".list-item .title", text: I18n.t(task1.class_name.underscore, scope: "job.models"))
         expect(page).to have_css(".list-item .title", text: I18n.t(task2.class_name.underscore, scope: "job.models"))
         expect(page).to have_no_content(I18n.t(task3.class_name.underscore, scope: "job.models"))
@@ -69,9 +67,7 @@ describe "gws_job_user_reservations", type: :feature, dbscope: :example, js: tru
 
     context "with user2" do
       it do
-        login_user user2
-
-        visit gws_job_user_reservations_path(site: site)
+        login_user user2, to: gws_job_user_reservations_path(site: site)
         expect(page).to have_no_content(I18n.t(task1.class_name.underscore, scope: "job.models"))
         expect(page).to have_no_content(I18n.t(task2.class_name.underscore, scope: "job.models"))
         expect(page).to have_css(".list-item .title", text: I18n.t(task3.class_name.underscore, scope: "job.models"))
@@ -85,9 +81,7 @@ describe "gws_job_user_reservations", type: :feature, dbscope: :example, js: tru
 
   describe "destroy all" do
     it do
-      login_user user1
-
-      visit gws_job_user_reservations_path(site: site)
+      login_user user1, to: gws_job_user_reservations_path(site: site)
       within first(".list-item") do
         first("[name='ids[]']").click
       end

--- a/spec/features/gws/memo/messages/redirect_to_appropriate_folder_spec.rb
+++ b/spec/features/gws/memo/messages/redirect_to_appropriate_folder_spec.rb
@@ -44,15 +44,13 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example do
       end
 
       it do
-        login_user user1
-        visit gws_memo_message_path(site, folder: 'REDIRECT', id: memo.id)
+        login_user user1, to: gws_memo_message_path(site, folder: 'REDIRECT', id: memo.id)
         expect(current_path).to eq gws_memo_message_path(site: site, folder: 'INBOX', id: memo)
 
         visit gws_memo_message_path(site, folder: 'REDIRECT', id: trash_memo.id)
         expect(current_path).to eq gws_memo_message_path(site: site, folder: 'INBOX.Trash', id: trash_memo)
 
-        login_user user2
-        visit gws_memo_message_path(site, folder: 'REDIRECT', id: memo.id)
+        login_user user2, to: gws_memo_message_path(site, folder: 'REDIRECT', id: memo.id)
         expect(current_path).to eq gws_memo_list_message_path(site: site, list_id: list, id: memo)
       end
     end

--- a/spec/features/gws/monitor/management/file_download_spec.rb
+++ b/spec/features/gws/monitor/management/file_download_spec.rb
@@ -38,8 +38,7 @@ describe "gws_monitor_management_admins", type: :feature, dbscope: :example, js:
   context "ss-4573" do
     it do
       # create cached file at
-      login_user user0
-      visit gws_monitor_management_admin_path(site: site, id: topic1)
+      login_user user0, to: gws_monitor_management_admin_path(site: site, id: topic1)
       click_on I18n.t("gws/monitor.links.file_download")
 
       wait_for_download
@@ -69,8 +68,7 @@ describe "gws_monitor_management_admins", type: :feature, dbscope: :example, js:
       #
       # 回答する
       #
-      login_user user1
-      visit gws_monitor_topic_path(site: site, id: topic1)
+      login_user user1, to: gws_monitor_topic_path(site: site, id: topic1)
       page.accept_confirm(I18n.t("gws/monitor.confirm.public")) do
         click_on I18n.t("gws/monitor.links.public")
       end
@@ -92,8 +90,7 @@ describe "gws_monitor_management_admins", type: :feature, dbscope: :example, js:
       #
       # 回答で追加されたファイルがダウンロードできるか（キャッシュが更新されるか）確認
       #
-      login_user user0
-      visit gws_monitor_management_admin_path(site: site, id: topic1)
+      login_user user0, to: gws_monitor_management_admin_path(site: site, id: topic1)
       click_on I18n.t("gws/monitor.links.file_download")
 
       wait_for_download
@@ -116,8 +113,7 @@ describe "gws_monitor_management_admins", type: :feature, dbscope: :example, js:
       #
       # 回答を編集する
       #
-      login_user user1
-      visit gws_monitor_answer_path(site: site, id: topic1)
+      login_user user1, to: gws_monitor_answer_path(site: site, id: topic1)
       click_on I18n.t("ss.links.edit")
       within "form#item-form" do
         ss_select_file user1_file2, addon: '#addon-gws-agents-addons-file'
@@ -130,8 +126,7 @@ describe "gws_monitor_management_admins", type: :feature, dbscope: :example, js:
       #
       # 回答の編集で追加されたファイルがダウンロードできるか（キャッシュが更新されるか）確認
       #
-      login_user user0
-      visit gws_monitor_management_admin_path(site: site, id: topic1)
+      login_user user0, to: gws_monitor_management_admin_path(site: site, id: topic1)
       click_on I18n.t("gws/monitor.links.file_download")
 
       wait_for_download
@@ -160,8 +155,7 @@ describe "gws_monitor_management_admins", type: :feature, dbscope: :example, js:
     end
 
     it do
-      login_user user0
-      visit gws_monitor_management_admin_path(site: site, id: topic1)
+      login_user user0, to: gws_monitor_management_admin_path(site: site, id: topic1)
       click_on I18n.t("gws/monitor.links.file_download")
       wait_for_notice I18n.t("errors.messages.other_task_is_running")
     end

--- a/spec/features/gws/notices/advanced_crud_spec.rb
+++ b/spec/features/gws/notices/advanced_crud_spec.rb
@@ -38,8 +38,7 @@ describe "gws_notices", type: :feature, dbscope: :example, js: true do
       #
       # [manager] create folders
       #
-      login_user manager
-      visit gws_notice_folders_path(site: site)
+      login_user manager, to: gws_notice_folders_path(site: site)
       click_on I18n.t('ss.links.new')
 
       within 'form#item-form' do
@@ -98,8 +97,7 @@ describe "gws_notices", type: :feature, dbscope: :example, js: true do
       #
       # [editor] create posts
       #
-      login_user editor
-      visit gws_notice_main_path(site: site)
+      login_user editor, to: gws_notice_main_path(site: site)
       click_on I18n.t('ss.navi.editable')
       within '.tree-navi' do
         click_on folder_name
@@ -138,8 +136,7 @@ describe "gws_notices", type: :feature, dbscope: :example, js: true do
       #
       # [reader] read posts
       #
-      login_user reader
-      visit gws_notice_main_path(site: site)
+      login_user reader, to: gws_notice_main_path(site: site)
       expect(page).to have_css('.tree-navi', text: folder_name)
       expect(page).to have_css('.list-items', text: notice_name)
 

--- a/spec/features/gws/qna/topics/without_auth_spec.rb
+++ b/spec/features/gws/qna/topics/without_auth_spec.rb
@@ -15,8 +15,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
     let(:user) { create :gws_user, group_ids: [ site.id ] }
 
     it do
-      login_user user
-      visit index_path
+      login_user user, to: index_path
       expect(page).to have_css(".index.gws-boards")
     end
   end

--- a/spec/features/gws/report/files/publish_and_notice_spec.rb
+++ b/spec/features/gws/report/files/publish_and_notice_spec.rb
@@ -49,8 +49,7 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
   context "publish and notification" do
     it do
       # publish
-      login_user user0
-      visit gws_report_files_main_path(site: site)
+      login_user user0, to: gws_report_files_main_path(site: site)
       within ".current-navi" do
         click_on I18n.t('gws/report.options.file_state.closed')
       end
@@ -95,8 +94,7 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
       end
 
       # user1 is able to read in inbox
-      login_user user1
-      visit gws_report_files_main_path(site: site)
+      login_user user1, to: gws_report_files_main_path(site: site)
       within ".current-navi" do
         click_on I18n.t('gws/report.options.file_state.inbox')
       end
@@ -106,8 +104,7 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
       end
 
       # user2 is able to read in readable
-      login_user user2
-      visit gws_report_files_main_path(site: site)
+      login_user user2, to: gws_report_files_main_path(site: site)
       within ".current-navi" do
         click_on I18n.t('gws/report.options.file_state.readable')
       end
@@ -117,8 +114,7 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
       end
 
       # depublish
-      login_user user0
-      visit gws_report_files_main_path(site: site)
+      login_user user0, to: gws_report_files_main_path(site: site)
       within ".current-navi" do
         click_on I18n.t('gws/report.options.file_state.sent')
       end
@@ -170,8 +166,7 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
     end
 
     it do
-      login_user user0
-      visit gws_report_files_main_path(site: site)
+      login_user user0, to: gws_report_files_main_path(site: site)
       within ".current-navi" do
         click_on I18n.t('gws/report.options.file_state.closed')
       end
@@ -200,8 +195,7 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
     end
 
     it do
-      login_user user0
-      visit gws_report_files_main_path(site: site)
+      login_user user0, to: gws_report_files_main_path(site: site)
       within ".current-navi" do
         click_on I18n.t('gws/report.options.file_state.sent')
       end

--- a/spec/features/gws/schedule/csv/facility_limit_spec.rb
+++ b/spec/features/gws/schedule/csv/facility_limit_spec.rb
@@ -45,9 +45,7 @@ describe "gws_schedule_csv", type: :feature, dbscope: :example, js: true do
     it do
       Gws::Schedule::Plan.all.destroy_all
 
-      login_user user
-
-      visit gws_schedule_csv_path(site: site)
+      login_user user, to: gws_schedule_csv_path(site: site)
       within "form#import_form" do
         attach_file "item[in_file]", csv_file
         page.accept_confirm do

--- a/spec/features/gws/schedule/facility_plans/approval/approve_user_spec.rb
+++ b/spec/features/gws/schedule/facility_plans/approval/approve_user_spec.rb
@@ -19,8 +19,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
   context "have no duplicate_private_gws_facility_plans" do
     it do
       # approve by user
-      login_user(user)
-      visit gws_schedule_facility_plan_path(site: site, facility: facility, id: item)
+      login_user(user, to: gws_schedule_facility_plan_path(site: site, facility: facility, id: item))
 
       within "#addon-basic" do
         expect(page).to have_text(I18n.t("gws/schedule.options.approved_state.request"))
@@ -49,8 +48,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       end
 
       # reset by user1
-      login_user(user1)
-      visit gws_schedule_facility_plan_path(site: site, facility: facility, id: item)
+      login_user(user1, to: gws_schedule_facility_plan_path(site: site, facility: facility, id: item))
 
       within "#addon-basic" do
         expect(page).to have_text(I18n.t("gws/schedule.options.approved_state.approve"))
@@ -79,8 +77,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       end
 
       # approve by user
-      login_user(user)
-      visit gws_schedule_facility_plan_path(site: site, facility: facility, id: item)
+      login_user(user, to: gws_schedule_facility_plan_path(site: site, facility: facility, id: item))
 
       within "#addon-basic" do
         expect(page).to have_text(I18n.t("gws/schedule.options.approved_state.request"))
@@ -109,8 +106,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       end
 
       # deny by user1
-      login_user(user1)
-      visit gws_schedule_facility_plan_path(site: site, facility: facility, id: item)
+      login_user(user1, to: gws_schedule_facility_plan_path(site: site, facility: facility, id: item))
 
       within "#addon-basic" do
         expect(page).to have_text(I18n.t("gws/schedule.options.approved_state.approve"))
@@ -139,8 +135,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       end
 
       # approve by user1
-      login_user(user1)
-      visit gws_schedule_facility_plan_path(site: site, facility: facility, id: item)
+      login_user(user1, to: gws_schedule_facility_plan_path(site: site, facility: facility, id: item))
 
       within "#addon-basic" do
         expect(page).to have_text(I18n.t("gws/schedule.options.approved_state.deny"))

--- a/spec/features/gws/schedule/facility_plans/approval/approved_and_locked_spec.rb
+++ b/spec/features/gws/schedule/facility_plans/approval/approved_and_locked_spec.rb
@@ -19,8 +19,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
     end
 
     it do
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       # create
       within ".gws-schedule-box .calendar-multiple-header" do
@@ -38,8 +37,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_ajax
 
       # approve
-      login_user(user2)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user2, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click
@@ -57,8 +55,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_notice I18n.t('ss.notice.saved')
 
       # able to edit within user2
-      login_user(user2)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user2, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click
@@ -80,8 +77,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       end
 
       # able to edit within user1
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click
@@ -111,8 +107,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
     end
 
     it do
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       # create
       within ".gws-schedule-box .calendar-multiple-header" do
@@ -130,8 +125,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_ajax
 
       # approve
-      login_user(user2)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user2, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click
@@ -149,8 +143,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_notice I18n.t('ss.notice.saved')
 
       # able to edit within user2
-      login_user(user2)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user2, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click
@@ -172,8 +165,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       end
 
       # disable edit within user1
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click

--- a/spec/features/gws/schedule/facility_plans/approval/deny_plans_spec.rb
+++ b/spec/features/gws/schedule/facility_plans/approval/deny_plans_spec.rb
@@ -13,8 +13,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
 
   context "have duplicate_private_gws_facility_plans" do
     it do
-      login_user(user)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user, to: gws_schedule_facilities_path(site: site))
 
       # create title1
       within ".gws-schedule-box .calendar-multiple-header" do
@@ -51,8 +50,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
 
   context "have no duplicate_private_gws_facility_plans" do
     it do
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       # create title1
       within ".gws-schedule-box .calendar-multiple-header" do
@@ -85,8 +83,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
     end
 
     it do
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       # create title1
       within ".gws-schedule-box .calendar-multiple-header" do
@@ -104,8 +101,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_ajax
 
       # approve title1
-      login_user(user)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click
@@ -123,8 +119,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_notice I18n.t('ss.notice.saved')
 
       # create faild title2
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       within ".gws-schedule-box .calendar-multiple-header" do
         click_on I18n.t("gws/schedule.links.add_plan")
@@ -141,8 +136,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
     end
 
     it do
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       # create title1
       within ".gws-schedule-box .calendar-multiple-header" do
@@ -160,8 +154,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_ajax
 
       # deny title1
-      login_user(user)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user, to: gws_schedule_facilities_path(site: site))
 
       within ".fc-event:not(.fc-holiday)" do
         first(".fc-title").click
@@ -179,8 +172,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
       wait_for_notice I18n.t('ss.notice.saved')
 
       # create title2
-      login_user(user1)
-      visit gws_schedule_facilities_path(site: site)
+      login_user(user1, to: gws_schedule_facilities_path(site: site))
 
       within ".gws-schedule-box .calendar-multiple-header" do
         click_on I18n.t("gws/schedule.links.add_plan")

--- a/spec/features/gws/schedule/facility_plans/max_days_limit_spec.rb
+++ b/spec/features/gws/schedule/facility_plans/max_days_limit_spec.rb
@@ -22,9 +22,7 @@ describe "gws_schedule_facility_plans", type: :feature, dbscope: :example, js: t
 
       it do
         Timecop.freeze(now) do
-          login_user user
-
-          visit gws_schedule_facility_plans_path(site: site, facility: facility)
+          login_user user, to: gws_schedule_facility_plans_path(site: site, facility: facility)
           click_on I18n.t("gws/schedule.links.add_plan")
 
           within "#item-form" do

--- a/spec/features/gws/schedule/plans/attendance_and_comment_spec.rb
+++ b/spec/features/gws/schedule/plans/attendance_and_comment_spec.rb
@@ -13,8 +13,7 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
 
   context "attendance crud" do
     it do
-      login_user user
-      visit gws_schedule_plan_path(site: site, id: item)
+      login_user user, to: gws_schedule_plan_path(site: site, id: item)
 
       within "#addon-gws-agents-addons-schedule-attendance" do
         wait_for_cbox_opened do
@@ -48,8 +47,7 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
 
   context "comment crud" do
     it do
-      login_user user
-      visit gws_schedule_plan_path(site: site, id: item)
+      login_user user, to: gws_schedule_plan_path(site: site, id: item)
 
       #
       # Create

--- a/spec/features/gws/schedule/plans/private_plan_spec.rb
+++ b/spec/features/gws/schedule/plans/private_plan_spec.rb
@@ -17,8 +17,7 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
     end
 
     it do
-      login_user user2
-      visit gws_schedule_user_plans_path(site: site, user: user1)
+      login_user user2, to: gws_schedule_user_plans_path(site: site, user: user1)
 
       within ".fc-day-grid" do
         expect(page).to have_css(".fc-event.fc-event-private", text: I18n.t("gws/schedule.private_plan"))

--- a/spec/features/gws/survey/basic_crud_spec.rb
+++ b/spec/features/gws/survey/basic_crud_spec.rb
@@ -106,8 +106,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       # answer by user1
       #
-      login_user user1
-      visit gws_survey_main_path(site: site)
+      login_user user1, to: gws_survey_main_path(site: site)
       click_on form_name
 
       # click print
@@ -138,8 +137,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       # answer by user2
       #
-      login_user user2
-      visit gws_survey_main_path(site: site)
+      login_user user2, to: gws_survey_main_path(site: site)
       click_on form_name
 
       # click print

--- a/spec/features/gws/survey/conditional_branch_spec.rb
+++ b/spec/features/gws/survey/conditional_branch_spec.rb
@@ -166,8 +166,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       # answer by user1
       #
-      login_user user1
-      visit gws_survey_main_path(site: site)
+      login_user user1, to: gws_survey_main_path(site: site)
       click_on form_name
       wait_for_js_ready
 
@@ -183,8 +182,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       # answer by user2
       #
-      login_user user2
-      visit gws_survey_main_path(site: site)
+      login_user user2, to: gws_survey_main_path(site: site)
       click_on form_name
       wait_for_js_ready
 
@@ -210,8 +208,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       # answer by user3
       #
-      login_user user3
-      visit gws_survey_main_path(site: site)
+      login_user user3, to: gws_survey_main_path(site: site)
       click_on form_name
       wait_for_js_ready
 
@@ -237,8 +234,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       # answer by user4
       #
-      login_user user4
-      visit gws_survey_main_path(site: site)
+      login_user user4, to: gws_survey_main_path(site: site)
       click_on form_name
       wait_for_js_ready
 

--- a/spec/features/gws/survey/copy_spec.rb
+++ b/spec/features/gws/survey/copy_spec.rb
@@ -55,8 +55,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       wait_for_notice I18n.t("ss.notice.answered")
 
       # answer by user1
-      login_user user1
-      visit gws_survey_main_path(site: site)
+      login_user user1, to: gws_survey_main_path(site: site)
       click_on form.name
       within "form#item-form" do
         within ".mod-gws-survey-custom_form" do
@@ -145,8 +144,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       expect(Gws::Survey::Form.all.count).to eq 2
 
       # answer by user2
-      login_user user2
-      visit gws_survey_main_path(site: site)
+      login_user user2, to: gws_survey_main_path(site: site)
 
       click_on copy_form.name
       within "form#item-form" do

--- a/spec/features/gws/survey/preview_spec.rb
+++ b/spec/features/gws/survey/preview_spec.rb
@@ -25,9 +25,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
   context "preview" do
     context "with user who is a manger and reader" do
       it do
-        login_user user1
-
-        visit gws_survey_main_path(site: site)
+        login_user user1, to: gws_survey_main_path(site: site)
         within ".current-navi" do
           click_on I18n.t("ss.navi.editable")
         end
@@ -47,9 +45,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
 
     context "with user who is a manger, but not a reader" do
       it do
-        login_user user2
-
-        visit gws_survey_main_path(site: site)
+        login_user user2, to: gws_survey_main_path(site: site)
         within ".current-navi" do
           click_on I18n.t("ss.navi.editable")
         end

--- a/spec/features/gws/survey/public_file_state_spec.rb
+++ b/spec/features/gws/survey/public_file_state_spec.rb
@@ -29,9 +29,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       # user1
       #
-      login_user user1
-
-      visit gws_survey_main_path(site: site)
+      login_user user1, to: gws_survey_main_path(site: site)
       click_on form.name
       expect(page).to have_css(".gws-survey .limit", text: Gws::Survey::Form.t(:due_date))
       within "form#item-form" do
@@ -43,9 +41,7 @@ describe "gws_survey", type: :feature, dbscope: :example, js: true do
       #
       #  user2
       #
-      login_user user2
-
-      visit gws_survey_main_path(site: site)
+      login_user user2, to: gws_survey_main_path(site: site)
       click_on form.name
       within "form#item-form" do
         fill_in "custom[#{column1.id}]", with: user2_answer

--- a/spec/features/gws/workflow/files/approves_spec.rb
+++ b/spec/features/gws/workflow/files/approves_spec.rb
@@ -124,8 +124,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user1: 申請を承認する
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: remand_comment1
@@ -153,8 +152,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user2: 申請を承認する
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: remand_comment2

--- a/spec/features/gws/workflow/files/attachments_within_steps_spec.rb
+++ b/spec/features/gws/workflow/files/attachments_within_steps_spec.rb
@@ -101,8 +101,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user1: 申請を承認する
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment1
@@ -155,8 +154,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user2: 申請を確認する
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: circulation_comment2

--- a/spec/features/gws/workflow/files/my_group_with_circulation_spec.rb
+++ b/spec/features/gws/workflow/files/my_group_with_circulation_spec.rb
@@ -79,8 +79,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user1: 申請を承認する
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment1
@@ -120,8 +119,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user2: 申請を確認する
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: circulation_comment2

--- a/spec/features/gws/workflow/files/request_by_agent_spec.rb
+++ b/spec/features/gws/workflow/files/request_by_agent_spec.rb
@@ -106,8 +106,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user2: 申請を承認する
       #
-      login_user user2
-      visit gws_workflow_files_path(site: site, state: "all")
+      login_user user2, to: gws_workflow_files_path(site: site, state: "all")
       click_on file_name
 
       within ".mod-workflow-approve" do
@@ -150,8 +149,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user3: 申請を確認する
       #
-      login_user user3
-      visit gws_workflow_files_path(site: site, state: "all")
+      login_user user3, to: gws_workflow_files_path(site: site, state: "all")
       click_on file_name
       expect(page).to have_css("#workflow_route", text: I18n.t("workflow.restart_workflow"))
 

--- a/spec/features/gws/workflow/files/restart_spec.rb
+++ b/spec/features/gws/workflow/files/restart_spec.rb
@@ -39,8 +39,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # admin: send request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
 
       within ".mod-workflow-request" do
         select route_name, from: "workflow_route"
@@ -69,8 +68,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment1
@@ -99,8 +97,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user2: remand request
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: remand_comment1
@@ -132,8 +129,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # admin: restart request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
 
       within ".mod-workflow-request" do
         select I18n.t("workflow.restart_workflow"), from: "workflow_route"
@@ -162,8 +158,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment2
@@ -193,8 +188,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user2: approve request
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment3
@@ -227,8 +221,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user3: approve request, he is the last one
       #
-      login_user user3
-      visit show_path
+      login_user user3, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment4

--- a/spec/features/gws/workflow/files/route_with_circulation_spec.rb
+++ b/spec/features/gws/workflow/files/route_with_circulation_spec.rb
@@ -93,8 +93,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user1: 申請を承認する
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment1
@@ -138,8 +137,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user2: 申請を確認する
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: circulation_comment2
@@ -177,8 +175,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user3: 申請を確認する
       #
-      login_user user3
-      visit show_path
+      login_user user3, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: circulation_comment3
@@ -222,8 +219,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       #
       # user4: 申請を確認する
       #
-      login_user user4
-      visit show_path
+      login_user user4, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: circulation_comment4

--- a/spec/features/gws/workflow2/files/alternatable_spec.rb
+++ b/spec/features/gws/workflow2/files/alternatable_spec.rb
@@ -57,8 +57,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
     context "when alternate is approved" do
       it do
-        login_user user1
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user1, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-request" do
@@ -115,8 +114,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # user2: 申請を承認する（代理承認者 ）
         #
-        login_user user2
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user2, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do
@@ -167,8 +165,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
     context "when original is approved" do
       it do
-        login_user user1
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user1, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-request" do
@@ -225,8 +222,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # admin: 申請を承認する（本来の承認者 ）
         #
-        login_user admin
-        visit gws_workflow2_files_main_path(site: site)
+        login_user admin, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do
@@ -284,8 +280,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
     context "when alternate is approved" do
       it do
-        login_user user1
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user1, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-request" do
@@ -344,8 +339,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # user2: 申請を承認する（代理承認者 ）
         #
-        login_user user2
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user2, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do
@@ -391,8 +385,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # admin: 申請を承認する
         #
-        login_user admin
-        visit gws_workflow2_files_main_path(site: site)
+        login_user admin, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do
@@ -446,8 +439,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
   context "when superior isn't existed" do
     it do
-      login_user user1
-      visit gws_workflow2_files_main_path(site: site)
+      login_user user1, to: gws_workflow2_files_main_path(site: site)
       click_on item.name
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-request" do
@@ -489,8 +481,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
     it do
       # user1: 申請する
-      login_user user1
-      visit gws_workflow2_files_main_path(site: site)
+      login_user user1, to: gws_workflow2_files_main_path(site: site)
       click_on item.name
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-request" do
@@ -557,8 +548,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       end
 
       # user2: 申請を承認する（代理承認者 ）
-      login_user user2
-      visit gws_workflow2_files_main_path(site: site)
+      login_user user2, to: gws_workflow2_files_main_path(site: site)
       click_on item.name
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
@@ -602,8 +592,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       expect(SS::Notification.count).to eq 1
 
       # user3: 申請を承認する
-      login_user user3
-      visit gws_workflow2_files_main_path(site: site)
+      login_user user3, to: gws_workflow2_files_main_path(site: site)
       click_on item.name
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do

--- a/spec/features/gws/workflow2/files/approves_spec.rb
+++ b/spec/features/gws/workflow2/files/approves_spec.rb
@@ -48,8 +48,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # 申請
         #
-        login_user user1
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user1, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
 
@@ -119,8 +118,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # 承認
         #
-        login_user user2
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user2, to: gws_workflow2_files_main_path(site: site)
         click_on I18n.t("gws/workflow2.navi.approve")
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
@@ -152,8 +150,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
     context "superior user isn't set if group isn't set superior user" do
       it do
-        login_user user1
-        visit gws_workflow2_files_main_path(site: site)
+        login_user user1, to: gws_workflow2_files_main_path(site: site)
         click_on item.name
         wait_for_turbo_frame "#workflow-approver-frame"
 

--- a/spec/features/gws/workflow2/files/attachments_within_steps_spec.rb
+++ b/spec/features/gws/workflow2/files/attachments_within_steps_spec.rb
@@ -70,8 +70,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: 申請する（承認者 1 段、1 名＋回覧者 1 段、1 名）
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-request" do
@@ -109,8 +108,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: 申請を承認する
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -198,8 +196,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: 申請を確認する
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.approve"))

--- a/spec/features/gws/workflow2/files/cancel_and_restart_spec.rb
+++ b/spec/features/gws/workflow2/files/cancel_and_restart_spec.rb
@@ -57,8 +57,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: send request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-request" do
@@ -97,8 +96,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -150,8 +148,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: cancel request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -203,8 +200,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: restart request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.cancelled"))
@@ -252,8 +248,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-approve" do
@@ -292,8 +287,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: approve request
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-approve" do
@@ -338,8 +332,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user3: approve request, he is the last one
       #
-      login_user user3
-      visit show_path
+      login_user user3, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-approve" do

--- a/spec/features/gws/workflow2/files/change_approver_aka_reroute_spec.rb
+++ b/spec/features/gws/workflow2/files/change_approver_aka_reroute_spec.rb
@@ -55,8 +55,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
   context "change approver (reroute)" do
     it do
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       #
@@ -100,8 +99,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: change first level approver to user4
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -144,8 +142,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: change second level approver to user4
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))

--- a/spec/features/gws/workflow2/files/crud_along_with_es_spec.rb
+++ b/spec/features/gws/workflow2/files/crud_along_with_es_spec.rb
@@ -73,8 +73,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         #
         # Create
         #
-        login_user gws_user
-        visit gws_workflow2_files_path(site, state: 'all')
+        login_user gws_user, to: gws_workflow2_files_path(site, state: 'all')
         within ".nav-menu" do
           click_link I18n.t('gws/workflow2.navi.find_by_keyword')
         end
@@ -133,8 +132,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(agent_user, site: site)).to be_falsey
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: agent_user, state: 'all').count).to eq 0
 
-        login_user agent_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user agent_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -145,8 +143,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(approver_user, site: site)).to be_falsey
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: approver_user, state: 'all').count).to eq 0
 
-        login_user approver_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user approver_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -157,8 +154,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(circular_user, site: site)).to be_falsey
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: circular_user, state: 'all').count).to eq 0
 
-        login_user circular_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user circular_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -169,8 +165,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(dest_user, site: site)).to be_falsey
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: dest_user, state: 'all').count).to eq 0
 
-        login_user dest_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user dest_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -180,8 +175,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         #
         # 承認依頼（承認者 1 名＋回覧者 1 名）
         #
-        login_user gws_user
-        visit gws_workflow2_files_path(site, state: 'all')
+        login_user gws_user, to: gws_workflow2_files_path(site, state: 'all')
         click_on item_name
         wait_for_turbo_frame "#workflow-approver-frame"
 
@@ -238,8 +232,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(agent_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: agent_user, state: 'all').count).to eq 1
 
-        login_user agent_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user agent_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -261,8 +254,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(approver_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: approver_user, state: 'all').count).to eq 1
 
-        login_user approver_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user approver_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -284,8 +276,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(circular_user, site: site)).to be_falsey
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: circular_user, state: 'all').count).to eq 0
 
-        login_user circular_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user circular_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -296,8 +287,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(dest_user, site: site)).to be_falsey
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: dest_user, state: 'all').count).to eq 0
 
-        login_user dest_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user dest_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -307,8 +297,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         #
         # 承認する
         #
-        login_user approver_user
-        visit gws_workflow2_files_path(site, state: 'all')
+        login_user approver_user, to: gws_workflow2_files_path(site, state: 'all')
         click_on item_name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do
@@ -341,8 +330,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(gws_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: gws_user, state: 'all').count).to eq 1
 
-        login_user gws_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user gws_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -370,8 +358,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(agent_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: agent_user, state: 'all').count).to eq 1
 
-        login_user agent_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user agent_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -399,8 +386,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(approver_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: approver_user, state: 'all').count).to eq 1
 
-        login_user approver_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user approver_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -428,8 +414,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(circular_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: circular_user, state: 'all').count).to eq 1
 
-        login_user circular_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user circular_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -457,8 +442,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(dest_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: dest_user, state: 'all').count).to eq 1
 
-        login_user dest_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user dest_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -504,8 +488,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         #
         # Create
         #
-        login_user gws_user
-        visit gws_workflow2_files_path(site, state: 'all')
+        login_user gws_user, to: gws_workflow2_files_path(site, state: 'all')
         within ".nav-menu" do
           click_link I18n.t('gws/workflow2.navi.find_by_keyword')
         end
@@ -566,8 +549,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(dest_user, site: site)).to be_falsey
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: dest_user, state: 'all').count).to eq 0
 
-        login_user dest_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user dest_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")
@@ -577,8 +559,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         #
         # 申請（承認なし）
         #
-        login_user gws_user
-        visit gws_workflow2_files_path(site, state: 'all')
+        login_user gws_user, to: gws_workflow2_files_path(site, state: 'all')
         click_on item_name
         wait_for_turbo_frame "#workflow-approver-frame"
 
@@ -624,8 +605,7 @@ describe "gws_workflow2_files", type: :feature, dbscope: :example, js: true, es:
         expect(item.readable?(dest_user, site: site)).to be_truthy
         expect(Gws::Workflow2::File.search(cur_site: site, cur_user: dest_user, state: 'all').count).to eq 1
 
-        login_user dest_user
-        visit gws_elasticsearch_search_main_path(site: site)
+        login_user dest_user, to: gws_elasticsearch_search_main_path(site: site)
         within "form#item-form" do
           fill_in "s[keyword]", with: "*:*"
           click_on I18n.t("ss.buttons.search")

--- a/spec/features/gws/workflow2/files/editable_approvers_spec.rb
+++ b/spec/features/gws/workflow2/files/editable_approvers_spec.rb
@@ -57,8 +57,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
   context "with editable approvers" do
     it do
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       #
@@ -102,8 +101,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: edit and approve
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -173,8 +171,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: edit and approve
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))

--- a/spec/features/gws/workflow2/files/my_group_alternate_spec.rb
+++ b/spec/features/gws/workflow2/files/my_group_alternate_spec.rb
@@ -33,8 +33,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
     end
 
     it do
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       #
@@ -83,8 +82,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: 申請を承認する（代理承認者 ）
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -153,8 +151,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
     end
 
     it do
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       #
@@ -205,8 +202,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user3: 申請を承認する（代理承認者 ）
       #
-      login_user user3
-      visit show_path
+      login_user user3, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))

--- a/spec/features/gws/workflow2/files/my_group_spec.rb
+++ b/spec/features/gws/workflow2/files/my_group_spec.rb
@@ -34,8 +34,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
     end
 
     it do
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       #
@@ -76,8 +75,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: 申請を承認する
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))

--- a/spec/features/gws/workflow2/files/pull_up_spec.rb
+++ b/spec/features/gws/workflow2/files/pull_up_spec.rb
@@ -53,8 +53,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
   context "pull up" do
     it do
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       #
@@ -101,8 +100,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user3: pull up request, he is the last one
       #
-      login_user user3
-      visit show_path
+      login_user user3, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))

--- a/spec/features/gws/workflow2/files/remand_and_restart_spec.rb
+++ b/spec/features/gws/workflow2/files/remand_and_restart_spec.rb
@@ -67,8 +67,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: send request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-request" do
@@ -107,8 +106,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -161,8 +159,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: remand request
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -238,8 +235,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: restart request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.remand"))
@@ -290,8 +286,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-approve" do
@@ -331,8 +326,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: approve request
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-approve" do
@@ -378,8 +372,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user3: approve request, he is the last one
       #
-      login_user user3
-      visit show_path
+      login_user user3, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-approve" do

--- a/spec/features/gws/workflow2/files/remand_with_back_to_previous_spec.rb
+++ b/spec/features/gws/workflow2/files/remand_with_back_to_previous_spec.rb
@@ -67,8 +67,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: send request
       #
-      login_user admin
-      visit show_path
+      login_user admin, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-request" do
@@ -108,8 +107,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))
@@ -170,8 +168,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: remand request
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-view" do
         expect(page).to have_css(".workflow_state", text: I18n.t("workflow.state.request"))

--- a/spec/features/gws/workflow2/files/request_by_agent_spec.rb
+++ b/spec/features/gws/workflow2/files/request_by_agent_spec.rb
@@ -64,8 +64,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
           #
           # admin: 申請書の作成
           #
-          login_user admin
-          visit new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
+          login_user admin, to: new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
 
           within "form#item-form" do
             fill_in "custom[#{column1.id}]", with: unique_id
@@ -142,8 +141,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
           #
           # user2: 申請を承認する
           #
-          login_user user2
-          visit gws_workflow2_files_path(site: site, state: "all")
+          login_user user2, to: gws_workflow2_files_path(site: site, state: "all")
           click_on file.name
           wait_for_turbo_frame "#workflow-approver-frame"
           within ".mod-workflow-view" do
@@ -202,8 +200,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
           #
           # user3: 申請を確認する
           #
-          login_user user3
-          visit gws_workflow2_files_path(site: site, state: "all")
+          login_user user3, to: gws_workflow2_files_path(site: site, state: "all")
           click_on file.name
           wait_for_turbo_frame "#workflow-approver-frame"
           within ".mod-workflow-view" do
@@ -270,8 +267,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
           #
           # admin: 申請書の作成
           #
-          login_user admin
-          visit new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
+          login_user admin, to: new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
 
           within "form#item-form" do
             fill_in "custom[#{column1.id}]", with: unique_id
@@ -362,8 +358,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # admin: 申請書の作成
         #
-        login_user admin
-        visit new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
+        login_user admin, to: new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
 
         within "form#item-form" do
           fill_in "custom[#{column1.id}]", with: unique_id
@@ -433,8 +428,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # user1_superior: 申請を承認する
         #
-        login_user user1_superior
-        visit gws_workflow2_files_path(site: site, state: "all")
+        login_user user1_superior, to: gws_workflow2_files_path(site: site, state: "all")
         click_on file.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do
@@ -513,8 +507,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # admin: 申請書の作成
         #
-        login_user admin
-        visit new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
+        login_user admin, to: new_gws_workflow2_form_file_path(site: site, state: "all", form_id: form)
 
         within "form#item-form" do
           fill_in "custom[#{column1.id}]", with: unique_id
@@ -586,8 +579,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # user1_superior: 申請を承認する
         #
-        login_user user1_superior
-        visit gws_workflow2_files_path(site: site, state: "all")
+        login_user user1_superior, to: gws_workflow2_files_path(site: site, state: "all")
         click_on file.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do
@@ -603,8 +595,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         #
         # user2: 申請を承認する
         #
-        login_user user2
-        visit gws_workflow2_files_path(site: site, state: "all")
+        login_user user2, to: gws_workflow2_files_path(site: site, state: "all")
         click_on file.name
         wait_for_turbo_frame "#workflow-approver-frame"
         within ".mod-workflow-view" do

--- a/spec/features/gws/workflow2/files/route_with_circulation_spec.rb
+++ b/spec/features/gws/workflow2/files/route_with_circulation_spec.rb
@@ -99,8 +99,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user1: 申請を承認する
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-approve" do
@@ -157,8 +156,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user2: 申請を確認する
       #
-      login_user user2
-      visit show_path
+      login_user user2, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-circulation" do
@@ -209,8 +207,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user3: 申請を確認する
       #
-      login_user user3
-      visit show_path
+      login_user user3, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-circulation" do
@@ -270,8 +267,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user4: 申請を確認する
       #
-      login_user user4
-      visit show_path
+      login_user user4, to: show_path
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-circulation" do

--- a/spec/features/gws/workflow2/files/specify_at_application_time_spec.rb
+++ b/spec/features/gws/workflow2/files/specify_at_application_time_spec.rb
@@ -60,8 +60,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # user0: 申請する（承認者 3＋回覧者 3 段）
       #
-      login_user user0
-      visit gws_workflow2_file_path(site: site, state: 'all', id: item)
+      login_user user0, to: gws_workflow2_file_path(site: site, state: 'all', id: item)
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-request" do
@@ -178,8 +177,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       end
 
       # user1: 承認
-      login_user user1
-      visit gws_workflow2_files_main_path(site: site)
+      login_user user1, to: gws_workflow2_files_main_path(site: site)
       click_on I18n.t("gws/workflow2.navi.approve")
       click_on item.name
       wait_for_turbo_frame "#workflow-approver-frame"
@@ -221,8 +219,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       end
 
       # user2: 承認
-      login_user user2
-      visit gws_workflow2_files_main_path(site: site)
+      login_user user2, to: gws_workflow2_files_main_path(site: site)
       click_on I18n.t("gws/workflow2.navi.approve")
       click_on item.name
       wait_for_turbo_frame "#workflow-approver-frame"
@@ -265,8 +262,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       end
 
       # user3: 承認
-      login_user user3
-      visit gws_workflow2_files_main_path(site: site)
+      login_user user3, to: gws_workflow2_files_main_path(site: site)
       click_on I18n.t("gws/workflow2.navi.approve")
       click_on item.name
       wait_for_turbo_frame "#workflow-approver-frame"
@@ -339,8 +335,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
     it do
       # user0: 申請する
-      login_user user0
-      visit gws_workflow2_file_path(site: site, state: 'all', id: item)
+      login_user user0, to: gws_workflow2_file_path(site: site, state: 'all', id: item)
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-request" do
@@ -374,8 +369,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
 
     it do
       # user0: 申請する
-      login_user user0
-      visit gws_workflow2_file_path(site: site, state: 'all', id: item)
+      login_user user0, to: gws_workflow2_file_path(site: site, state: 'all', id: item)
       wait_for_turbo_frame "#workflow-approver-frame"
 
       within ".mod-workflow-request" do

--- a/spec/features/gws/workflow2/files/without_approval_spec.rb
+++ b/spec/features/gws/workflow2/files/without_approval_spec.rb
@@ -41,8 +41,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       #
       # admin: 申請する（承認なし）
       #
-      login_user admin
-      visit gws_workflow2_file_path(site, item, state: 'all')
+      login_user admin, to: gws_workflow2_file_path(site, item, state: 'all')
       wait_for_turbo_frame "#workflow-approver-frame"
       within ".mod-workflow-request" do
         click_on I18n.t("workflow.buttons.request")

--- a/spec/features/gws/workflow2/form/applications/case1_spec.rb
+++ b/spec/features/gws/workflow2/form/applications/case1_spec.rb
@@ -26,8 +26,7 @@ describe "gws_workflow2_form_applications", type: :feature, dbscope: :example, j
   let(:memo) { Array.new(2) { "memo-#{unique_id}" } }
 
   it do
-    login_user user1
-    visit gws_workflow2_form_forms_path(site: site)
+    login_user user1, to: gws_workflow2_form_forms_path(site: site)
     within ".nav-menu" do
       click_on I18n.t("ss.links.new")
     end
@@ -45,8 +44,7 @@ describe "gws_workflow2_form_applications", type: :feature, dbscope: :example, j
     expect(form.name).to eq name
     expect(form.default_route_id).to eq route.id.to_s
 
-    login_user user2
-    visit gws_workflow2_form_forms_path(site: site)
+    login_user user2, to: gws_workflow2_form_forms_path(site: site)
     click_on form.name
     within ".nav-menu" do
       click_on I18n.t("ss.links.edit")

--- a/spec/features/gws/workflow2/routes/private_readable_setting_range_spec.rb
+++ b/spec/features/gws/workflow2/routes/private_readable_setting_range_spec.rb
@@ -33,8 +33,7 @@ describe "gws_workflow2_routes", type: :feature, dbscope: :example, js: true do
       #
       # Create
       #
-      login_user user1
-      visit gws_workflow2_routes_path(site: site)
+      login_user user1, to: gws_workflow2_routes_path(site: site)
       within ".nav-menu" do
         click_on I18n.t("ss.links.new")
       end

--- a/spec/features/gws/workload/cycles_spec.rb
+++ b/spec/features/gws/workload/cycles_spec.rb
@@ -66,8 +66,7 @@ describe "gws_workload_cycles", type: :feature, dbscope: :example, js: true do
       Timecop.travel(site.fiscal_first_date(year1)) do
         item
 
-        login_gws_user
-        visit download_path
+        login_gws_user to: download_path
         click_on I18n.t("ss.links.download")
         wait_for_download
 
@@ -79,8 +78,7 @@ describe "gws_workload_cycles", type: :feature, dbscope: :example, js: true do
       clear_downloads
 
       Timecop.travel(site.fiscal_first_date(year2)) do
-        login_gws_user
-        visit download_path
+        login_gws_user to: download_path
         click_on I18n.t("ss.links.download")
         wait_for_download
 
@@ -91,8 +89,7 @@ describe "gws_workload_cycles", type: :feature, dbscope: :example, js: true do
 
     it "#import" do
       Timecop.travel(site.fiscal_first_date(year1)) do
-        login_gws_user
-        visit import_path
+        login_gws_user to: import_path
 
         within "form#item-form" do
           attach_file "item[in_file]", "#{Rails.root}/spec/fixtures/gws/workload/cycles.csv"

--- a/spec/features/gws/workload/loads_spec.rb
+++ b/spec/features/gws/workload/loads_spec.rb
@@ -66,8 +66,7 @@ describe "gws_workload_loads", type: :feature, dbscope: :example, js: true do
       Timecop.travel(site.fiscal_first_date(year1)) do
         item
 
-        login_gws_user
-        visit download_path
+        login_gws_user to: download_path
         click_on I18n.t("ss.links.download")
         wait_for_download
 
@@ -79,8 +78,7 @@ describe "gws_workload_loads", type: :feature, dbscope: :example, js: true do
       clear_downloads
 
       Timecop.travel(site.fiscal_first_date(year2)) do
-        login_gws_user
-        visit download_path
+        login_gws_user to: download_path
         click_on I18n.t("ss.links.download")
         wait_for_download
 
@@ -91,8 +89,7 @@ describe "gws_workload_loads", type: :feature, dbscope: :example, js: true do
 
     it "#import" do
       Timecop.travel(site.fiscal_first_date(year1)) do
-        login_gws_user
-        visit import_path
+        login_gws_user to: import_path
 
         within "form#item-form" do
           attach_file "item[in_file]", "#{Rails.root}/spec/fixtures/gws/workload/loads.csv"

--- a/spec/features/member/blogs/release_page_spec.rb
+++ b/spec/features/member/blogs/release_page_spec.rb
@@ -75,8 +75,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1

--- a/spec/features/member/photos/release_page_spec.rb
+++ b/spec/features/member/photos/release_page_spec.rb
@@ -65,8 +65,7 @@ describe "member_photos", type: :feature, dbscope: :example, js: true do
         expect(mail.body.raw_source).to include(workflow_comment)
       end
 
-      login_user user
-      visit show_path
+      login_user user, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment

--- a/spec/features/sns/job/logs/basic_index_spec.rb
+++ b/spec/features/sns/job/logs/basic_index_spec.rb
@@ -37,8 +37,7 @@ describe "sns_job_logs", type: :feature, dbscope: :example, js: true do
   context "basic index" do
     context "with user1" do
       it do
-        login_user user1
-        visit job_sns_logs_path(site: site)
+        login_user user1, to: job_sns_logs_path(site: site)
 
         expect(page).to have_content(I18n.t(log1.class_name.underscore, scope: "job.models"))
         expect(page).to have_content(I18n.t(log2.class_name.underscore, scope: "job.models"))
@@ -60,8 +59,7 @@ describe "sns_job_logs", type: :feature, dbscope: :example, js: true do
 
     context "with user2" do
       it do
-        login_user user2
-        visit job_sns_logs_path(site: site)
+        login_user user2, to: job_sns_logs_path(site: site)
 
         expect(page).to have_no_content(I18n.t(log1.class_name.underscore, scope: "job.models"))
         expect(page).to have_no_content(I18n.t(log2.class_name.underscore, scope: "job.models"))

--- a/spec/features/sns/job/logs/filter_by_job_spec.rb
+++ b/spec/features/sns/job/logs/filter_by_job_spec.rb
@@ -36,8 +36,7 @@ describe "sns_job_logs", type: :feature, dbscope: :example, js: true do
   context "filter by job class name" do
     context "without ymd" do
       it do
-        login_user user
-        visit job_sns_logs_path(site: site)
+        login_user user, to: job_sns_logs_path(site: site)
 
         wait_for_event_fired "turbo:frame-load" do
           within ".list-head" do
@@ -67,8 +66,7 @@ describe "sns_job_logs", type: :feature, dbscope: :example, js: true do
 
     context "with ymd" do
       it do
-        login_user user
-        visit job_sns_logs_path(site: site)
+        login_user user, to: job_sns_logs_path(site: site)
         wait_for_event_fired "turbo:frame-load" do
           within ".list-head" do
             expect(page).to have_css("option[value='#{log1.class_name}']")

--- a/spec/features/sns/job/logs/move_spec.rb
+++ b/spec/features/sns/job/logs/move_spec.rb
@@ -35,8 +35,7 @@ describe "sns_job_logs", type: :feature, dbscope: :example, js: true do
 
   context "move with buttons" do
     it do
-      login_user user
-      visit job_sns_logs_path(site: site)
+      login_user user, to: job_sns_logs_path(site: site)
       wait_for_event_fired "turbo:frame-load" do
         within ".list-head" do
           click_on I18n.t('gws.history.days.today')
@@ -101,8 +100,7 @@ describe "sns_job_logs", type: :feature, dbscope: :example, js: true do
 
   context "move with directly inputting date value" do
     it do
-      login_user user
-      visit job_sns_logs_path(site: site)
+      login_user user, to: job_sns_logs_path(site: site)
 
       wait_for_event_fired "turbo:frame-load" do
         within ".list-head" do

--- a/spec/features/sys/error_page_spec.rb
+++ b/spec/features/sys/error_page_spec.rb
@@ -27,8 +27,7 @@ describe "sys_users", type: :feature, dbscope: :example do
     let(:title) { "403 Forbidden | SHIRASAGI" }
 
     before do
-      login_user user
-      visit sys_users_path
+      login_user user, to: sys_users_path
     end
 
     include_context "shows sys/sns error page"

--- a/spec/features/sys/notice/release_plan_spec.rb
+++ b/spec/features/sys/notice/release_plan_spec.rb
@@ -32,16 +32,13 @@ describe "sys_notice", type: :feature, dbscope: :example do
         visit sns_login_path
         expect(page).to have_no_css(".login-notice")
 
-        login_sys_user
-        visit sns_mypage_path
+        login_sys_user to: sns_mypage_path
         expect(page).to have_no_css(".notices")
 
-        login_cms_user
-        visit cms_contents_path(site: cms_site)
+        login_cms_user to: cms_contents_path(site: cms_site)
         expect(page).to have_no_css(".notices")
 
-        login_gws_user
-        visit gws_portal_path(site: gws_site)
+        login_gws_user to: gws_portal_path(site: gws_site)
         expect(page).to have_no_css(".sys-notices")
       end
     end
@@ -56,22 +53,19 @@ describe "sys_notice", type: :feature, dbscope: :example do
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
         end
 
-        login_sys_user
-        visit sns_mypage_path
+        login_sys_user to: sns_mypage_path
         within ".notices" do
           expect(page).to have_css(".list-item .notice-severity-high", text: notice0.name)
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
         end
 
-        login_cms_user
-        visit cms_contents_path(site: cms_site)
+        login_cms_user to: cms_contents_path(site: cms_site)
         within ".notices" do
           expect(page).to have_css(".list-item .notice-severity-high", text: notice0.name)
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
         end
 
-        login_gws_user
-        visit gws_portal_path(site: gws_site)
+        login_gws_user to: gws_portal_path(site: gws_site)
         within ".sys-notices" do
           expect(page).to have_css(".list-item .notice-severity-high", text: notice0.name)
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
@@ -89,22 +83,19 @@ describe "sys_notice", type: :feature, dbscope: :example do
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
         end
 
-        login_sys_user
-        visit sns_mypage_path
+        login_sys_user to: sns_mypage_path
         within ".notices" do
           expect(page).to have_css(".list-item .notice-severity-high", text: notice0.name)
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
         end
 
-        login_cms_user
-        visit cms_contents_path(site: cms_site)
+        login_cms_user to: cms_contents_path(site: cms_site)
         within ".notices" do
           expect(page).to have_css(".list-item .notice-severity-high", text: notice0.name)
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
         end
 
-        login_gws_user
-        visit gws_portal_path(site: gws_site)
+        login_gws_user to: gws_portal_path(site: gws_site)
         within ".sys-notices" do
           expect(page).to have_css(".list-item .notice-severity-high", text: notice0.name)
           expect(page).to have_css(".list-item .notice-severity-normal", text: notice1.name)
@@ -119,16 +110,13 @@ describe "sys_notice", type: :feature, dbscope: :example do
         visit sns_login_path
         expect(page).to have_no_css(".login-notice")
 
-        login_sys_user
-        visit sns_mypage_path
+        login_sys_user to: sns_mypage_path
         expect(page).to have_no_css(".notices")
 
-        login_cms_user
-        visit cms_contents_path(site: cms_site)
+        login_cms_user to: cms_contents_path(site: cms_site)
         expect(page).to have_no_css(".notices")
 
-        login_gws_user
-        visit gws_portal_path(site: gws_site)
+        login_gws_user to: gws_portal_path(site: gws_site)
         expect(page).to have_no_css(".sys-notices")
       end
     end

--- a/spec/features/sys/site_maint_mode_spec.rb
+++ b/spec/features/sys/site_maint_mode_spec.rb
@@ -50,16 +50,14 @@ describe "maint mode", type: :feature, dbscope: :example, js: true do
     expect(site1.maint_remark).to eq maint_remark
 
     # 除外ユーザーでログイン
-    login_user user1
-    visit sns_mypage_path
+    login_user user1, to: sns_mypage_path
     expect(page).to have_text(I18n.t("ss.under_maintenance_mode"))
     expect(page).to have_link(site1.name, href: "/.s#{site1.id}/cms/contents")
     click_on site1.name
     expect(page).to have_no_css(".maint-mode-text")
 
     # 除外ユーザーではないユーザーでログイン
-    login_user user2
-    visit sns_mypage_path
+    login_user user2, to: sns_mypage_path
     expect(page).to have_text(I18n.t("ss.under_maintenance_mode"))
     expect(page).to have_no_link(site1.name, href: "/.s#{site1.id}/cms/contents")
     visit cms_contents_path(site: site1)

--- a/spec/features/webmail/error_page_spec.rb
+++ b/spec/features/webmail/error_page_spec.rb
@@ -30,8 +30,7 @@ describe "webmail_users", type: :feature, dbscope: :example do
     let(:title) { "403 Forbidden | SHIRASAGI" }
 
     before do
-      login_user user
-      visit webmail_users_path
+      login_user user, to: webmail_users_path
     end
 
     include_context "shows webmail error page"

--- a/spec/features/webmail/login_spec.rb
+++ b/spec/features/webmail/login_spec.rb
@@ -14,6 +14,7 @@ describe "webmail_login", type: :feature, dbscope: :example, imap: true, js: tru
         fill_in "item[password]", with: "pass"
         click_button I18n.t("ss.login")
       end
+      expect(page).to have_css(".error-message", text: I18n.t("sns.errors.invalid_login"))
       expect(current_path).to eq login_path
     end
   end
@@ -26,6 +27,9 @@ describe "webmail_login", type: :feature, dbscope: :example, imap: true, js: tru
         fill_in "item[password]", with: "pass"
         click_button I18n.t("ss.login")
       end
+      within ".user-navigation" do
+        expect(page).to have_css(".user-name", text: user.name)
+      end
       expect(current_path).to eq main_path
     end
 
@@ -36,6 +40,9 @@ describe "webmail_login", type: :feature, dbscope: :example, imap: true, js: tru
         fill_in "item[password]", with: "pass"
         click_button I18n.t("ss.login")
       end
+      within ".user-navigation" do
+        expect(page).to have_css(".user-name", text: user.name)
+      end
       expect(current_path).to eq main_path
       within ".user-navigation" do
         wait_for_event_fired("turbo:frame-load") { click_on user.name }
@@ -43,9 +50,11 @@ describe "webmail_login", type: :feature, dbscope: :example, imap: true, js: tru
         click_on I18n.t("ss.logout")
       end
 
+      expect(page).to have_css(".login-box", text: SS.version)
       expect(current_path).to eq login_path
 
       visit main_path
+      expect(page).to have_css(".login-box", text: SS.version)
       expect(current_path).to eq login_path
     end
   end
@@ -57,6 +66,9 @@ describe "webmail_login", type: :feature, dbscope: :example, imap: true, js: tru
         fill_in "item[email]", with: user.email
         fill_in "item[password]", with: "pass"
         click_button I18n.t("ss.login")
+      end
+      within ".user-navigation" do
+        expect(page).to have_css(".user-name", text: user.name)
       end
 
       expect(current_path).to eq webmail_addresses_path(group: "-")
@@ -73,6 +85,9 @@ describe "webmail_login", type: :feature, dbscope: :example, imap: true, js: tru
         fill_in "item[email]", with: user.email
         fill_in "item[password]", with: "pass"
         click_button I18n.t("ss.login")
+      end
+      within ".user-navigation" do
+        expect(page).to have_css(".user-name", text: user.name)
       end
 
       expect(current_path).to eq webmail_addresses_path(group: "-")
@@ -97,6 +112,9 @@ describe "webmail_login", type: :feature, dbscope: :example, imap: true, js: tru
         fill_in "item[email]", with: user.email
         fill_in "item[password]", with: "pass"
         click_button I18n.t("ss.login")
+      end
+      within ".user-navigation" do
+        expect(page).to have_css(".user-name", text: user.name)
       end
 
       expect(current_path).to eq main_path

--- a/spec/features/workflow/back_to_previous_spec.rb
+++ b/spec/features/workflow/back_to_previous_spec.rb
@@ -74,8 +74,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -103,8 +102,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: remand request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -134,8 +132,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: approve request again
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -164,8 +161,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -196,8 +192,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user3: approve request
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -266,8 +261,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -294,8 +288,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -326,8 +319,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user3: remand request
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -356,8 +348,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: remand request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -390,8 +381,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: remand request; first user remand a request then document workflow status goes to remand
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -465,8 +455,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -494,8 +483,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: remand request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -525,8 +513,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: approve request again
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -555,8 +542,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -587,8 +573,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user3: approve request
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -657,8 +642,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -683,8 +667,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -715,8 +698,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user3: remand request
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -749,8 +731,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user2: remand request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)
@@ -783,8 +764,7 @@ describe "back_to_previous route", type: :feature, dbscope: :example, js: true d
         #
         # user1: remand request; first user remand a request then document workflow status goes to remand
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         wait_for_all_turbo_frames
         expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
         expect(page).to have_css(".mod-workflow-view dd", text: workflow_comment)

--- a/spec/features/workflow/close_page_spec.rb
+++ b/spec/features/workflow/close_page_spec.rb
@@ -79,8 +79,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
       #
       # user1: approve request
       #
-      login_user user1
-      visit show_path
+      login_user user1, to: show_path
 
       within ".mod-workflow-approve" do
         fill_in "remand[comment]", with: approve_comment1

--- a/spec/features/workflow/edit_requested_page_spec.rb
+++ b/spec/features/workflow/edit_requested_page_spec.rb
@@ -65,8 +65,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
         #
         # user1: edit requested page
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
         click_on I18n.t("ss.links.edit")
         within "#item-form" do
           fill_in_ckeditor "item[html]", with: unique_id

--- a/spec/features/workflow/multi_stage_spec.rb
+++ b/spec/features/workflow/multi_stage_spec.rb
@@ -102,8 +102,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -151,8 +150,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment2
@@ -201,8 +199,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user3: approve request, he is the last one
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment3
@@ -319,8 +316,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -350,8 +346,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment2
@@ -392,8 +387,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user3: approve request, he is the last one
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment3
@@ -501,8 +495,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -549,8 +542,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment2
@@ -598,8 +590,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user3: remand request, he is the last one
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: remand_comment3
@@ -719,8 +710,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -761,8 +751,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         #
         # user3: approve request, user2 no needs to approve request
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment3

--- a/spec/features/workflow/my_group_spec.rb
+++ b/spec/features/workflow/my_group_spec.rb
@@ -112,8 +112,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -161,8 +160,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment2
@@ -302,8 +300,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         #
         # user1: remand request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: remand_comment1
@@ -426,8 +423,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -475,8 +471,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         #
         # user2: remand request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: remand_comment2

--- a/spec/features/workflow/pull_up_spec.rb
+++ b/spec/features/workflow/pull_up_spec.rb
@@ -82,8 +82,7 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         #
         # user3: pull up request, he is the last one
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment3
@@ -166,8 +165,7 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         #
         # user2: pull up request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment2
@@ -255,8 +253,7 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         #
         # user3: pull up request, he is the last one
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment3
@@ -339,8 +336,7 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         #
         # user2: pull up request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment2

--- a/spec/features/workflow/release_page_spec.rb
+++ b/spec/features/workflow/release_page_spec.rb
@@ -77,8 +77,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -177,8 +176,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           #
           # user1: approve request
           #
-          login_user user1
-          visit show_path
+          login_user user1, to: show_path
 
           within ".mod-workflow-approve" do
             fill_in "remand[comment]", with: approve_comment1

--- a/spec/features/workflow/restart_spec.rb
+++ b/spec/features/workflow/restart_spec.rb
@@ -69,8 +69,7 @@ describe "restart", type: :feature, dbscope: :example, js: true do
         #
         # user1: remand request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: remand_comment1
@@ -119,8 +118,7 @@ describe "restart", type: :feature, dbscope: :example, js: true do
         #
         # user1: approve request
         #
-        login_user user1
-        visit show_path
+        login_user user1, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment1
@@ -142,8 +140,7 @@ describe "restart", type: :feature, dbscope: :example, js: true do
         #
         # user2: approve request
         #
-        login_user user2
-        visit show_path
+        login_user user2, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment2
@@ -166,8 +163,7 @@ describe "restart", type: :feature, dbscope: :example, js: true do
         #
         # user3: approve request, he is the last one
         #
-        login_user user3
-        visit show_path
+        login_user user3, to: show_path
 
         within ".mod-workflow-approve" do
           fill_in "remand[comment]", with: approve_comment3

--- a/spec/support/cms/user.rb
+++ b/spec/support/cms/user.rb
@@ -23,6 +23,6 @@ def cms_role
   cms_role
 end
 
-def login_cms_user
-  login_user cms_user
+def login_cms_user(to: nil)
+  login_user cms_user, to: to
 end

--- a/spec/support/gws/user.rb
+++ b/spec/support/gws/user.rb
@@ -29,8 +29,8 @@ def gws_sys_user
   create_gws_users[:sys_user]
 end
 
-def login_gws_user
-  login_user(gws_user)
+def login_gws_user(to: nil)
+  login_user(gws_user, to: to)
 end
 
 def create_gws_users

--- a/spec/support/ss/user.rb
+++ b/spec/support/ss/user.rb
@@ -16,22 +16,26 @@ def ss_site
   ss_site
 end
 
-def login_user(user, pass: nil, login_path: nil)
+def login_user(user, pass: nil, login_path: nil, to: nil)
   visit login_path.presence || sns_login_path
+  ref = to.presence || '/robots.txt'
   within "form" do
     fill_in "item[email]", with: user.email.presence || user.uid
     fill_in "item[password]", with: pass.presence || user.in_password.presence || "pass"
-    set_value_to_hidden_input('input#ref', '/robots.txt')
+    set_value_to_hidden_input('input#ref', ref)
     click_button I18n.t("ss.login", locale: I18n.default_locale)
   end
-  expect(page).to have_content('User-agent')
-  expect(page).to have_no_css('.login-box [name="item[password]"]')
-
   # rubocop:disable Rails/I18nLocaleAssignment
   if user.lang.present?
     I18n.locale = user.lang.to_sym
   end
   # rubocop:enable Rails/I18nLocaleAssignment
+
+  if ref == '/robots.txt'
+    expect(page).to have_content('User-agent')
+  else
+    expect(page).to have_css('#head', text: user.name)
+  end
 end
 
 # set value to hidden input

--- a/spec/support/sys/user.rb
+++ b/spec/support/sys/user.rb
@@ -10,6 +10,6 @@ def sys_role
   sys_role
 end
 
-def login_sys_user
-  login_user sys_user
+def login_sys_user(to: nil)
+  login_user sys_user, to: to
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

- Chrome 134 でテストが失敗する問題の修正
- テストヘルパー "#login_user" に `to: ` オプションを追加し、このオプションを利用するように変更