### PR TITLE
[modify] rename label of twitter to x

### DIFF
--- a/app/models/concerns/cms/addon/node_twitter_post_setting.rb
+++ b/app/models/concerns/cms/addon/node_twitter_post_setting.rb
@@ -5,9 +5,8 @@ module Cms::Addon::NodeTwitterPostSetting
   included do
     field :node_twitter_poster_state, type: String
     field :node_twitter_auto_post, type: String
-    field :node_twitter_post_format, type: String
     field :node_twitter_edit_auto_post, type: String
-    permit_params :node_twitter_poster_state, :node_twitter_auto_post, :node_twitter_post_format, :node_twitter_edit_auto_post
+    permit_params :node_twitter_poster_state, :node_twitter_auto_post, :node_twitter_edit_auto_post
   end
 
   def node_twitter_poster_state_options
@@ -20,10 +19,6 @@ module Cms::Addon::NodeTwitterPostSetting
 
   def node_twitter_edit_auto_post_options
     %w(disabled enabled).map { |v| [I18n.t("ss.options.state.#{v}"), v] }
-  end
-
-  def node_twitter_post_format_options
-    I18n.t("cms.options.twitter_post_format").map { |k, v| [v, k] }
   end
 
   def node_twitter_poster_enabled?

--- a/app/models/concerns/cms/addon/twitter_poster.rb
+++ b/app/models/concerns/cms/addon/twitter_poster.rb
@@ -11,13 +11,12 @@ module Cms::Addon
       attr_accessor :skip_twitter_post
 
       field :twitter_auto_post, type: String
-      field :twitter_post_format, type: String
       field :twitter_edit_auto_post, type: String
 
       field :twitter_posted, type: Array, default: [], metadata: { branch: false }
       field :twitter_post_error, type: String, metadata: { branch: false }
 
-      permit_params :twitter_auto_post, :twitter_edit_auto_post, :twitter_post_format, :twitter_post_id, :twitter_user_id
+      permit_params :twitter_auto_post, :twitter_edit_auto_post, :twitter_post_id, :twitter_user_id
 
       validate :validate_twitter_postable, if: -> { twitter_auto_post == "active" }
 
@@ -26,10 +25,6 @@ module Cms::Addon
 
     def twitter_auto_post_options
       %w(expired active).map { |v| [I18n.t("ss.options.state.#{v}"), v] }
-    end
-
-    def twitter_post_format_options
-      I18n.t("cms.options.twitter_post_format").map { |k, v| [v, k] }
     end
 
     def twitter_edit_auto_post_options
@@ -99,11 +94,6 @@ module Cms::Addon
       if policy
         msg = I18n.t("errors.messages.denied_with_upload_policy", policy: I18n.t("ss.options.upload_policy.#{policy}"))
         errors.add :base, "#{t(:twitter_auto_post)}：#{msg}"
-        return
-      end
-
-      if twitter_post_format == "thumb_and_page" && thumb.blank?
-        errors.add :thumb_id, :blank
       end
     end
 

--- a/app/views/cms/agents/addons/node_twitter_post_setting/_form.html.erb
+++ b/app/views/cms/agents/addons/node_twitter_post_setting/_form.html.erb
@@ -12,9 +12,6 @@
   <dt><%= @model.t :node_twitter_auto_post %><%= @model.tt :node_twitter_auto_post %></dt>
   <dd><%= f.select :node_twitter_auto_post, @item.node_twitter_auto_post_options, include_blank: true %></dd>
 
-  <dt><%= @model.t :node_twitter_post_format %><%= @model.tt :node_twitter_post_format %></dt>
-  <dd><%= f.select :node_twitter_post_format, @item.node_twitter_post_format_options, include_blank: true %></dd>
-
   <dt><%= @model.t :node_twitter_edit_auto_post %><%= @model.tt :node_twitter_edit_auto_post %></dt>
   <dd><%= f.select :node_twitter_edit_auto_post, @item.node_twitter_edit_auto_post_options, include_blank: true %></dd>
 </dl>

