### PR TITLE
[modify] rename send button

### DIFF
--- a/app/views/sns/login/redirect.html.erb
+++ b/app/views/sns/login/redirect.html.erb
@@ -8,6 +8,6 @@
   </div>
 
   <footer class="send" style="border-top: none;">
-    <%= link_to t('ss.buttons.send'), @url.to_s, class: 'btn-primary save js-send' %>
+    <%= link_to t('ss.buttons.do_access_to_unreliable_site'), @url.to_s, class: 'btn-primary save js-send' %>
   </footer>
 </div>

--- a/config/locales/ss/en.yml
+++ b/config/locales/ss/en.yml
@@ -277,6 +277,7 @@ en:
       select_from_list: Select from list
       select_files: Select files
       cancel_upload: Cancel upload
+      do_access_to_unreliable_site: Go to external site
     confirm:
       change_state: Are you sure you want to change your publication status?
       delete: Are you sure you want to delete it?

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -277,6 +277,7 @@ ja:
       select_from_list: 一覧から選択
       select_files: ファイル選択
       cancel_upload: アップロード取消
+      do_access_to_unreliable_site: 外部サイトへ進む
     confirm:
       change_state: 公開状態を変更してよろしいですか？
       delete: 削除してよろしいですか？


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

リダイレクト警告画面の「送信」ボタンを「外部サイトへ進む」へ変更