### PR TITLE
[fix][cms]approval-disable-without-permission

### DIFF
--- a/app/controllers/concerns/cms/syntax_checkable.rb
+++ b/app/controllers/concerns/cms/syntax_checkable.rb
@@ -4,7 +4,8 @@ module Cms::SyntaxCheckable
   private
 
   def syntax_check
-    contents = [{ "id" => "html", "content" => @item.html, "resolve" => "html", "type" => "scalar" }]
+    contents = build_syntax_check_contents
+
     @syntax_checker = Cms::SyntaxChecker.check(cur_site: @cur_site, cur_user: @cur_user, contents: contents)
     if @syntax_checker.errors.present?
       @syntax_checker.errors.each do |error|
@@ -13,6 +14,32 @@ module Cms::SyntaxCheckable
       return false
     end
     true
+  end
+
+  def build_syntax_check_contents
+    contents = [{ "id" => "html", "content" => @item.html, "resolve" => "html", "type" => "scalar" }]
+
+    # ブロック入力（カラム値）もcontentsに追加
+    if @item.respond_to?(:column_values)
+      @item.column_values.each_with_index do |column_value, idx|
+        value =
+          if column_value.respond_to?(:in_wrap) && column_value.in_wrap.present?
+            column_value.in_wrap
+          elsif column_value.respond_to?(:value)
+            column_value.value
+          else
+            nil
+          end
+        next if value.blank?
+        contents << {
+          "id" => "column_#{idx}",
+          "content" => value,
+          "resolve" => "html",
+          "type" => "scalar"
+        }
+      end
+    end
+    contents
   end
 
   def auto_correct

--- a/app/controllers/concerns/cms/syntax_checkable.rb
+++ b/app/controllers/concerns/cms/syntax_checkable.rb
@@ -4,8 +4,7 @@ module Cms::SyntaxCheckable
   private
 
   def syntax_check
-    contents = build_syntax_check_contents
-
+    contents = [{ "id" => "html", "content" => @item.html, "resolve" => "html", "type" => "scalar" }]
     @syntax_checker = Cms::SyntaxChecker.check(cur_site: @cur_site, cur_user: @cur_user, contents: contents)
     if @syntax_checker.errors.present?
       @syntax_checker.errors.each do |error|
@@ -14,32 +13,6 @@ module Cms::SyntaxCheckable
       return false
     end
     true
-  end
-
-  def build_syntax_check_contents
-    contents = [{ "id" => "html", "content" => @item.html, "resolve" => "html", "type" => "scalar" }]
-
-    # ブロック入力（カラム値）もcontentsに追加
-    if @item.respond_to?(:column_values)
-      @item.column_values.each_with_index do |column_value, idx|
-        value =
-          if column_value.respond_to?(:in_wrap) && column_value.in_wrap.present?
-            column_value.in_wrap
-          elsif column_value.respond_to?(:value)
-            column_value.value
-          else
-            nil
-          end
-        next if value.blank?
-        contents << {
-          "id" => "column_#{idx}",
-          "content" => value,
-          "resolve" => "html",
-          "type" => "scalar"
-        }
-      end
-    end
-    contents
   end
 
   def auto_correct

--- a/app/models/concerns/workflow/approver.rb
+++ b/app/models/concerns/workflow/approver.rb
@@ -455,10 +455,16 @@ module Workflow::Approver
     max_editable_approvers[:editable].to_i > 0
   end
 
+  def ignore_alert_to_syntax_check?
+    @cur_user.cms_role_permit_any?(@cur_site, %w(edit_cms_ignore_syntax_check))
+  end
+
   def can_approve_with_accessibility_errors?
     Rails.logger.debug("[workflow/approver] can_approve_with_accessibility_errors? called: workflow_kind=#{workflow_kind}")
-    return true if workflow_kind != 'public'
+    return true if workflow_kind != 'public' && workflow_kind != 'replace'
     result = !accessibility_errors?(@cur_user, @cur_site)
+    Rails.logger.debug("[workflow/approver] can_approve_with_accessibility_errors? result: #{result}")
+    return true if ignore_alert_to_syntax_check?
     Rails.logger.debug("[workflow/approver] can_approve_with_accessibility_errors? result: #{result}")
     result
   end

--- a/app/models/concerns/workflow/approver.rb
+++ b/app/models/concerns/workflow/approver.rb
@@ -575,10 +575,8 @@ module Workflow::Approver
   end
 
   def build_syntax_check_contents