--- a/app/views/cms/agents/addons/node_twitter_post_setting/_show.html.erb
+++ b/app/views/cms/agents/addons/node_twitter_post_setting/_show.html.erb
@@ -7,9 +7,6 @@
   <dt><%= @model.t :node_twitter_auto_post %></dt>
   <dd><%= @item.label :node_twitter_auto_post %></dd>
 
-  <dt><%= @model.t :node_twitter_post_format %></dt>
-  <dd><%= @item.label :node_twitter_post_format %></dd>
-
   <dt><%= @model.t :node_twitter_edit_auto_post %></dt>
   <dd><%= @item.label :node_twitter_edit_auto_post %></dd>
 </dl>

--- a/app/views/cms/agents/addons/twitter_poster/_form.html.erb
+++ b/app/views/cms/agents/addons/twitter_poster/_form.html.erb
@@ -7,16 +7,12 @@
   addon[:display_body] = "hide"
 
   twitter_auto_post = @item.twitter_auto_post.presence || @cur_node.try(:node_twitter_auto_post).presence || "expired"
-  twitter_post_format = @item.twitter_post_format.presence || @cur_node.try(:node_twitter_post_format).presence || "thumb_and_page"
   twitter_edit_auto_post = @item.twitter_edit_auto_post.presence || @cur_node.try(:node_twitter_edit_auto_post).presence || "disabled"
 %>
 
 <dl class="see mod-cms-twitter_poster">
   <dt><%= @model.t :twitter_auto_post %><%= @model.tt :twitter_auto_post %></dt>
   <dd><%=  f.select :twitter_auto_post, @item.twitter_auto_post_options, :selected => twitter_auto_post %></dd>
-
-  <dt><%= @model.t :twitter_post_format %><%= @model.tt :twitter_post_format %></dt>
-  <dd><%=  f.select :twitter_post_format, @item.twitter_post_format_options, selected: twitter_post_format %></dd>
 
   <dt><%= @model.t :twitter_edit_auto_post %><%= @model.tt :twitter_edit_auto_post %></dt>
   <dd><%=  f.select :twitter_edit_auto_post, @item.twitter_edit_auto_post_options, :selected => twitter_edit_auto_post %></dd>

--- a/app/views/cms/agents/addons/twitter_poster/_show.html.erb
+++ b/app/views/cms/agents/addons/twitter_poster/_show.html.erb
@@ -9,9 +9,6 @@
   <dd><%= @item.label :twitter_auto_post %></dd>
 
   <% if @item.use_twitter_post? %>
-    <dt><%= @model.t :twitter_post_format %></dt>
-    <dd><%= @item.label :twitter_post_format %></dd>
-
     <% if @item.twitter_edit_auto_post_enabled? %>
       <dt><%= @model.t :twitter_edit_auto_post %></dt>
       <dd><%= @item.label :twitter_edit_auto_post %></dd>

--- a/app/views/ss/agents/addons/twitter_setting/_show.html.erb
+++ b/app/views/ss/agents/addons/twitter_setting/_show.html.erb
@@ -1,5 +1,5 @@
 <dl class="see mod-ss-twitter-setting">
-  <dt><%= @model.t :twitter_poster %></dt>
+  <dt><%= @model.t :twitter_poster_state %></dt>
   <dd><%= @item.label :twitter_poster_state %></dd>
 
   <dt><%= @model.t :twitter_card %></dt>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -279,7 +279,7 @@ ja:
       check_accessibility_manually: "セマンティックなマークアップであり、コントラスト比に問題がない事を確認してください。"
       when_publish: 公開時の注意
       line_post_enabled: LINE連携が有効になっています。連携しない場合は、設定を解除してください。
-      twitter_post_enabled: Twitter投稿が有効になっています。連携しない場合は、設定を解除してください。
+      twitter_post_enabled: X(旧Twitter)投稿が有効になっています。連携しない場合は、設定を解除してください。
       source_clean: "ソースクリーニングを実行してよろしいですか。\nソースクリーニングにより表示が崩れる可能性があります。"
       change_form: 定型フォームを変更してよろしいですか？
       line_apply_richmenu: リッチメニューの反映処理を開始してよろしいですか？
