### PR TITLE
[fix] job/sys/site_import_job some issues

### DIFF
--- a/app/jobs/sys/site_export_job.rb
+++ b/app/jobs/sys/site_export_job.rb
@@ -43,6 +43,7 @@ class Sys::SiteExportJob < SS::ApplicationJob
     invoke :export_cms_theme_templates
     invoke :export_cms_source_cleaner_templates
     invoke :export_cms_loop_settings
+    invoke :export_cms_check_links_ignore_urls
     invoke :export_ezine_columns
     invoke :export_inquiry_columns
     invoke :export_kana_dictionaries
@@ -208,6 +209,10 @@ class Sys::SiteExportJob < SS::ApplicationJob
 
   def export_cms_loop_settings
     export_documents "cms_loop_settings", Cms::LoopSetting
+  end
+
+  def export_cms_check_links_ignore_urls
+    export_documents "cms_check_links_ignore_urls", Cms::CheckLinks::IgnoreUrl
   end
 
   def export_ezine_columns

--- a/app/jobs/sys/site_export_job.rb
+++ b/app/jobs/sys/site_export_job.rb
@@ -48,6 +48,7 @@ class Sys::SiteExportJob < SS::ApplicationJob
     invoke :export_kana_dictionaries
     invoke :export_opendata_dataset_groups
     invoke :export_opendata_licenses
+    invoke :export_guide_diagram_point
 
     # files
     invoke :export_cms_files
@@ -227,6 +228,10 @@ class Sys::SiteExportJob < SS::ApplicationJob
 
   def export_opendata_licenses
     export_documents "opendata_licenses", Opendata::License
+  end
+
+  def export_guide_diagram_point
+    export_documents "guide_diagram_point", Guide::Diagram::Point
   end
 
   def export_cms_files

--- a/app/jobs/sys/site_import/contents.rb
+++ b/app/jobs/sys/site_import/contents.rb
@@ -41,12 +41,6 @@ module Sys::SiteImport::Contents
             column_value['file_ids'] = column_value['file_ids'].map do |file_id|
               @ss_files_map[file_id]
             end
-            if column_value.value.present?
-              @ss_files_url.each do |src, dst|
-                src_path = /#{::Regexp.escape(::File.dirname(src))}\/[^"]*/
-                column_value.value = column_value.value.gsub(src_path, dst)
-              end
-            end
           end
           column_value
         end

--- a/app/jobs/sys/site_import/file.rb
+++ b/app/jobs/sys/site_import/file.rb
@@ -103,9 +103,10 @@ module Sys::SiteImport::File
       next if item.column_values.blank?
 
       item.column_values.each do |column_value|
-        value = column_value.value
-        next if value.blank?
+        next if !column_value.respond_to?(:value)
+        next if column_value.value.blank?
 
+        value = column_value.value
         new_value = value.gsub(src_path, dst_path)
         column_value.set(value: new_value) if new_value != value
       end

--- a/app/jobs/sys/site_import/file.rb
+++ b/app/jobs/sys/site_import/file.rb
@@ -21,12 +21,19 @@ module Sys::SiteImport::File
       end
 
       if item.save
-        src = SS::File.new(id: id, name: item.name, filename: item.filename)
+        src = SS::File.new(id: id, name: data["name"], filename: data["filename"])
         src = src.becomes_with_model
+
         @ss_files_map[id] = item.id
         @ss_files_url[src.url] = item.url
         FileUtils.mkdir_p(File.dirname(item.path))
         FileUtils.cp(path, item.path) # FileUtils.mv
+
+        if Fs.to_io(path) { |io| SS::ImageConverter.image?(io) }
+          @ss_files_url[src.thumb_url] = item.thumb_url
+          item.in_disable_variant_processing = false
+          item.update_variants
+        end
       else
         @task.log "[#{item.class}##{item.id}] " + item.errors.full_messages.join(' ')
       end
@@ -65,11 +72,13 @@ module Sys::SiteImport::File
   end
 
   def replace_html_with_url(src, dst)
-    src_path = /="#{::Regexp.escape(::File.dirname(src))}\/[^"]*/
+    src_path = "=\"#{src}"
     dst_path = "=\"#{dst}"
 
+    # html fields
     fields = Cms::ApiFilter::Contents::HTML_FIELDS + Cms::ApiFilter::Contents::CONTACT_FIELDS