-    Rails.logger.debug("[workflow/approver] build_syntax_check_contents called")
     contents = []
     if self.respond_to?(:html) && self.html.present?
-      Rails.logger.debug("[workflow/approver] build_syntax_check_contents: html found, html=#{self.html.inspect}")
       contents << { "id" => "html", "content" => self.html, "resolve" => "html", "type" => "scalar" }
     end
 
@@ -596,7 +594,6 @@ module Workflow::Approver
           else
             nil
           end
-        Rails.logger.debug("[workflow/approver] build_syntax_check_contents: column_value[#{idx}] class=#{column_value.class.name} value=#{value.inspect}")
         next if value.blank?
         contents << {
           "id" => "column_#{idx}",
@@ -606,22 +603,16 @@ module Workflow::Approver
         }
       end
     end
-
-    Rails.logger.debug("[workflow/approver] build_syntax_check_contents: contents=#{contents.inspect}")
     contents
   end
 
   def accessibility_errors?(user, site)
-    Rails.logger.debug("[workflow/approver] accessibility_errors? called user=#{user.id} site=#{site.id if site}")
     contents = build_syntax_check_contents
-    Rails.logger.debug("[workflow/approver] accessibility_errors? contents=#{contents.inspect}")
     return false if contents.blank?
 
     result = Cms::SyntaxChecker.check(cur_site: site, cur_user: user, contents: contents)
-    Rails.logger.debug("[workflow/approver] accessibility_errors? result.errors=#{result.errors.inspect}")
 
     accessibility_error = result.errors.any? { |error| error[:msg].present? }
-    Rails.logger.debug("[workflow/approver] accessibility_errors? accessibility_error=#{accessibility_error}")
     accessibility_error
   end
 

--- a/app/models/concerns/workflow/approver.rb
+++ b/app/models/concerns/workflow/approver.rb
@@ -460,13 +460,9 @@ module Workflow::Approver
   end
 
   def can_approve_with_accessibility_errors?
-    Rails.logger.debug("[workflow/approver] can_approve_with_accessibility_errors? called: workflow_kind=#{workflow_kind}")
-    return true if workflow_kind != 'public' && workflow_kind != 'replace'
-    result = !accessibility_errors?(@cur_user, @cur_site)
-    Rails.logger.debug("[workflow/approver] can_approve_with_accessibility_errors? result: #{result}")
+    return true unless %w(public replace).include?(workflow_kind)
     return true if ignore_alert_to_syntax_check?
-    Rails.logger.debug("[workflow/approver] can_approve_with_accessibility_errors? result: #{result}")
-    result
+    !accessibility_errors?(@cur_user, @cur_site)
   end
 
   def workflow_back_to_previous?
@@ -608,17 +604,6 @@ module Workflow::Approver
           "resolve" => "html",
           "type" => "scalar"
         }
-      end
-    end
-
-    # siteのurl_scheme属性が未定義の場合はデフォルト値をセット
-    site = self.respond_to?(:site) ? self.site : nil
-    if site
-      unless site.respond_to?(:syntax_checker_url_scheme_attributes)
-        site.define_singleton_method(:syntax_checker_url_scheme_attributes) { %w(href src) }
-      end
-      unless site.respond_to?(:syntax_checker_url_scheme_schemes)
-        site.define_singleton_method(:syntax_checker_url_scheme_schemes) { %w(http https) }
       end
     end
 

--- a/app/views/workflow/agents/addons/approver/_show.html.erb
+++ b/app/views/workflow/agents/addons/approver/_show.html.erb
@@ -30,7 +30,6 @@
           <% end %>
           <dl class="see">
             <% if @item.workflow_kind.present? %>
-              <h1>テスト</h1>
               <dt><%= @model.t :workflow_kind %><%= @model.tt :workflow_kind %></dt>
               <dd><%= @item.label(:workflow_kind) %></dd>
             <% end %>

--- a/app/views/workflow/agents/addons/approver/_show.html.erb
+++ b/app/views/workflow/agents/addons/approver/_show.html.erb
@@ -30,6 +30,7 @@
           <% end %>
           <dl class="see">
             <% if @item.workflow_kind.present? %>
+              <h1>テスト</h1>
               <dt><%= @model.t :workflow_kind %><%= @model.tt :workflow_kind %></dt>
               <dd><%= @item.label(:workflow_kind) %></dd>
             <% end %>