@@ -597,7 +597,7 @@ ja:
         main: 本配信
         test: テスト配信
       sns_post_log_type:
-        twitter: Twitter投稿
+        twitter: X(旧Twitter)投稿
         line: LINE投稿
       sns_post_log_state:
         success: 成功
@@ -646,7 +646,7 @@ ja:
     sns_share:
       fb_share: Facebook シェア
       fb_lang: ja_JP
-      twitter: Twitter
+      twitter: X(旧Twitter)
       tweet: ツイート
       hatena: はてなブックマーク
       hatena_add: このエントリーをはてなブックマークに追加
@@ -876,7 +876,7 @@ ja:
     use_cms_line_deliver_categories: LINE配信カテゴリーの管理
     use_cms_line_services: LINEサービスの管理
     use_cms_all_contents: 全コンテンツの利用
-    use_cms_page_twitter_posts: ページTwitter投稿の利用
+    use_cms_page_twitter_posts: ページX(旧Twitter)投稿の利用
     use_cms_page_line_posts: ページLINE投稿の利用
     use_other_cms_line_mail_handlers: LINEメール連携の管理（全て）
     use_private_cms_line_mail_handlers: LINEメール連携の管理（所有）
@@ -919,8 +919,8 @@ ja:
       cms/import/body: 本文
       cms/edit_lock: 排他制御
       cms/sns_share: SNS共有
-      cms/twitter_poster: Twitter連携
-      cms/node_twitter_post_setting: Twitter連携設定
+      cms/twitter_poster: X(旧Twitter)連携
+      cms/node_twitter_post_setting: X(旧Twitter)連携設定
       cms/node_line_post_setting: LINE連携設定
       cms/captcha: 認証
       cms/body_layout_html: HTML
@@ -1254,10 +1254,10 @@ ja:
         sns_share_states: 表示
         sns_share_orders: 並び順
       cms/addon/twitter_poster:
-        twitter_auto_post: Twitter投稿
+        twitter_auto_post: X(旧Twitter)投稿
         twitter_edit_auto_post: 編集時に自動投稿
         twitter_post_format: 投稿形式
-        twitter_posted: Twitter投稿履歴
+        twitter_posted: X(旧Twitter)投稿履歴
         twitter_posted_url: TweetURL
         twitter_posted_at: 投稿日時
         twitter_post_error: 投稿エラー
@@ -1271,7 +1271,7 @@ ja:
         line_post_error: 投稿エラー
       cms/addon/node_twitter_post_setting:
         node_twitter_poster_state: ページ連携
-        node_twitter_auto_post: Twitter投稿
+        node_twitter_auto_post: X(旧Twitter)投稿
         node_twitter_post_format: 投稿形式
         node_twitter_edit_auto_post: 編集時に自動投稿
       cms/addon/node_line_post_setting:
@@ -2386,7 +2386,7 @@ ja:
           パンくずリストを自動生成します。
         - |-
           標準機能/SNSシェアボタン
-          facebook、Twitter等のSNSシェアボタンを表示します。
+          facebook、X(旧Twitter)等のSNSシェアボタンを表示します。
         - |-
           イベント/カレンダー
           イベントカレンダーを表示します。
@@ -3114,11 +3114,11 @@ ja:
         インポートした際に記事ページを書き出します。
     cms/addon/node_twitter_post_setting:
       node_twitter_poster_state:
-        - 有効に設定するとフォルダー内の記事編集時にTwitter連携が表示されます。
+        - 有効に設定するとフォルダー内の記事編集時にX(旧Twitter)連携が表示されます。
       node_twitter_auto_post:
-        - 有効に設定すると公開時にTwitter投稿をおこないます。
+        - 有効に設定すると公開時にX(旧Twitter)投稿をおこないます。
       node_twitter_edit_auto_post:
-        - 有効に設定すると再度公開した際にTwitter投稿をおこないます。
+        - 有効に設定すると再度公開した際にX(旧Twitter)投稿をおこないます。
         - この設定は再投稿が完了した際に、自動的に無効に戻ります。
       node_twitter_post_format:
         - 投稿形式を選択します。
