### PR TITLE
[fix] ss model role permission_names

### DIFF
--- a/app/models/concerns/ss/model/role.rb
+++ b/app/models/concerns/ss/model/role.rb
@@ -40,12 +40,10 @@ module SS::Model::Role
     end
 
     def permission_names
-      Rails.application.reload_routes_unless_loaded
       _permission_names.sort
     end
 
     def module_permission_names(opts = {})
-      Rails.application.reload_routes_unless_loaded
       permissions = _module_permission_names.sort_by { |k, v| k }.map do |mod, names|
         [mod, names.sort_by { |name| name.to_s.split('_').reverse.join } ]
       end.to_h

--- a/app/models/concerns/ss/model/role.rb
+++ b/app/models/concerns/ss/model/role.rb
@@ -40,10 +40,12 @@ module SS::Model::Role
     end
 
     def permission_names
+      Rails.application.reload_routes_unless_loaded
       _permission_names.sort
     end
 
     def module_permission_names(opts = {})
+      Rails.application.reload_routes_unless_loaded
       permissions = _module_permission_names.sort_by { |k, v| k }.map do |mod, names|
         [mod, names.sort_by { |name| name.to_s.split('_').reverse.join } ]
       end.to_h

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -105,8 +105,10 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
   config.log_level = ENV['DEVELOPMENT_LOG_LEVEL'] || :debug
 
-  # HACK: Load routes because load initializers in rake tasks.
+  # HACK: Load initializers without load routes in rake tasks.
   config.after_initialize do
-    Rails.application.reload_routes!
+    Dir["#{config.root}/app/models/**/initializer.rb"].each do |file|
+      require file
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -104,4 +104,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::Logger.new("#{Rails.root}/log/development.log")
   config.log_formatter = ::Logger::Formatter.new
   config.log_level = ENV['DEVELOPMENT_LOG_LEVEL'] || :debug
+
+  # HACK: Load routes because load initializers in rake tasks.
+  config.after_initialize do
+    Rails.application.reload_routes!
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -88,8 +88,10 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :test
 
-  # HACK: Load routes because load initializers in rake tasks.
+  # HACK: Load initializers without load routes in rake tasks.
   config.after_initialize do
-    Rails.application.reload_routes!
+    Dir["#{config.root}/app/models/**/initializer.rb"].each do |file|
+      require file
+    end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -87,4 +87,9 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :test
+
+  # HACK: Load routes because load initializers in rake tasks.
+  config.after_initialize do
+    Rails.application.reload_routes!
+  end
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

1. development 環境では Rails のバージョンアップにより rake で routes が読み込まれなくなった。 ( おそらく高速化した )
2. routes 内の initializer が読み込まれなくなった。
3. SS::Model::Role の permission_names が想定通りに初期化されず空になる。
4. permission_names を参照する rake タスクが正常に動作しない。

## 変更内容

permission_names の参照時に routes を読み込みように変更。

## その他

routes を読み込む処理はそれほど重くないが、 initializer のみを読み込みできるとより良い。