-    cond = { "$or" => fields.map { |field| { field => src_path } } }
+    path = "=\"#{::Regexp.escape(src)}"
+    cond = { "$or" => fields.map { |field| { field => /#{path}/ } } }
 
     criterias = [
       Cms::Page.in(id: @cms_pages_map.values),
@@ -85,6 +94,20 @@ module Sys::SiteImport::File
           attr[field] = html if item[field] != html
         end
         item.set(attr) if attr.present?
+      end
+    end
+
+    # column_values
+    Cms::Page.in(id: @cms_pages_map.values).each do |item|
+      next if !item.respond_to?(:column_values)
+      next if item.column_values.blank?
+
+      item.column_values.each do |column_value|
+        value = column_value.value
+        next if value.blank?
+
+        new_value = value.gsub(src_path, dst_path)
+        column_value.set(value: new_value) if new_value != value
       end
     end
   end

--- a/app/jobs/sys/site_import_job.rb
+++ b/app/jobs/sys/site_import_job.rb
@@ -66,6 +66,7 @@ class Sys::SiteImportJob < SS::ApplicationJob
     invoke :import_cms_translate_text_caches
     invoke :import_cms_page_search
     invoke :import_cms_guides
+    invoke :import_cms_check_links_ignore_urls
 
     FileUtils.rm_rf(@import_dir)
     @task.log("Completed.")
@@ -524,5 +525,10 @@ class Sys::SiteImportJob < SS::ApplicationJob
       end
       save_document(point)
     end
+  end
+
+  def import_cms_check_links_ignore_urls
+    @task.log("- import cms_check_links_ignore_urls")
+    @cms_roles_map = import_documents "cms_check_links_ignore_urls", Cms::CheckLinks::IgnoreUrl, %w(site_id name)
   end
 end

--- a/app/jobs/sys/site_import_job.rb
+++ b/app/jobs/sys/site_import_job.rb
@@ -183,6 +183,7 @@ class Sys::SiteImportJob < SS::ApplicationJob
 
     data['form_id'] = @cms_forms_map[data['form_id']] if data['form_id'].present?
     data['st_form_ids'] = convert_ids(@cms_forms_map, data['st_form_ids']) if data['st_form_ids'].present?
+    data['st_form_default_id'] = @cms_forms_map[data['st_form_default_id']] if data['st_form_default_id'].present?
 
     data['loop_setting_id'] = @cms_loop_settings_map[data['loop_setting_id']] if data['loop_setting_id'].present?
 
@@ -348,20 +349,20 @@ class Sys::SiteImportJob < SS::ApplicationJob
 
   def import_cms_editor_templates
     @task.log("- import cms_editor_templates")
-    
+
     read_json("cms_editor_templates").each do |data|
       id   = data.delete('_id')
       data = convert_data(data)
-  
+
       thumb_id = data['thumb_id']
       file_ids = data['file_ids']
 
       # Find or initialize the editor template for the destination site
       cond = { name: data['name'], site_id: @dst_site.id }
       item = Cms::EditorTemplate.find_or_initialize_by(cond)
-  
+
       data.each { |k, v| item[k] = v }
-  
+
       if thumb_id.present?
         new_thumb_id = @ss_files_map[thumb_id]
         if new_thumb_id.present?
@@ -370,13 +371,13 @@ class Sys::SiteImportJob < SS::ApplicationJob
           item.thumb_id = thumb_file.id
         end
       end
-  
+
       # Process additional files
       if file_ids.present?
         new_file_ids = convert_ids(@ss_files_map, file_ids)
         item.file_ids = new_file_ids
       end
-  
+
       save_document(item)
     end
   end
@@ -393,7 +394,7 @@ class Sys::SiteImportJob < SS::ApplicationJob
 
       save_document(item)
     end
-  end  
+  end
 
   def import_theme_templates
     @task.log("- import theme templates")
@@ -407,7 +408,7 @@ class Sys::SiteImportJob < SS::ApplicationJob
 
       save_document(item)
     end
-  end  
+  end
 
   def import_cms_word_dictionaries
     @task.log("- import cms word dictionaries")

--- a/app/models/fs.rb
+++ b/app/models/fs.rb
@@ -223,7 +223,7 @@ module Fs
     return name if name.blank?
 
     if Zip.unicode_names
-      SS::FilenameUtils.convert_to_url_safe_japanese(name)
+      SS::FilenameUtils.convert_to_url_safe_japanese(name, normalize: false)
     else
       name.encode('cp932', invalid: :replace, undef: :replace, replace: "_")
     end

--- a/lib/ss/filename_utils.rb
+++ b/lib/ss/filename_utils.rb
@@ -111,7 +111,7 @@ class SS::FilenameUtils
       str.each_char.all? { |ch| url_safe_japanese_char?(ch) }
     end
 
-    def convert_to_url_safe_japanese(str)
+    def convert_to_url_safe_japanese(str, normalize: true)
       chars = normalize(str).each_char.map do |ch|
         next ch if url_safe_japanese_char?(ch)
 
@@ -125,6 +125,7 @@ class SS::FilenameUtils
       end
 
       ret = chars.join
+      return ret if !normalize
 
       #
       # 様々な案件を考慮して、なんとなく納得感のある正規化を ret に対して実施する。

--- a/spec/jobs/sys/site_import/cms_check_links_ignore_urls_spec.rb
+++ b/spec/jobs/sys/site_import/cms_check_links_ignore_urls_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Sys::SiteImportJob, dbscope: :example do
+  let!(:source_site) { create :cms_site_unique }
+  let!(:item1) { create :check_links_ignore_url, site: source_site }
+  let!(:item2) { create :check_links_ignore_url, site: source_site }
+
+  let!(:file_path) do
+    save_export_root = Sys::SiteExportJob.export_root
+    Sys::SiteExportJob.export_root = tmpdir
+
+    begin
+      job = ::Sys::SiteExportJob.new
+      job.task = ::Tasks::Cms.mock_task(source_site_id: source_site.id)
+      job.perform
+      output_zip = job.instance_variable_get(:@output_zip)
+
+      output_zip
+    ensure
+      Sys::SiteExportJob.export_root = save_export_root
+    end
+  end
+
+  describe "#perform" do
+    let!(:destination_site) { create :cms_site_unique }
+
+    it do
+      job = ::Sys::SiteImportJob.new
+      job.task = ::Tasks::Cms.mock_task(target_site_id: destination_site.id, import_file: file_path)
+      job.perform
+
+      expect(Cms::CheckLinks::IgnoreUrl.site(destination_site).count).to eq 2
+      dest_item1 = Cms::CheckLinks::IgnoreUrl.site(destination_site).where(name: item1.name).first
+      dest_item2 = Cms::CheckLinks::IgnoreUrl.site(destination_site).where(name: item2.name).first
+      expect(dest_item1).to be_present
+      expect(dest_item2).to be_present
+    end
+  end
+end

--- a/spec/jobs/sys/site_import/guide_spec.rb
+++ b/spec/jobs/sys/site_import/guide_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+describe Sys::SiteImportJob, dbscope: :example do
+  let!(:source_site) { create :cms_site_unique }
+  let!(:source_setting) { create :cms_loop_setting, site: source_site }
+
+  let!(:node1) { create :guide_node_guide, site: source_site }
+  let!(:procedure1_1) do
+    create(:guide_procedure, cur_site: source_site, cur_node: node1, order: 10,
+      name: "procedure1", id_name: unique_id)
+  end
+  let!(:procedure1_2) do
+    create(:guide_procedure, cur_site: source_site, cur_node: node1, order: 20,
+      name: "procedure2", id_name: unique_id)
+  end
+  let!(:question1_1) do
+    create(:guide_question, cur_site: source_site, cur_node: node1, order: 10,
+      name: "question1", id_name: unique_id, in_edges: in_edges(procedure1_1))
+  end
+  let!(:question1_2) do
+    create(:guide_question, cur_site: source_site, cur_node: node1, order: 20,
+      name: "question2", id_name: unique_id, in_edges: in_edges(procedure1_2))
+  end
+
+  let!(:node2) { create :guide_node_guide, site: source_site }
+  let!(:procedure2_1) do
+    create(:guide_procedure, cur_site: source_site, cur_node: node2, order: 10,
+      name: "procedure1", id_name: unique_id)
+  end
+  let!(:procedure2_2) do
+    create(:guide_procedure, cur_site: source_site, cur_node: node2, order: 20,
+      name: "procedure2", id_name: unique_id)
+  end
+  let!(:question2_1) do
+    create(:guide_question, cur_site: source_site, cur_node: node2, order: 10,
+      name: "question1", id_name: unique_id, in_edges: in_edges(procedure2_1))
+  end
+  let!(:question2_2) do
+    create(:guide_question, cur_site: source_site, cur_node: node2, order: 20,
+      name: "question2", id_name: unique_id, in_edges: in_edges(procedure2_2))
+  end
+
+  def in_edges(point)
+    [
+      { value: I18n.t("guide.links.applicable"), question_type: "yes_no", point_ids: [point.id] },
+      { value: I18n.t("guide.links.not_applicable"), question_type: "yes_no", point_ids: [] }
+    ]
+  end
+
+  let!(:file_path) do
+    save_export_root = Sys::SiteExportJob.export_root
+    Sys::SiteExportJob.export_root = tmpdir
+
+    begin
+      job = ::Sys::SiteExportJob.new
+      job.task = ::Tasks::Cms.mock_task(source_site_id: source_site.id)
+      job.perform
+      output_zip = job.instance_variable_get(:@output_zip)
+
+      output_zip
+    ensure
+      Sys::SiteExportJob.export_root = save_export_root
+    end
+  end
+
+  describe "#perform" do
+    let!(:destination_site) { create :cms_site_unique }
+
+    it do
+      job = ::Sys::SiteImportJob.new
+      job.task = ::Tasks::Cms.mock_task(target_site_id: destination_site.id, import_file: file_path)
+      job.perform
+
+      expect(Guide::Node::Guide.site(destination_site).count).to eq 2
+      dest_node1 = Guide::Node::Guide.site(destination_site).where(filename: node1.filename).first
+      dest_node2 = Guide::Node::Guide.site(destination_site).where(filename: node2.filename).first
+      expect(dest_node1).to be_present
+      expect(dest_node2).to be_present
+
+      # node1
+      expect(Guide::Procedure.site(destination_site).node(dest_node1).count).to eq 2
+      dest_procedure1_1 = Guide::Procedure.site(destination_site).node(dest_node1).where(id_name: procedure1_1.id_name).first
+      dest_procedure1_2 = Guide::Procedure.site(destination_site).node(dest_node1).where(id_name: procedure1_2.id_name).first
+      expect(dest_procedure1_1).to be_present
+      expect(dest_procedure1_2).to be_present
+
+      expect(Guide::Question.site(destination_site).node(dest_node1).count).to eq 2
+      dest_question1_1 = Guide::Question.site(destination_site).node(dest_node1).where(id_name: question1_1.id_name).first
+      dest_question1_2 = Guide::Question.site(destination_site).node(dest_node1).where(id_name: question1_2.id_name).first
+      expect(dest_question1_1).to be_present
+      expect(dest_question1_2).to be_present
+
+      dest_question1_1_edges = dest_question1_1.edges.map do |edge|
+        { value: edge[:value], question_type: edge[:question_type], point_ids: edge[:point_ids] }
+      end
+      dest_question1_2_edges = dest_question1_2.edges.map do |edge|
+        { value: edge[:value], question_type: edge[:question_type], point_ids: edge[:point_ids] }
+      end
+      expect(dest_question1_1_edges).to match_array(in_edges(dest_procedure1_1))
+      expect(dest_question1_2_edges).to match_array(in_edges(dest_procedure1_2))
+
+      # node2
+      expect(Guide::Procedure.site(destination_site).node(dest_node2).count).to eq 2
+      dest_procedure2_1 = Guide::Procedure.site(destination_site).node(dest_node2).where(id_name: procedure2_1.id_name).first
+      dest_procedure2_2 = Guide::Procedure.site(destination_site).node(dest_node2).where(id_name: procedure2_2.id_name).first
+      expect(dest_procedure2_1).to be_present
+      expect(dest_procedure2_2).to be_present
+
+      expect(Guide::Question.site(destination_site).node(dest_node2).count).to eq 2
+      dest_question2_1 = Guide::Question.site(destination_site).node(dest_node2).where(id_name: question2_1.id_name).first
+      dest_question2_2 = Guide::Question.site(destination_site).node(dest_node2).where(id_name: question2_2.id_name).first
+      expect(dest_question2_1).to be_present
+      expect(dest_question2_2).to be_present
+
+      dest_question2_1_edges = dest_question2_1.edges.map do |edge|
+        { value: edge[:value], question_type: edge[:question_type], point_ids: edge[:point_ids] }
+      end
+      dest_question2_2_edges = dest_question2_2.edges.map do |edge|
+        { value: edge[:value], question_type: edge[:question_type], point_ids: edge[:point_ids] }
+      end
+      expect(dest_question2_1_edges).to match_array(in_edges(dest_procedure2_1))
+      expect(dest_question2_2_edges).to match_array(in_edges(dest_procedure2_2))
+    end
+  end
+end

--- a/spec/jobs/sys/site_import/upload_files_spec.rb
+++ b/spec/jobs/sys/site_import/upload_files_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Sys::SiteImportJob, dbscope: :example do
+  let!(:source_site) { create :cms_site_unique }
+  let!(:node1) { create :uploader_node_file, cur_site: source_site }
+  let!(:node2) { create :uploader_node_file, cur_site: source_site }
+  let!(:node3) { create :uploader_node_file, cur_node: node2, cur_site: source_site }
+
+  let!(:filename1) { "#{unique_id}.png" }
+  let!(:file1) do
+    path = "#{node1.path}/#{filename1}"
+    ::Fs.mkdir_p(::File.dirname(path))
+    ::Fs.cp("#{Rails.root}/spec/fixtures/ss/logo.png", path)
+    path
+  end
+  let!(:filename2) { "__#{unique_id}__.jpg" }
+  let!(:file2) do
+    path = "#{node2.path}/#{filename2}"
+    ::Fs.mkdir_p(::File.dirname(path))
+    ::Fs.cp("#{Rails.root}/spec/fixtures/ss/file/keyvisual.jpg", path)
+    path
+  end
+  let!(:filename3) { "#{unique_id}.pdf" }
+  let!(:file3) do
+    path = "#{node3.path}/#{filename3}"
+    ::Fs.mkdir_p(::File.dirname(path))
+    ::Fs.cp("#{Rails.root}/spec/fixtures/ss/shirasagi.pdf", path)
+    path
+  end
+
+  let!(:file_path) do
+    save_export_root = Sys::SiteExportJob.export_root
+    Sys::SiteExportJob.export_root = tmpdir
+
+    begin
+      job = ::Sys::SiteExportJob.new
+      job.task = ::Tasks::Cms.mock_task(source_site_id: source_site.id)
+      job.perform
+      output_zip = job.instance_variable_get(:@output_zip)
+
+      output_zip
+    ensure
+      Sys::SiteExportJob.export_root = save_export_root
+    end
+  end
+
+  describe "#perform" do
+    let!(:destination_site) { create :cms_site_unique }
+
+    it do
+      job = ::Sys::SiteImportJob.new
+      job.task = ::Tasks::Cms.mock_task(target_site_id: destination_site.id, import_file: file_path)
+      job.perform
+
+      expect(Uploader::Node::File.site(destination_site).count).to eq 3
+      dest_node1 = Uploader::Node::File.site(destination_site).where(filename: node1.filename).first
+      dest_node2 = Uploader::Node::File.site(destination_site).where(filename: node2.filename).first
+      dest_node3 = Uploader::Node::File.site(destination_site).where(filename: node3.filename).first
+      expect(dest_node1).to be_present
+      expect(dest_node2).to be_present
+      expect(dest_node3).to be_present
+
+      path = "#{dest_node1.path}/#{filename1}"
+      expect(Fs.exist?(path)).to be_truthy
+      expect(Fs.binread(path)).to eq Fs.binread(file1)
+
+      path = "#{dest_node2.path}/#{filename2}"
+      expect(Fs.exist?(path)).to be_truthy
+      expect(Fs.binread(path)).to eq Fs.binread(file2)
+
+      path = "#{dest_node3.path}/#{filename3}"
+      expect(Fs.exist?(path)).to be_truthy
+      expect(Fs.binread(path)).to eq Fs.binread(file3)
+    end
+  end
+end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
サイトインポートのいくつかの不具合修正

- 記事フォルダーの既定の定型フォームが移行されない問題の修正
- 手続き型ガイドのインポート
- インポート後の画像が別の添付ファイルに差し代わる問題の修正
- リンクチェック除外URLのインポート
- アップローダ配下のunderscoreが連続したファイル名の画像がリンク切れになる問題の修正