@@ -3156,9 +3156,9 @@ ja:
 
     cms/addon/twitter_poster:
       twitter_auto_post:
-        - 有効に設定すると公開時にTwitter投稿をおこないます。
+        - 有効に設定すると公開時にX(旧Twitter)投稿をおこないます。
       twitter_edit_auto_post:
-        - 有効に設定すると再度公開した際にTwitter投稿をおこないます。
+        - 有効に設定すると再度公開した際にX(旧Twitter)投稿をおこないます。
         - この設定は再投稿が完了した際に、自動的に無効に戻ります。
       twitter_post_format:
         - 投稿形式を選択します。
@@ -3503,7 +3503,7 @@ ja:
       cms/form_db/import_url_job: CMS/定型DBインポート
       cms/all_contents_import_job: CMS/全コンテンツ一括設定
       cms/michecker_job: CMS/miChecker
-      cms/sns_post/twitter_job: CMS/Twitterページ投稿
+      cms/sns_post/twitter_job: CMS/X(旧Twitter)ページ投稿
       cms/sns_post/line_job: LINE/ページ投稿
       cms/line/deliver_job: LINE/配信
       cms/line/test_deliver_job: LINE/テスト配信

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -549,10 +549,6 @@ ja:
         same_as_updated: 更新日
         same_as_created: 作成日
         same_as_first_released: 初公開日
-      twitter_post_format:
-        thumb_and_page: サムネイル画像とページ
-        files_and_page: 本文内の画像とページ
-        page_only: ページ
       line_post_format:
         thumb_carousel: サムネイル画像とLINEメッセージ
         body_carousel: 本文内の最初の画像とLINEメッセージ
@@ -1256,7 +1252,6 @@ ja:
       cms/addon/twitter_poster:
         twitter_auto_post: X(旧Twitter)投稿
         twitter_edit_auto_post: 編集時に自動投稿
-        twitter_post_format: 投稿形式
         twitter_posted: X(旧Twitter)投稿履歴
         twitter_posted_url: TweetURL
         twitter_posted_at: 投稿日時
@@ -1272,7 +1267,6 @@ ja:
       cms/addon/node_twitter_post_setting:
         node_twitter_poster_state: ページ連携
         node_twitter_auto_post: X(旧Twitter)投稿
-        node_twitter_post_format: 投稿形式
         node_twitter_edit_auto_post: 編集時に自動投稿
       cms/addon/node_line_post_setting:
         node_line_poster_state: ページ連携
@@ -3120,19 +3114,6 @@ ja:
       node_twitter_edit_auto_post:
         - 有効に設定すると再度公開した際にX(旧Twitter)投稿をおこないます。
         - この設定は再投稿が完了した際に、自動的に無効に戻ります。
-      node_twitter_post_format:
-        - 投稿形式を選択します。
-        -
-        - ・サムネイル画像とページ
-        - サムネイル画像とページタイトルおよびリンクを投稿します。
-        -
-        - ・本文内の画像とページ
-        - 本文内の画像とページタイトルおよびリンクを投稿します。
-        - 画像は最大４件表示されます。
-        -
-        - ・ページ
-        - ページタイトルおよびリンクを投稿します。
-        - ページをOGPで表示する場合は、こちらを選択してください。
 
     cms/addon/node_line_post_setting:
       node_line_poster_state:
@@ -3160,19 +3141,6 @@ ja:
       twitter_edit_auto_post:
         - 有効に設定すると再度公開した際にX(旧Twitter)投稿をおこないます。
         - この設定は再投稿が完了した際に、自動的に無効に戻ります。
-      twitter_post_format:
-        - 投稿形式を選択します。
-        -
-        - ・サムネイル画像とページ
-        - サムネイル画像とページタイトルおよびリンクを投稿します。
-        -
-        - ・本文内の画像とページ
-        - 本文内の画像とページタイトルおよびリンクを投稿します。
-        - 画像は最大４件表示されます。
-        -
-        - ・ページ
-        - ページタイトルおよびリンクを投稿します。
-        - ページをOGPで表示する場合は、こちらを選択してください。
 
     cms/addon/line_poster:
       line_auto_post:

