### PR TITLE
[gws][workflow2] 承認ルートの移行タスクとジョブ

### DIFF
--- a/app/jobs/gws/workflow2/route_migration_job.rb
+++ b/app/jobs/gws/workflow2/route_migration_job.rb
@@ -1,0 +1,90 @@
+class Gws::Workflow2::RouteMigrationJob < Gws::ApplicationJob
+  include Job::Gws::TaskFilter
+
+  self.task_name = 'gws:workflow2_route_migration'
+
+  def perform
+    Rails.logger.tagged(site.name) do
+      each_route do |route|
+        migrate_route(route)
+
+        task.log "#{route}: 移行しました。"
+      end
+    end
+  end
+
+  private
+
+  def each_route
+    criteria = Gws::Workflow::Route.all.site(site)
+    all_ids = criteria.pluck(:id)
+    all_ids.each_slice(20) do |ids|
+      criteria.in(id: ids).to_a.each do |item|
+        Rails.logger.tagged(item.name) do
+          yield item
+        end
+      end
+    end
+  end
+
+  def migrate_route(route)
+    new_route = Gws::Workflow2::Route.new
+    # Gws::Workflow2::Route <= Workflow::Model::Route
+    new_route.name = route.name
+    new_route.order = next_order
+    new_route.pull_up = route.pull_up
+    new_route.on_remand = route.on_remand
+    new_route.approvers = convert_approvers(route.approvers)
+    new_route.required_counts = route.required_counts
+    new_route.approver_attachment_uses = route.approver_attachment_uses
+    new_route.circulations = convert_circulations(route.circulations)
+    new_route.circulation_attachment_uses = route.circulation_attachment_uses
+    new_route.remark = "migrated from #{route.name}(#{route.id}) at #{Time.zone.now.iso8601}"
+    # Gws::Reference::Site
+    new_route.cur_site = self.site
+    new_route.site = self.site
+    # Gws::Addon::Workflow2::RouteReadableSetting
+    new_route.readable_setting_range = "public"
+    # Gws::Addon::Workflow2::RouteGroupPermission <= Gws::GroupPermission
+    new_route.group_ids = route.group_ids
+    new_route.user_ids = route.user_ids
+    new_route.custom_group_ids = route.custom_group_ids
+
+    new_route.save!
+  end
+
+  def next_order
+    @next_order ||= begin
+      order = Gws::Workflow2::Route.unscoped.max(:order)
+      order || 10
+    end
+
+    @next_order += 10
+    @next_order
+  end
+
+  def convert_approvers(approvers)
+    return [] if approvers.blank?
+
+    approvers.map do |approver|
+      next unless approver[:user_id].numeric?
+      new_approver = {
+        "level" => approver[:level], "user_id" => approver[:user_id].to_i, "user_type" => Gws::User.name
+      }
+      new_approver["editable"] = approver[:editable] if approver.key?(:editable)
+      new_approver
+    end
+  end
+
+  def convert_circulations(circulations)
+    return [] if circulations.blank?
+
+    circulations.map do |circulation|
+      next unless circulation[:user_id].numeric?
+      new_circulation = {
+        "level" => circulation[:level], "user_id" => circulation[:user_id].to_i, "user_type" => Gws::User.name
+      }
+      new_circulation
+    end
+  end
+end

--- a/config/locales/gws/workflow2/en.yml
+++ b/config/locales/gws/workflow2/en.yml
@@ -403,3 +403,4 @@ en:
   job:
     models:
       gws/workflow2/trash_purge_job: Application2/Empty application trash
+      gws/workflow2/route_migration_job: Application2/Approval route setting migration

--- a/config/locales/gws/workflow2/ja.yml
+++ b/config/locales/gws/workflow2/ja.yml
@@ -403,3 +403,4 @@ ja:
   job:
     models:
       gws/workflow2/trash_purge_job: ワークフロー2/申請ゴミ箱の掃除