@@ -45,8 +46,14 @@
             end
           %>
           <div class="buttons">
-            <% if workflow_approver[:state] == 'request' %>
-              <%= button_tag t("workflow.buttons.approve"), updatetype: :approve, class: "update-item btn-primary", disabled: true, data: { disable: '' } %>
+            <% if workflow_approver[:state] == 'request'  %>
+              <% if @item.can_approve_with_accessibility_errors? %>
+                <%= button_tag t("workflow.buttons.approve"), updatetype: :approve, class: "update-item btn-primary", disabled: true, data: { disable: '' } %>
+              <% else %>
+                <div class="error-message">
+                  <%= t("errors.messages.accessibility_check_required") %>
+                </div>
+              <% end %>
               <%= button_tag t("workflow.buttons.remand"), updatetype: :remand, class: "update-item btn-default", disabled: true, data: { disable: '' } %>
             <% elsif workflow_approver[:state] == 'pending' %>
               <%= button_tag t("workflow.buttons.pull_up"), updatetype: :pull_up, class: "update-item btn-primary", disabled: true, data: { disable: '' } %>

--- a/app/views/workflow/agents/addons/approver/_show.html.erb
+++ b/app/views/workflow/agents/addons/approver/_show.html.erb
@@ -47,6 +47,11 @@
           <div class="buttons">
             <% if workflow_approver[:state] == 'request'  %>
               <% if @item.can_approve_with_accessibility_errors? %>
+                <% if @item.accessibility_errors?(@cur_user, @cur_site) %>
+                  <div class="error-message">
+                    <%= t("errors.messages.check_html") %>
+                  </div>
+                <% end %>
                 <%= button_tag t("workflow.buttons.approve"), updatetype: :approve, class: "update-item btn-primary", disabled: true, data: { disable: '' } %>
               <% else %>
                 <div class="error-message">

--- a/config/locales/workflow/en.yml
+++ b/config/locales/workflow/en.yml
@@ -209,6 +209,7 @@ en:
       forced_update: Run even if an e-mail address is not set.
       no_approvers: No approver found.
       branch_is_already_existed: A replacement page has been created.
+      accessibility_check_required: Accessibility errors exist. You need permission to ignore the accessibility check.
 
   tooltip:
     workflow/approver:

--- a/config/locales/workflow/ja.yml
+++ b/config/locales/workflow/ja.yml
@@ -209,6 +209,7 @@ ja:
       forced_update: "メールアドレスが未設定でも実行する。"
       no_approvers: 承認者がみつかりません。
       branch_is_already_existed: 差し替えページが作成されています。
+      accessibility_check_required: "アクセシビリティエラーが存在します。エラーを修正するか、アクセシビリティチェックを無視する権限が必要です。"
 
   tooltip:
     workflow/approver:

--- a/spec/features/workflow/edit_requested_page_spec.rb
+++ b/spec/features/workflow/edit_requested_page_spec.rb
@@ -101,7 +101,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
     end
     let(:show_path) { article_page_path(site, node, item) }
 
-    # アクセシビリティチェックを無視して保存する権限がある場合、承認ボタンが表示される
+    # アクセシビリティチェックを無視して保存する権限がある場合、公開承認ボタンが表示される
     context "when user with permission approves" do
       it do
         login_cms_user
@@ -147,7 +147,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
       end
     end
 
-    # アクセシビリティエラーがある記事の承認を試みた場合、承認ボタンが表示されず、差し戻しのみ可能
+    # アクセシビリティエラーがある記事の公開承認を試みた場合、承認ボタンが表示されず、差し戻しのみ可能
     context "when user without permission attempts to approve" do
       it do
         role = cms_role

--- a/spec/features/workflow/edit_requested_page_spec.rb
+++ b/spec/features/workflow/edit_requested_page_spec.rb
@@ -97,7 +97,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
     end
     let!(:item) do
       create(:article_page, cur_site: site, cur_node: node, layout_id: layout.id,
-             html: html_with_accessibility_error, state: "closed")
+            html: html_with_accessibility_error, state: "closed")
     end
     let(:show_path) { article_page_path(site, node, item) }
 
@@ -139,6 +139,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
         visit show_path
 
         expect(page).to have_button(I18n.t("workflow.buttons.approve"))
+        expect(page).to have_content(I18n.t("errors.messages.check_html"))
 
         click_on I18n.t("workflow.buttons.approve")
         click_on I18n.t("article.page_navi.back_to_index")