--- a/config/locales/sns_poster/ja.yml
+++ b/config/locales/sns_poster/ja.yml
@@ -2,7 +2,7 @@ ja:
   tooltip:
     cms/addon/sns_poster:
       twitter_auto_post:
-        - Twitterへの自動投稿の設定を行います。
+        - X(旧Twitter)への自動投稿の設定を行います。
     cms/addon/node_auto_post_setting:
       node_twitter_auto_post:
-        - Twitterへの自動投稿の設定を行います。
+        - X(旧Twitter)への自動投稿の設定を行います。

--- a/config/locales/ss/en.yml
+++ b/config/locales/ss/en.yml
@@ -665,7 +665,7 @@ en:
       ss/kana_setting: Kana settings
       ss/open_graph_setting: OpenGraph settings
       ss/facebook_setting: Facebook settings
-      ss/twitter_setting: Twitter settings
+      ss/twitter_setting: X(formerly Twitter) settings
       ss/line_setting: LINE settings
       ss/kintone_setting: Kintone settings
       ss/approve_setting: Approval settings
@@ -955,7 +955,7 @@ en:
         kintone_user: Basic auth user
         kintone_password: Basic auth password
       ss/addon/site_auto_post_setting:
-        site_twitter_auto_post: Twitter auto-post
+        site_twitter_auto_post: X(formerly Twitter) auto-post
         site_edit_auto_post: Auto-post when editing
       ss/addon/file_setting:
         file_resizing: Resize attached file
@@ -1440,7 +1440,7 @@ en:
         - Select the Open Graph format.
         - "You can see what it looks like:"
         - "Facebook share debugger: https://developers.facebook.com/tools/debug/sharing/"
-        - "Twitter Card Validator: https://cards-dev.twitter.com/validator/"
+        - "X(formerly Twitter) Card Validator: https://cards-dev.twitter.com/validator/"
         - "LINE Page Poker: https://poker.line.naver.jp/"
       opengraph_defaul_image_url:
         - Set the default image URL.
@@ -1448,14 +1448,14 @@ en:
         - If the page contains an image, the URL you set here is not used.
     ss/addon/twitter_setting:
       twitter_poster_state:
-        - If enabled, Twitter integration will appear when editing pages.
+        - If enabled, X(formerly Twitter) integration will appear when editing pages.
         - A consumer key and an access token, each with its own secret key, must be set.
       twitter_card:
-        - Select the Twitter card format.
-        - "You can see what it looks like on Twitter with “Twitter Card Validator”: https://cards-dev.twitter.com/validator ."
+        - Select the X(formerly Twitter) card format.
+        - "You can see what it looks like on X(formerly Twitter)with “X(formerly Twitter) Card Validator”: https://cards-dev.twitter.com/validator ."
       twitter_username:
-        - Set your Twitter username.
-        - Once set, you can analyze access with Twitter Card Analytics.
+        - Set your X(formerly Twitter) username.
+        - Once set, you can analyze access with X(formerly Twitter) Card Analytics.
       twitter_default_image_url:
         - Set the default image URL.
         - If the page does not contain an image, the URL will be set to “twitter:image”.

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -665,7 +665,7 @@ ja:
       ss/kana_setting: かな設定
       ss/open_graph_setting: OpenGraph設定
       ss/facebook_setting: Facebook設定
-      ss/twitter_setting: Twitter設定
+      ss/twitter_setting: X(旧Twitter)設定
       ss/line_setting: LINE設定
       ss/kintone_setting: kintone設定
       ss/approve_setting: 承認設定
@@ -955,7 +955,7 @@ ja:
         kintone_user: Basic認証ユーザー
         kintone_password: Basic認証パスワード
       ss/addon/site_auto_post_setting:
-        site_twitter_auto_post: Twitter自動投稿
+        site_twitter_auto_post: X(旧Twitter)自動投稿
         site_edit_auto_post: 編集時に自動投稿
       ss/addon/file_setting:
         file_resizing: 添付ファイルリサイズ
@@ -1441,7 +1441,7 @@ ja:
         - Open Graph 形式を選択します。
         - それぞれのSNSでシェアした場合の表示確認を以下のURLからできます。
         - Facebook share debugger：https://developers.facebook.com/tools/debug/sharing/
