### PR TITLE
[fix] unable to delete ad

### DIFF
--- a/app/assets/stylesheets/ss/link_item/_ss.scss
+++ b/app/assets/stylesheets/ss/link_item/_ss.scss
@@ -4,6 +4,10 @@
     grid-template-columns: 1fr 1fr auto auto auto;
     align-items: center;
 
+    &:not(:has([data-id])) {
+      display: none;
+    }
+
     .ss-link-item-name, .ss-link-item-url {
       display: -webkit-box;
       overflow: hidden;

--- a/app/views/sys/ads/_form_link_items.html.erb
+++ b/app/views/sys/ads/_form_link_items.html.erb
@@ -29,6 +29,9 @@
 <% end %>
 
 <div data-controller="ss--increase-decrease" data-ss--increase-decrease-max-value="<%= max_count %>" data-ss--increase-decrease-attribute-value="<%= attribute_name %>">
+  <%# 全ての広告を削除すると ad_links がサーバーへ送られなくなるため、削除したのに削除されない現象が発生することを防ぐ目的でダミーを追加する %>
+  <%= hidden_field_tag "#{field_name_prefix}[$unused$]", "", id: nil %>
+
   <table class="index ss-link-item-table ss-link-item-table-form">
     <thead>
     <tr>

--- a/spec/features/sys/ad_spec.rb
+++ b/spec/features/sys/ad_spec.rb
@@ -42,6 +42,7 @@ describe "sys_ad", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t('ss.notice.saved')
 
+      ad_file1 = nil
       Sys::Setting.first.tap do |setting|
         expect(setting.time).to eq time1
         expect(setting.width).to eq width1
@@ -62,6 +63,8 @@ describe "sys_ad", type: :feature, dbscope: :example, js: true do
             expect(file.owner_item_type).to eq setting.class.name
             expect(file.owner_item_id.to_s).to eq setting.id.to_s
             expect(file.state).to eq "public"
+
+            ad_file1 = file
           end
         end
       end
@@ -87,6 +90,7 @@ describe "sys_ad", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t('ss.notice.saved')
 
+      ad_file2 = nil
       Sys::Setting.first.tap do |setting|
         expect(setting.time).to eq time2
         expect(setting.width).to eq width2
@@ -107,6 +111,8 @@ describe "sys_ad", type: :feature, dbscope: :example, js: true do
             expect(file.owner_item_type).to eq setting.class.name
             expect(file.owner_item_id.to_s).to eq setting.id.to_s
             expect(file.state).to eq "public"
+
+            ad_file2 = file
           end
         end
       end
@@ -146,6 +152,111 @@ describe "sys_ad", type: :feature, dbscope: :example, js: true do
           end
         end
       end
+
+      expect { ad_file1.reload }.to raise_error Mongoid::Errors::DocumentNotFound
+      expect { ad_file2.reload }.to raise_error Mongoid::Errors::DocumentNotFound
+    end
+  end
+
+  context "when all are removed" do
+    let!(:file1) do
+      tmp_ss_file(basename: "logo-#{unique_id}.png", contents: "#{Rails.root}/spec/fixtures/ss/logo.png", user: user)
+    end
+    let(:time1) { rand(5..10) }
+    let(:width1) { rand(200..300) }
+    let(:name1) { "name-#{unique_id}" }
+    let(:url1) { unique_url }
+
+    it do
+      #
+      # Create
+      #
+      login_user user, to: sys_ad_path
+      click_on I18n.t("ss.links.edit")
+
+      within "form#item-form" do
+        fill_in "item[time]", with: time1
+        fill_in "item[width]", with: width1
+
+        within "[data-index='new']" do
+          fill_in "item[ad_links][][name]", with: name1
+          fill_in "item[ad_links][][url]", with: url1
+          select I18n.t("ss.options.link_target._blank"), from: "item[ad_links][][target]"
+          attach_to_ss_file_field "item[ad_links][][file_id]", file1
+          select I18n.t("ss.options.state.show"), from: "item[ad_links][][state]"
+        end
+
+        click_on I18n.t("ss.buttons.save")
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      ad_file1 = nil
+      Sys::Setting.first.tap do |setting|
+        expect(setting.time).to eq time1
+        expect(setting.width).to eq width1
+
+        setting.ad_links.to_a.tap do |ad_links|
+          expect(ad_links).to have(1).items
+          ad_links[0].tap do |ad_link|
+            expect(ad_link.id).to be_present
+            expect(ad_link.name).to eq name1
+            expect(ad_link.url).to eq url1
+            expect(ad_link.target).to eq "_blank"
+            expect(ad_link.file).to be_present
+            expect(ad_link.state).to eq "show"
+
+            file = ad_link.file
+            expect(file.id).to eq file1.id
+            expect(file.model).to eq setting.class.name.underscore
+            expect(file.owner_item_type).to eq setting.class.name
+            expect(file.owner_item_id.to_s).to eq setting.id.to_s
+            expect(file.state).to eq "public"
+
+            ad_file1 = file
+          end
+        end
+      end
+
+      #
+      # Delete
+      #
+      visit sys_ad_path
+      click_on I18n.t("ss.links.edit")
+      within "form#item-form" do
+        fill_in "item[time]", with: ""
+        fill_in "item[width]", with: ""
+
+        data_indexes = all("[data-index]")
+        data_indexes.reverse_each do |data_index|
+          within data_index do
+            click_on "remove"
+          end
+        end
+
+        click_on I18n.t("ss.buttons.save")
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      Sys::Setting.first.tap do |setting|
+        expect(setting.time).to be_blank
+        expect(setting.width).to be_blank
+
+        # 全部削除しても、どうしても一つ残ってしまう。
+        setting.ad_links.to_a.tap do |ad_links|
+          expect(ad_links).to have(1).items
+
+          ad_links[0].tap do |ad_link|
+            expect(ad_link.id).to be_present
+            expect(ad_link.name).to be_blank
+            expect(ad_link.url).to be_blank
+            expect(ad_link.target).to eq "_blank"
+            expect(ad_link.file).to be_blank
+            expect(ad_link.state).to eq "show"
+          end
+        end
+      end
+
+      expect { ad_file1.reload }.to raise_error Mongoid::Errors::DocumentNotFound
     end
   end
 

--- a/spec/features/sys/ad_spec.rb
+++ b/spec/features/sys/ad_spec.rb
@@ -249,9 +249,9 @@ describe "sys_ad", type: :feature, dbscope: :example, js: true do
             expect(ad_link.id).to be_present
             expect(ad_link.name).to be_blank
             expect(ad_link.url).to be_blank
-            expect(ad_link.target).to eq "_blank"
+            expect(ad_link.target).to be_blank
             expect(ad_link.file).to be_blank
-            expect(ad_link.state).to eq "show"
+            expect(ad_link.state).to be_blank
           end
         end
       end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

ログイン広告をすべて削除すると、削除できない問題の修正。
空のレコードを一つ残しておくと削除は可能だった。