@@ -248,6 +249,7 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
 
         # 非公開申請の場合は承認ボタンが表示され、承認できる
         expect(page).to have_button(I18n.t("workflow.buttons.approve"))
+        expect(page).to have_content(I18n.t("errors.messages.check_html"))
 
         click_on I18n.t("workflow.buttons.approve")
         click_on I18n.t("article.page_navi.back_to_index")
@@ -329,6 +331,7 @@ comment: ''})
         visit branch_path
 
         expect(page).to have_button(I18n.t("workflow.buttons.approve"))
+        expect(page).to have_content(I18n.t("errors.messages.check_html"))
 
         click_on I18n.t("workflow.buttons.approve")
         click_on I18n.t("article.page_navi.back_to_index")

--- a/spec/features/workflow/edit_requested_page_spec.rb
+++ b/spec/features/workflow/edit_requested_page_spec.rb
@@ -256,4 +256,169 @@ describe "edit requested page", type: :feature, dbscope: :example, js: true do
       end
     end
   end
+
+  context "with branch page with accessibility errors" do
+    let(:node) { create(:article_node_page, cur_site: site, layout_id: layout.id) }
+    let(:html_with_accessibility_error) do
+      <<~HTML
+        <div>
+          <img src=\"image.jpg\">
+        </div>
+      HTML
+    end
+    let!(:original_item) do
+      create(:article_page, cur_site: site, cur_node: node, layout_id: layout.id, html: html_with_accessibility_error,
+state: "closed")
+    end
+    let(:show_path) { article_page_path(site, node, original_item) }
+
+    # 権限ありの場合、差し替えページも承認できる
+    context "when user with permission approves branch" do
+      it do
+        login_cms_user
+        visit show_path
+
+        within "#addon-workflow-agents-addons-branch" do
+          click_on I18n.t('workflow.create_branch')
+          expect(page).to have_content(original_item.name)
+          click_on original_item.name
+        end
+
+        click_on I18n.t('ss.links.edit')
+        within "form#item-form" do
+          fill_in "item[name]", with: "replacement"
+          click_button I18n.t('ss.buttons.draft_save')
+        end
+        within_cbox do
+          click_on I18n.t("ss.buttons.ignore_alert")
+        end
+        wait_for_notice I18n.t("ss.notice.saved")
+        branch_item = Cms::Page.last
+        branch_path = article_page_path(site, node, branch_item)
+
+        within ".mod-workflow-request" do
+          select I18n.t("mongoid.attributes.workflow/model/route.my_group"), from: "workflow_route"
+          click_on I18n.t("workflow.buttons.select")
+          wait_for_cbox_opened do
+            click_on I18n.t("workflow.search_approvers.index")
+          end
+        end
+        within_cbox do
+          expect(page).to have_content(user1.long_name)
+          find("tr[data-id='1,#{user1.id}'] input[type=checkbox]").click
+          wait_for_cbox_closed do
+            click_on I18n.t("workflow.search_approvers.select")
+          end
+        end
+        within ".mod-workflow-request" do
+          fill_in "workflow[comment]", with: workflow_comment
+          click_on I18n.t("workflow.buttons.request")
+        end
+        expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
+
+        branch_item.reload
+        expect(branch_item.workflow_user_id).to eq cms_user.id
+        expect(branch_item.workflow_state).to eq "request"
+        expect(branch_item.state).to eq "closed"
+        expect(branch_item.workflow_comment).to eq workflow_comment
+        expect(branch_item.workflow_approvers.count).to eq 1
+        expect(branch_item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request',
+comment: ''})
+
+        login_user user1
+        visit branch_path
+
+        expect(page).to have_button(I18n.t("workflow.buttons.approve"))
+
+        click_on I18n.t("workflow.buttons.approve")
+        click_on I18n.t("article.page_navi.back_to_index")
+        expect(page).to have_content(branch_item.name)
+        expect(page).to have_content(I18n.t("ss.state.public"))
+      end
+    end
+
+    # 権限なしの場合、差し替えページの承認ボタンは表示されず、差し戻しのみ可能
+    context "when user without permission attempts to approve branch" do
+      let(:node) { create(:article_node_page, cur_site: site, layout_id: layout.id) }
+      let(:html_with_accessibility_error) do
+        <<~HTML
+          <div>
+            <img src=\"image.jpg\">
+          </div>
+        HTML
+      end
+      let!(:original_item) do
+        create(:article_page, cur_site: site, cur_node: node, layout_id: layout.id, html: html_with_accessibility_error,
+state: "closed")
+      end
+      let(:show_path) { article_page_path(site, node, original_item) }
+      it do
+
+        login_cms_user
+        visit show_path
+
+        within "#addon-workflow-agents-addons-branch" do
+          click_on I18n.t('workflow.create_branch')
+          expect(page).to have_content(original_item.name)
+          click_on original_item.name
+        end
+
+        click_on I18n.t('ss.links.edit')
+        within "form#item-form" do
+          fill_in "item[name]", with: "replacement"
+          click_button I18n.t('ss.buttons.draft_save')
+        end
+        within_cbox do
+          click_on I18n.t("ss.buttons.ignore_alert")
+        end
+        wait_for_notice I18n.t("ss.notice.saved")
+        branch_item = Cms::Page.last
+        branch_path = article_page_path(site, node, branch_item)
+
+        within ".mod-workflow-request" do
+          select I18n.t("mongoid.attributes.workflow/model/route.my_group"), from: "workflow_route"
+          click_on I18n.t("workflow.buttons.select")
+          wait_for_cbox_opened do
+            click_on I18n.t("workflow.search_approvers.index")
+          end
+        end
+        within_cbox do
+          expect(page).to have_content(user1.long_name)
+          find("tr[data-id='1,#{user1.id}'] input[type=checkbox]").click
+          wait_for_cbox_closed do
+            click_on I18n.t("workflow.search_approvers.select")
+          end
+        end
+        within ".mod-workflow-request" do
+          fill_in "workflow[comment]", with: workflow_comment
+          click_on I18n.t("workflow.buttons.request")
+        end
+        expect(page).to have_css(".mod-workflow-view dd", text: I18n.t("workflow.state.request"))
+
+        branch_item.reload
+        expect(branch_item.workflow_user_id).to eq cms_user.id
+        expect(branch_item.workflow_state).to eq "request"
+        expect(branch_item.state).to eq "closed"
+        expect(branch_item.workflow_comment).to eq workflow_comment
+        expect(branch_item.workflow_approvers.count).to eq 1
+        expect(branch_item.workflow_approvers).to include({level: 1, user_id: user1.id, editable: '', state: 'request',
+comment: ''})
+
+        role = cms_role
+        role.update(permissions: (role.permissions - %w(edit_cms_ignore_syntax_check)))
+        role.reload
+        login_user user1
+        visit branch_path
+
+        expect(page).to have_content(I18n.t("errors.messages.accessibility_check_required"))
+        expect(page).not_to have_button(I18n.t("workflow.buttons.approve"))
+        expect(page).to have_button(I18n.t("workflow.buttons.remand"))
+
+        click_on I18n.t("workflow.buttons.remand")
+        click_on I18n.t("article.page_navi.back_to_index")
+        expect(page).to have_content(branch_item.name)
+        expect(page).to have_content(I18n.t("workflow.state.remand"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
アクセシビリティエラーのある記事の「公開」「差し替え」承認の制限

## 変更内容
- アクセシビリティチェックを無視して保存する権限がないユーザーが、アクセシビリティエラーがある記事の「公開」を承認できないように修正
![スクリーンショット 2025-06-03 10 36 24（2）](https://github.com/user-attachments/assets/15204396-7c24-45b1-b169-e3938b1737d8)

- アクセシビリティチェックを無視して保存する権限がないユーザーが、アクセシビリティエラーがある記事の「差し替え」を承認できないように修正
![スクリーンショット 2025-06-03 11 52 19（2）](https://github.com/user-attachments/assets/1d56db51-ec52-4932-9bfb-2849bc52727a)

- アクセシビリティチェックを無視して保存する権限があるユーザーが、アクセシビリティエラーのある記事を「公開」または「差し替え」しようとした場合にアクセシビリティエラーの表示がされる
![スクリーンショット 2025-06-04 9 03 36（2）](https://github.com/user-attachments/assets/9bf1deae-0e52-42f7-a7ec-18fad1324589)

## その他
下記の項目にアクセシビリティエラーがある記事は今回の修正の制限の対象外になります。

- ブロック入力「見出し」（hタグ順序エラー）
- ブロック入力「リンク」（リンクテキスト未入力）
- ブロック入力「添付ファイル」（リンクテキスト未入力）