-        - Twitter Card Validator：https://cards-dev.twitter.com/validator/
+        - X(旧twitter) Card Validator：https://cards-dev.twitter.com/validator/
         - LINE Page Poker：https://poker.line.naver.jp/
       opengraph_defaul_image_url:
         - 既定の画像のURL を設定します。
@@ -1449,14 +1449,14 @@ ja:
         - ページに画像が含まれている場合、ここで設定した URL は使用されません。
     ss/addon/twitter_setting:
       twitter_poster_state:
-        - 有効にすると、ページ編集時にTwitter連携が表示されます。
+        - 有効にすると、ページ編集時にX(旧Twitter)連携が表示されます。
         - コンシューマーキーとアクセストークン、それぞれのシークレットキーを設定する必要があります。
       twitter_card:
-        - Twitter のカード形式を選択します。
-        - Twitter でどのような見え方をするかは「Twitter Card Validator（https://cards-dev.twitter.com/validator）」で確認することができます。
+        - X(旧twitter) のカード形式を選択します。
+        - X(旧twitter) でどのような見え方をするかは「X(旧twitter) Card Validator（https://cards-dev.twitter.com/validator）」で確認することができます。
       twitter_username:
-        - Twitter のユーザー名を設定します。
-        - 設定すると「Twitter Card Analytics」でアクセスを解析できるようになります。
+        - X(旧twitter) のユーザー名を設定します。
+        - 設定すると「X(旧twitter) Card Analytics」でアクセスを解析できるようになります。
       twitter_default_image_url:
         - 既定の画像のURL を設定します。
         - ページに画像が含まれていない場合、ここで設定した URL が twitter:image として使用されます。

--- a/spec/features/cms/sns_post/logs/basic_spec.rb
+++ b/spec/features/cms/sns_post/logs/basic_spec.rb
@@ -43,7 +43,6 @@ describe "cms_pages sns post", type: :feature, dbscope: :example, js: true do
             ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
             within "#addon-cms-agents-addons-twitter_poster" do
               select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-              select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             end
 
             perform_enqueued_jobs do

--- a/spec/features/cms/sns_post/twitter/approval_spec.rb
+++ b/spec/features/cms/sns_post/twitter/approval_spec.rb
@@ -121,7 +121,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -215,7 +214,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -304,7 +302,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.enabled"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -370,11 +367,9 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.active"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.enabled"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -444,11 +439,9 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.active"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.disabled"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -538,7 +531,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.active"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -621,7 +613,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
@@ -707,7 +698,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"

--- a/spec/features/cms/sns_post/twitter/basic_spec.rb
+++ b/spec/features/cms/sns_post/twitter/basic_spec.rb
@@ -99,7 +99,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -132,7 +131,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -180,7 +178,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.files_and_page"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -220,7 +217,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.files_and_page"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -263,7 +259,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.enabled"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -291,7 +286,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.active"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.enabled"), from: "item[twitter_edit_auto_post]"
@@ -321,7 +315,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.active"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.disabled"), from: "item[twitter_edit_auto_post]"

--- a/spec/features/cms/sns_post/twitter/merge_spec.rb
+++ b/spec/features/cms/sns_post/twitter/merge_spec.rb
@@ -91,7 +91,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -140,7 +139,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -233,7 +231,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           perform_enqueued_jobs do
@@ -272,7 +269,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.expired"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"

--- a/spec/features/cms/sns_post/twitter/release_page_spec.rb
+++ b/spec/features/cms/sns_post/twitter/release_page_spec.rb
@@ -91,7 +91,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           ensure_addon_opened("#addon-cms-agents-addons-release_plan")
@@ -162,7 +161,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
           end
 
           ensure_addon_opened("#addon-cms-agents-addons-release_plan")
@@ -277,7 +275,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.active"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -305,7 +302,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.active"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.disabled"), from: "item[twitter_edit_auto_post]"
@@ -357,7 +353,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.active"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -385,7 +380,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.active"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.enabled"), from: "item[twitter_edit_auto_post]"
@@ -442,7 +436,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-            select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
             select I18n.t("ss.options.state.active"), from: "item[twitter_edit_auto_post]"
           end
 
