### PR TITLE
[feature]rename-cms-ignore-alert-permissions

### DIFF
--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -859,8 +859,8 @@ ja:
     delete_private_cms_forms: 定型フォームの削除（所有）
     delete_other_cms_forms: 定型フォームの削除（全て）
     use_cms_michecker: micheckerの利用
-    delete_cms_ignore_alert: 警告を無視して削除する
-    edit_cms_ignore_alert: 警告を無視して非公開保存する
+    delete_cms_ignore_alert: リンクチェック警告を無視して削除する
+    edit_cms_ignore_alert: リンクチェック警告を無視して非公開保存する
     use_cms_sitemap: フォルダ容量のCSVダウンロード
     use_cms_check_links: リンクチェックの利用
     run_cms_check_links: リンクチェックの実行


### PR DESCRIPTION
## 概要
警告を無視して削除する、警告を無視して非公開保存する権限の名称変更

## 変更内容
- 警告を無視して削除する → リンクチェック警告を無視して削除する
- 警告を無視して非公開保存する → リンクチェック警告を無視して非公開にする