+      gws/workflow2/route_migration_job: ワークフロー2/承認ルート設定の移行

--- a/lib/tasks/gws/workflow2.rake
+++ b/lib/tasks/gws/workflow2.rake
@@ -1,0 +1,8 @@
+namespace :gws do
+  namespace :workflow2 do
+    # ワークフローの承認ルート設定をワークフロー2へ移行（コピー）するタスク
+    task migrate_route: :environment do
+      ::Tasks::Gws::Workflow2.migrate_route
+    end
+  end
+end

--- a/lib/tasks/gws/workflow2.rb
+++ b/lib/tasks/gws/workflow2.rb
@@ -1,0 +1,18 @@
+module Tasks
+  module Gws
+    class Workflow2
+      extend Tasks::Gws::Base
+
+      class << self
+        # ワークフローの承認ルート設定をワークフロー2へ移行（コピー）するタスク
+        def migrate_route
+          each_sites do |site|
+            puts "# #{site.name}"
+            job_class = ::Gws::Workflow2::RouteMigrationJob.bind(site_id: site.id)
+            job_class.perform_now
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/gws/workflow2/route_migration_job_spec.rb
+++ b/spec/jobs/gws/workflow2/route_migration_job_spec.rb
@@ -1,0 +1,210 @@
+require 'spec_helper'
+
+describe Gws::Workflow2::RouteMigrationJob, dbscope: :example do
+  let!(:site) { gws_site }
+  let!(:admin) { gws_user }
+  let!(:user1) { create(:gws_user, group_ids: admin.group_ids, gws_role_ids: admin.gws_role_ids) }
+  let!(:user2) { create(:gws_user, group_ids: admin.group_ids, gws_role_ids: admin.gws_role_ids) }
+  let!(:user3) { create(:gws_user, group_ids: admin.group_ids, gws_role_ids: admin.gws_role_ids) }
+
+  let!(:route1_single_approver) do
+    create(
+      :gws_workflow_route, cur_site: site, name: unique_id, group_ids: admin.group_ids,
+      approvers: [
+        { "level" => 1, "user_id" => user1.id, "editable" => 1 }
+      ],
+      required_counts: [ false ], approver_attachment_uses: %w(enabled),
+      circulations: [], circulation_attachment_uses: []
+    )
+  end
+  let!(:route2_multiple_approvers) do
+    create(
+      :gws_workflow_route, cur_site: site, name: unique_id, group_ids: admin.group_ids,
+      approvers: [
+        { "level" => 1, "user_id" => user1.id, "editable" => 0 },
+        { "level" => 1, "user_id" => user2.id, "editable" => 0 },
+        { "level" => 2, "user_id" => user3.id, "editable" => 1 },
+      ],
+      required_counts: [ false, false ], approver_attachment_uses: %w(enabled enabled),
+      circulations: [], circulation_attachment_uses: []
+    )
+  end
+  let!(:route3_multiple_approvers_and_circulations) do
+    create(
+      :gws_workflow_route, cur_site: site, name: unique_id, group_ids: admin.group_ids,
+      approvers: [
+        { "level" => 1, "user_id" => user1.id },
+        { "level" => 1, "user_id" => user2.id },
+        { "level" => 2, "user_id" => user3.id },
+      ],
+      required_counts: [ false, false ], approver_attachment_uses: %w(enabled enabled),
+      circulations: [
+        { "level" => 1, "user_id" => user3.id },
+        { "level" => 1, "user_id" => user1.id },
+        { "level" => 2, "user_id" => user2.id },
+      ],
+      circulation_attachment_uses: %w(enabled enabled)
+    )
+  end
+
+  it do
+    expect { described_class.bind(site_id: site.id).perform_now }.to output.to_stdout
+
+    expect(Job::Log.count).to eq 1
+    Job::Log.first.tap do |log|
+      expect(log.logs).to include(/INFO -- : .* Started Job/)
+      expect(log.logs).to include(/INFO -- : .* Completed Job/)
+    end
+
+    expect(Gws::Workflow2::Route.all.count).to eq 3
+
+    Gws::Workflow2::Route.find_by(name: route1_single_approver.name).tap do |new_route|
+      # Gws::Reference::Site
+      expect(new_route.site_id).to eq site.id
+      # Gws::Workflow2::Route
+      expect(new_route.name).to eq route1_single_approver.name
+      expect(new_route.order).to be_numeric
+      expect(new_route.pull_up).to eq route1_single_approver.pull_up
+      expect(new_route.on_remand).to eq route1_single_approver.on_remand
+      new_route.approvers.tap do |new_approvers|
+        source_approvers = route1_single_approver.approvers
+        expect(new_approvers.count).to eq 1
+        expect(new_approvers.count).to eq source_approvers.count
+        expect(new_approvers[0][:level]).to eq source_approvers[0][:level]
+        expect(new_approvers[0][:user_id]).to eq source_approvers[0][:user_id]
+        expect(new_approvers[0][:editable]).to eq source_approvers[0][:editable]
+        expect(new_approvers[0][:user_type]).to eq Gws::User.name
+      end
+      expect(new_route.required_counts).to eq route1_single_approver.required_counts
+      expect(new_route.approver_attachment_uses).to eq route1_single_approver.approver_attachment_uses
+      expect(new_route.circulations.count).to eq route1_single_approver.circulations.count
+      expect(new_route.circulations).to be_blank
+      expect(new_route.circulation_attachment_uses).to eq route1_single_approver.circulation_attachment_uses
+      expect(new_route.remark).to include(route1_single_approver.name)
+      # Gws::Reference::User
+      expect(new_route.user_uid).to be_blank
+      expect(new_route.user_name).to be_blank
+      expect(new_route.user_group_id).to be_blank
+      expect(new_route.user_group_name).to be_blank
+      expect(new_route.user_id).to be_blank
+      # Gws::Addon::Workflow2::RouteReadableSetting
+      expect(new_route.readable_setting_range).to eq "public"
+      expect(new_route.readable_group_ids).to be_blank
+      expect(new_route.readable_member_ids).to be_blank
+      expect(new_route.readable_custom_group_ids).to be_blank
+      # Gws::Addon::Workflow2::RouteGroupPermission
+      expect(new_route.group_ids).to eq route1_single_approver.group_ids
+      expect(new_route.user_ids).to eq route1_single_approver.user_ids
+      expect(new_route.custom_group_ids).to eq route1_single_approver.custom_group_ids
+    end
+
+    Gws::Workflow2::Route.find_by(name: route2_multiple_approvers.name).tap do |new_route|
+      # Gws::Reference::Site
+      expect(new_route.site_id).to eq site.id
+      # Gws::Workflow2::Route
+      expect(new_route.name).to eq route2_multiple_approvers.name
+      expect(new_route.order).to be_numeric
+      expect(new_route.pull_up).to eq route2_multiple_approvers.pull_up
+      expect(new_route.on_remand).to eq route2_multiple_approvers.on_remand
+      new_route.approvers.tap do |new_approvers|
+        source_approvers = route2_multiple_approvers.approvers
+        expect(new_approvers.count).to eq 3
+        expect(new_approvers.count).to eq source_approvers.count
+        expect(new_approvers[0][:level]).to eq source_approvers[0][:level]
+        expect(new_approvers[0][:user_id]).to eq source_approvers[0][:user_id]
+        expect(new_approvers[0][:editable]).to eq source_approvers[0][:editable]
+        expect(new_approvers[0][:user_type]).to eq Gws::User.name
+        expect(new_approvers[1][:level]).to eq source_approvers[1][:level]
+        expect(new_approvers[1][:user_id]).to eq source_approvers[1][:user_id]
+        expect(new_approvers[1][:editable]).to eq source_approvers[1][:editable]
+        expect(new_approvers[1][:user_type]).to eq Gws::User.name
+        expect(new_approvers[2][:level]).to eq source_approvers[2][:level]
+        expect(new_approvers[2][:user_id]).to eq source_approvers[2][:user_id]
+        expect(new_approvers[2][:editable]).to eq source_approvers[2][:editable]
+        expect(new_approvers[2][:user_type]).to eq Gws::User.name
+      end
+      expect(new_route.required_counts).to eq route2_multiple_approvers.required_counts
+      expect(new_route.approver_attachment_uses).to eq route2_multiple_approvers.approver_attachment_uses
+      expect(new_route.circulations.count).to eq route2_multiple_approvers.circulations.count
+      expect(new_route.circulations).to be_blank
+      expect(new_route.circulation_attachment_uses).to eq route2_multiple_approvers.circulation_attachment_uses
+      expect(new_route.remark).to include(route2_multiple_approvers.name)
+      # Gws::Reference::User
+      expect(new_route.user_uid).to be_blank
+      expect(new_route.user_name).to be_blank
+      expect(new_route.user_group_id).to be_blank
+      expect(new_route.user_group_name).to be_blank
+      expect(new_route.user_id).to be_blank
+      # Gws::Addon::Workflow2::RouteReadableSetting
+      expect(new_route.readable_setting_range).to eq "public"
+      expect(new_route.readable_group_ids).to be_blank
+      expect(new_route.readable_member_ids).to be_blank
+      expect(new_route.readable_custom_group_ids).to be_blank
+      # Gws::Addon::Workflow2::RouteGroupPermission
+      expect(new_route.group_ids).to eq route2_multiple_approvers.group_ids
+      expect(new_route.user_ids).to eq route2_multiple_approvers.user_ids
+      expect(new_route.custom_group_ids).to eq route2_multiple_approvers.custom_group_ids
+    end
+
+    Gws::Workflow2::Route.find_by(name: route3_multiple_approvers_and_circulations.name).tap do |new_route|
+      # Gws::Reference::Site
+      expect(new_route.site_id).to eq site.id
+      # Gws::Workflow2::Route
+      expect(new_route.name).to eq route3_multiple_approvers_and_circulations.name
+      expect(new_route.order).to be_numeric
+      expect(new_route.pull_up).to eq route3_multiple_approvers_and_circulations.pull_up
+      expect(new_route.on_remand).to eq route3_multiple_approvers_and_circulations.on_remand
+      new_route.approvers.tap do |new_approvers|
+        source_approvers = route3_multiple_approvers_and_circulations.approvers
+        expect(new_approvers.count).to eq 3
+        expect(new_approvers.count).to eq source_approvers.count
+        expect(new_approvers[0][:level]).to eq source_approvers[0][:level]
+        expect(new_approvers[0][:user_id]).to eq source_approvers[0][:user_id]
+        expect(new_approvers[0][:editable]).to be_blank
+        expect(new_approvers[0][:user_type]).to eq Gws::User.name
+        expect(new_approvers[1][:level]).to eq source_approvers[1][:level]
+        expect(new_approvers[1][:user_id]).to eq source_approvers[1][:user_id]
+        expect(new_approvers[1][:editable]).to be_blank
+        expect(new_approvers[1][:user_type]).to eq Gws::User.name
+        expect(new_approvers[2][:level]).to eq source_approvers[2][:level]
+        expect(new_approvers[2][:user_id]).to eq source_approvers[2][:user_id]
+        expect(new_approvers[2][:editable]).to be_blank
+        expect(new_approvers[2][:user_type]).to eq Gws::User.name
+      end
+      expect(new_route.required_counts).to eq route3_multiple_approvers_and_circulations.required_counts
+      expect(new_route.approver_attachment_uses).to eq route3_multiple_approvers_and_circulations.approver_attachment_uses
+      expect(new_route.circulations.count).to eq route3_multiple_approvers_and_circulations.circulations.count
+      new_route.circulations.tap do |new_circulations|
+        source_circulations = route3_multiple_approvers_and_circulations.circulations
+        expect(new_circulations.count).to eq 3
+        expect(new_circulations.count).to eq source_circulations.count
+        expect(new_circulations[0][:level]).to eq source_circulations[0][:level]
+        expect(new_circulations[0][:user_id]).to eq source_circulations[0][:user_id]
+        expect(new_circulations[0][:user_type]).to eq Gws::User.name
+        expect(new_circulations[1][:level]).to eq source_circulations[1][:level]
+        expect(new_circulations[1][:user_id]).to eq source_circulations[1][:user_id]
+        expect(new_circulations[1][:user_type]).to eq Gws::User.name
+        expect(new_circulations[2][:level]).to eq source_circulations[2][:level]
+        expect(new_circulations[2][:user_id]).to eq source_circulations[2][:user_id]
+        expect(new_circulations[2][:user_type]).to eq Gws::User.name
+      end
+      expect(new_route.circulation_attachment_uses).to eq route3_multiple_approvers_and_circulations.circulation_attachment_uses
+      expect(new_route.remark).to include(route3_multiple_approvers_and_circulations.name)
+      # Gws::Reference::User
+      expect(new_route.user_uid).to be_blank
+      expect(new_route.user_name).to be_blank
+      expect(new_route.user_group_id).to be_blank
+      expect(new_route.user_group_name).to be_blank
+      expect(new_route.user_id).to be_blank
+      # Gws::Addon::Workflow2::RouteReadableSetting
+      expect(new_route.readable_setting_range).to eq "public"
+      expect(new_route.readable_group_ids).to be_blank
+      expect(new_route.readable_member_ids).to be_blank
+      expect(new_route.readable_custom_group_ids).to be_blank
+      # Gws::Addon::Workflow2::RouteGroupPermission
+      expect(new_route.group_ids).to eq route3_multiple_approvers_and_circulations.group_ids
+      expect(new_route.user_ids).to eq route3_multiple_approvers_and_circulations.user_ids
+      expect(new_route.custom_group_ids).to eq route3_multiple_approvers_and_circulations.custom_group_ids
+    end
+  end
+end