@@ -484,7 +477,6 @@ describe "article_pages twitter post", type: :feature, dbscope: :example, js: tr
           ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
           within "#addon-cms-agents-addons-twitter_poster" do
             expect(page).to have_css('select[name="item[twitter_auto_post]"] option[selected]', text: I18n.t("ss.options.state.expired"))
-            expect(page).to have_css('select[name="item[twitter_post_format]"] option[selected]', text: I18n.t("cms.options.twitter_post_format.page_only"))
             expect(page).to have_css('select[name="item[twitter_edit_auto_post]"] option[selected]', text: I18n.t("ss.options.state.disabled"))
 
             select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"

--- a/spec/features/cms/sns_post/twitter/unpostable_spec.rb
+++ b/spec/features/cms/sns_post/twitter/unpostable_spec.rb
@@ -57,7 +57,6 @@ describe "article_pages line post", type: :feature, dbscope: :example, js: true 
         ensure_addon_opened("#addon-cms-agents-addons-twitter_poster")
         within "#addon-cms-agents-addons-twitter_poster" do
           select I18n.t("ss.options.state.active"), from: "item[twitter_auto_post]"
-          select I18n.t("cms.options.twitter_post_format.page_only"), from: "item[twitter_post_format]"
         end
         within "form#item-form" do
           wait_for_cbox_opened { click_on I18n.t("ss.buttons.publish_save") }

--- a/spec/models/history/trash/restore_article_page_spec.rb
+++ b/spec/models/history/trash/restore_article_page_spec.rb
@@ -77,20 +77,16 @@ describe History::Trash, type: :model, dbscope: :example do
 
     context "with cms/twitter_poster" do
       let(:twitter_auto_post) { %w(expired active).sample }
-      # let(:twitter_post_format) { %w(thumb_and_page files_and_page page_only).sample }
-      let(:twitter_post_format) { %w(files_and_page page_only).sample }
       let(:twitter_edit_auto_post) { %w(disabled enabled).sample }
       let!(:item) do
         create(
           :article_page, cur_user: user, cur_site: site, cur_node: node,
-          twitter_auto_post: twitter_auto_post, twitter_post_format: twitter_post_format,
-          twitter_edit_auto_post: twitter_edit_auto_post
+          twitter_auto_post: twitter_auto_post, twitter_edit_auto_post: twitter_edit_auto_post
         )
       end
 
       it do
         expect(item.twitter_auto_post).to eq twitter_auto_post
-        expect(item.twitter_post_format).to eq twitter_post_format
         expect(item.twitter_edit_auto_post).to eq twitter_edit_auto_post
       end
     end

--- a/spec/models/history/trash/restore_cms_page_spec.rb
+++ b/spec/models/history/trash/restore_cms_page_spec.rb
@@ -76,20 +76,16 @@ describe History::Trash, type: :model, dbscope: :example do
 
     context "with cms/twitter_poster" do
       let(:twitter_auto_post) { %w(expired active).sample }
-      # let(:twitter_post_format) { %w(thumb_and_page files_and_page page_only).sample }
-      let(:twitter_post_format) { %w(files_and_page page_only).sample }
       let(:twitter_edit_auto_post) { %w(disabled enabled).sample }
       let!(:item) do
         create(
           :cms_page, cur_user: user, cur_site: site,
-          twitter_auto_post: twitter_auto_post, twitter_post_format: twitter_post_format,
-          twitter_edit_auto_post: twitter_edit_auto_post
+          twitter_auto_post: twitter_auto_post, twitter_edit_auto_post: twitter_edit_auto_post
         )
       end
 
       it do
         expect(item.twitter_auto_post).to eq twitter_auto_post
-        expect(item.twitter_post_format).to eq twitter_post_format
         expect(item.twitter_edit_auto_post).to eq twitter_edit_auto_post
       end
     end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

CMSのTwitter連携の表記をX(旧Twitter)連携に変更
記事ページのTwitter連携設定の twitter_post_format が使用されなくなった為、削除