### PR TITLE
制作の差分です。

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -2113,11 +2113,11 @@ footer.send {
   &.unused{
     .unused-message{
       position: absolute;
-      background: rgba(173, 34, 4, 0.8);
-      padding: 3px 5px;
-      color: white;
       top: 0;
       right: 0;
+      padding: 3px 5px;
+      background: rgba(173, 34, 4, 0.8);
+      color: white;
       font-size: 10px;
       font-weight: bold;
     }

--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -637,14 +637,13 @@ _::-webkit-full-page-media, _:future, :root .gws-memo-message .popup-notice:befo
 // nav
 #navi {
   position: relative;
-  z-index: 1;
+  z-index: 10;
   width: 211px;
   min-width: 211px;
   padding-bottom: 120px;
   border-right: 1px solid #dcdcdc;
   border-bottom: 1px solid #dcdcdc;
   background: $white;
-  z-index: 10;
   .icon-material::before {
     top: 6px;
     left: 16px;
@@ -2115,11 +2114,11 @@ footer.send {
     .unused-message{
       position: absolute;
       background: rgba(173, 34, 4, 0.8);
-      color: white;
       padding: 3px 5px;
-      font-size: 10px;
+      color: white;
       top: 0;
       right: 0;
+      font-size: 10px;
       font-weight: bold;
     }
   }

--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -639,10 +639,12 @@ _::-webkit-full-page-media, _:future, :root .gws-memo-message .popup-notice:befo
   position: relative;
   z-index: 1;
   width: 211px;
+  min-width: 211px;
   padding-bottom: 120px;
   border-right: 1px solid #dcdcdc;
   border-bottom: 1px solid #dcdcdc;
   background: $white;
+  z-index: 10;
   .icon-material::before {
     top: 6px;
     left: 16px;
@@ -1747,6 +1749,14 @@ _::-webkit-full-page-media, _:future, :root .gws-memo-message .popup-notice:befo
   &.print {
     border-top: $border-black2;
   }
+  .images{
+    .image{
+      img{
+        max-width: 140px;
+        object-fit: scale-down;
+      }
+    }
+  }
 }
 dl.see {
   margin: 5px 0;
@@ -2100,6 +2110,18 @@ footer.send {
   //margin: 0 28px 20px 0;
   @include mb {
     //margin: 0 10px 10px 0;
+  }
+  &.unused{
+    .unused-message{
+      position: absolute;
+      background: rgba(173, 34, 4, 0.8);
+      color: white;
+      padding: 3px 5px;
+      font-size: 10px;
+      top: 0;
+      right: 0;
+      font-weight: bold;
+    }
   }
   .sanitizer-status {
     position: absolute;
@@ -3343,6 +3365,12 @@ form .CodeMirror {
     top: 65px;
     right: 15px;
     @include mb { position: static;}
+    a{
+      img{
+        max-width: 140px;
+        object-fit: scale-down;
+      }
+    }
   }
   #map-canvas {
     margin-bottom: 10px;

--- a/app/assets/stylesheets/ss/_tree.scss
+++ b/app/assets/stylesheets/ss/_tree.scss
@@ -10,7 +10,14 @@
     padding-left: calc(1.5 * var(--spacing) - var(--radius) - 2px);
 
     &.is-current{
-      a{
+      .ss-tree-subtree-wrap{
+        summary{
+          a{
+            background: #fbeee8;
+          }
+        }
+      }
+      > a{
         background: #fbeee8;
       }
     }

--- a/spec/features/facility/images_spec.rb
+++ b/spec/features/facility/images_spec.rb
@@ -76,15 +76,15 @@ describe "facility_images", type: :feature, dbscope: :example, js: true do
         expect(page).to have_css(".summary.image img[alt='#{image_page.image_alt}']")
 
         info = image_element_info(first(".summary.image img[alt='#{image_page.image_alt}']"))
-        expect(info[:width]).to eq 712
-        expect(info[:height]).to eq 210
+        expect(info[:width]).to eq 140
+        expect(info[:height]).to eq 41
       end
       within "#facility-images" do
         expect(page).to have_css("img[alt='#{image_page2.image_alt}']")
 
         info = image_element_info(first("img[alt='#{image_page2.image_alt}']"))
-        expect(info[:width]).to eq 160
-        expect(info[:height]).to eq 160
+        expect(info[:width]).to eq 140
+        expect(info[:height]).to eq 140
       end
 
       #


### PR DESCRIPTION
制作チームで下記のCSS調整を行なっていただきました。
施設情報の写真のサイズが変更されましたので、テストコードの修正を行なっています。

- 施設写真の画像サイズ
![スクリーンショット 2025-06-27 12 43 04（2）](https://github.com/user-attachments/assets/c13e7685-9649-4235-b4f6-a6b2d1f125e5)

- ファイルアップロードの未使用タグ表示
![スクリーンショット 2025-06-27 12 10 18（2）](https://github.com/user-attachments/assets/9a7f2cb6-00ca-44b8-9ff7-4607d9869d85)

- 
![スクリーンショット 2025-06-27 12 08 29（2）](https://github.com/user-attachments/assets/8d4d622e-d189-4b5a-a2f3-ffb35573e2a3)

- 
![スクリーンショット 2025-06-27 12 07 15（2）](https://github.com/user-attachments/assets/1732f050-99ec-4e39-afd4-c4452074ab7d)

- 
![スクリーンショット 2025-06-27 12 40 42（2）](https://github.com/user-attachments/assets/15dcfdb3-dacd-4017-a1c8-1310d823e96e)