--- a/spec/lib/tasks/gws/workflow2/migrate_route_spec.rb
+++ b/spec/lib/tasks/gws/workflow2/migrate_route_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Tasks::Gws::Workflow2, dbscope: :example do
+  describe ".migrate_route" do
+    let!(:site) { gws_site }
+    let!(:admin) { gws_user }
+    let!(:user1) { create(:gws_user, group_ids: admin.group_ids, gws_role_ids: admin.gws_role_ids) }
+
+    let!(:route1) do
+      create(
+        :gws_workflow_route, cur_site: site, name: unique_id, group_ids: admin.group_ids,
+        approvers: [
+          { "level" => 1, "user_id" => user1.id, "editable" => 1 }
+        ],
+        required_counts: [ false ], approver_attachment_uses: %w(enabled),
+        circulations: [], circulation_attachment_uses: []
+      )
+    end
+
+    it do
+      expect { described_class.migrate_route }.to output.to_stdout
+
+      expect(Job::Log.count).to eq 1
+      Job::Log.first.tap do |log|
+        expect(log.logs).to include(/INFO -- : .* Started Job/)
+        expect(log.logs).to include(/INFO -- : .* Completed Job/)
+      end
+
+      expect(Gws::Workflow2::Route.all.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

- Gws::Workflow::Route を Gws::Workflow2::Route へ移行するタスクとジョブ。
- 元となる Gws::Workflow::Route は削除されずに残る（これはCMSと共有されている可能性があるため）。
- 移行時、Gws::Workflow2::Route の備考に移行したことを示す証跡を残す。
