### PR TITLE
【fixup】【cms】meta-content-association (#5612)

### DIFF
--- a/app/views/cms/agents/addons/meta/_form.html.erb
+++ b/app/views/cms/agents/addons/meta/_form.html.erb
@@ -12,22 +12,18 @@
 
   <dt><%= @model.t :description %></dt>
   <dd></dd>
-  <dt class="depth-2"><%= @model.t :description_setting %><%= @model.tt :description_setting %></dt>
-  <dd>
-    <%
-      if @item.description_setting.blank? && @cur_site
-        @item.description_setting_auto?
-      end
-    %>
 
+  <dt class="depth-2"><%= @model.t :description_setting %><%= @model.tt :description_setting %></dt>
+  <dd class="depth-2">
     <%= f.radio_button :description_setting, "manual", checked: @item.description_setting_manual? %>
-    <%= f.label :description_setting, t("cms.cms/addon/meta.description_setting_manual"), value: "manual" %>
+    <%= f.label :description_setting, t("cms.options.description_setting.description_setting_manual"), value: "manual" %>
 
     <%= f.radio_button :description_setting, "auto", checked: @item.description_setting_auto? %>
-    <%= f.label :description_setting, t("cms.cms/addon/meta.description_setting_auto"), value: "auto" %>
+    <%= f.label :description_setting, t("cms.options.description_setting.description_setting_auto"), value: "auto" %>
   </dd>
-  <dt class="depth-2"><%= t("cms.cms/addon/meta.description_body") %><%= tt("cms/addon/meta.description_body") %></dt>
-  <dd>
+
+  <dt class="depth-2"><%= @model.t :description_body %><%= @model.tt :description_body %></dt>
+  <dd class="depth-2">
     <% opts = @cur_site.auto_description_enabled? ? {} : { class: "presence" } %>
     <% opts[:readonly] = @item.description_setting_auto? %>
     <%= f.text_area :description, opts %>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -624,10 +624,9 @@ ja:
       subject_state:
         disabled: 本文に含めない
         include: 本文に含める
-    cms/addon/meta:
-      description_setting_manual: 手動
-      description_setting_auto: 自動的に本文と連動
-      description_body: 概要の本文
+      description_setting:
+        description_setting_manual: 手動
+        description_setting_auto: 自動的に本文と連動
       site_search_type:
         page: ウェブページ
         file: 添付ファイル
@@ -1181,6 +1180,7 @@ ja:
         keywords: キーワード
         description: 概要
         description_setting: 概要の連動設定
+        description_body: 概要の本文
         summary_html: サマリー
       cms/addon/editor_setting:
         color_button: 文字色変更ボタン
@@ -3424,7 +3424,6 @@ ja:
         - メタ情報の概要欄を入力します。
         - メタ情報の概要欄を設定しておくことで、閲覧者の方が必要な情報を見つけやすくなり、サイトの利便性が高まります。
         - ・「自動的に本文と連動」を選択した場合は、常に本文の内容の冒頭60文字を概要として表示します。
-        - ・「自動的に本文と連動」を選択した場合であっても、「サイト設定」の「概要自動設定」が「無効」に設定されている場合は、本文の内容が変更されても、概要欄に変更内容は反映されません。
         - ・「手動」を選択した場合は本文の内容が変更されても、概要欄に変更内容は反映されません。
 
   all_content:


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

ja.yml のオプションの定義位置が不味い。

site_search_type、link_target、archive_view が、cms.options 配下から外れてしまっている（cms.cms/addon/meta配下へ移動してしまっている）。

## 変更内容

ja.yml を修正。それに伴って form を修正。
