### PR TITLE
[fixup] gws change menu icon (#5704)

### DIFF
--- a/app/helpers/gws/layout_helper.rb
+++ b/app/helpers/gws/layout_helper.rb
@@ -24,15 +24,15 @@ module Gws::LayoutHelper
     icon_class = "icon-#{type.to_s.dasherize}"
 
     if icon_file.present?
-      content_tag(:h2) do
+      tag.h2 do
         link_to(path, class: "#{icon_class} has-custom-icon") do
-          image_tag(icon_file.url, class: "nav-icon-img") + label
+          image_tag(icon_file.url, class: "nav-icon-img", aria: { hidden: true }) + label
         end
       end
     else
-      content_tag(:h2) do
+      tag.h2 do
         link_to(path, class: "#{icon_class} has-font-icon") do
-          content_tag(:span, "", class: "ss-icon ss-icon-#{type.to_s.dasherize}") + label
+          tag.span("", class: "ss-icon ss-icon-#{type.to_s.dasherize}", role: "img", aria: { hidden: true }) + label
         end
       end
     end

--- a/app/views/gws/agents/addons/system/menu_setting/_form.html.erb
+++ b/app/views/gws/agents/addons/system/menu_setting/_form.html.erb
@@ -10,19 +10,21 @@
   <dl class="see addon-gws-system-menu-setting">
     <dt><%= t('gws.site_config') %></dt>
     <dd>
-      <%= f.select "menu_#{type}_state", { t('ss.options.state.show') => "show" } %>
-      <%= f.text_field("menu_#{type}_label", value: @item.send("menu_#{type}_label"), placeholder: fallback_label || t("modules.gws/#{type}")) %>
+      <div class="input-group gap-5 align-items-center">
+        <%= f.select "menu_#{type}_state", { t('ss.options.state.show') => "show" } %>
+        <%= f.text_field("menu_#{type}_label", value: @item.send("menu_#{type}_label"), placeholder: fallback_label || t("modules.gws/#{type}")) %>
+      </div>
     </dd>
     <dt class="depth-2"><%= t("gws.buttons.change_menu_icon") %></dt>
-    <dd>
-      <span class="menu-icon-field">
+    <dd class="depth-2">
+      <div class="menu-icon-field input-group gap-5 align-items-center">
         <% if @item.send("menu_#{type}_icon_image").present? %>
-          <%= image_tag @item.send("menu_#{type}_icon_image").url, class: "icon-#{type.to_s.dasherize}", style: "width: 32px; height: 32px;" %>
+          <%= image_tag @item.send("menu_#{type}_icon_image").url, class: "icon-#{type.to_s.dasherize}", aria: { hidden: true }, style: "width: 32px; height: 32px;" %>
         <% else %>
-          <span class="ss-icon ss-icon-<%= type.to_s.dasherize %>"></span>
+          <span class="ss-icon ss-icon-<%= type.to_s.dasherize %>" role="img" aria-hidden="true"></span>
         <% end %>
         <%= f.ss_file_field "menu_#{type}_icon_image", accepts: SS::File::IMAGE_FILE_EXTENSIONS + [".svg"] %>
-      </span>
+      </div>
     </dd>
   </dl>
 <% end %>
@@ -34,20 +36,22 @@
     <dl class="see addon-gws-system-menu-setting">
       <dt><%= @model.t("menu_#{type}_state") %><%= @model.tt("menu_#{type}_state") %></dt>
       <dd>
-        <%= f.select "menu_#{type}_state", @item.send("menu_#{type}_state_options") %>
-        <%= f.text_field("menu_#{type}_label", value: @item.send("menu_#{type}_label"), placeholder: fallback_label || t("modules.gws/#{type}")) %>
+        <div class="input-group gap-5 align-items-center">
+          <%= f.select "menu_#{type}_state", @item.send("menu_#{type}_state_options") %>
+          <%= f.text_field("menu_#{type}_label", value: @item.send("menu_#{type}_label"), placeholder: fallback_label || t("modules.gws/#{type}")) %>
+        </div>
       </dd>
       <% unless skip_icon_types.include?(type.to_s) %>
       <dt class="depth-2"><%= t("gws.buttons.change_menu_icon") %></dt>
-      <dd>
-        <span class="menu-icon-field">
+      <dd class="depth-2">
+        <div class="menu-icon-field input-group gap-5 align-items-center">
           <% if @item.send("menu_#{type}_icon_image").present? %>
-            <%= image_tag @item.send("menu_#{type}_icon_image").url, class: "icon-#{type.to_s.dasherize}", style: "width: 32px; height: 32px;" %>
+            <%= image_tag @item.send("menu_#{type}_icon_image").url, class: "icon-#{type.to_s.dasherize}", aria: { hidden: true }, style: "width: 32px; height: 32px;" %>
           <% else %>
-            <span class="ss-icon ss-icon-<%= type.to_s.dasherize %>"></span>
+            <span class="ss-icon ss-icon-<%= type.to_s.dasherize %>" role="img" aria-hidden="true"></span>
           <% end %>
           <%= f.ss_file_field "menu_#{type}_icon_image", accepts: SS::File::IMAGE_FILE_EXTENSIONS + [".svg"] %>
-        </span>
+        </div>
       </dd>
       <% end %>
     </dl>

--- a/app/views/gws/agents/addons/system/menu_setting/_show.html.erb
+++ b/app/views/gws/agents/addons/system/menu_setting/_show.html.erb
@@ -10,20 +10,23 @@
   <dl class="see addon-gws-system-menu-setting">
     <dt><%= @model.t("menu_#{type}_state") %></dt>
     <dd>
-      <% unless skip_icon_types.include?(type.to_s) %>
-        <% if @item.send("menu_#{type}_icon_image").present? %>
-            <%= image_tag @item.send("menu_#{type}_icon_image").url, class: "icon-#{type.to_s.dasherize}", style: "width: 32px; height: 32px;" %>
-        <% else %>
-          <span class="ss-icon ss-icon-<%= type.to_s.dasherize %>"></span>
+      <div class="input-group gap-5 align-items-center">
+        <% unless skip_icon_types.include?(type.to_s) %>
+          <% if @item.send("menu_#{type}_icon_image").present? %>
+            <%= image_tag(@item.send("menu_#{type}_icon_image").url, class: "icon-#{type.to_s.dasherize}", style: "width: 32px; height: 32px;", aria: { hidden: true }) %> } %>
+          <% else %>
+            <span class="ss-icon ss-icon-<%= type.to_s.dasherize %>" role="img" aria-hidden="true"></span>
+          <% end %>
         <% end %>
-      <% end %>
-    </dd>
-    <dd>
-      <% if @item.send("menu_#{type}_visible?") %>
-        <%= @item.send("menu_#{type}_label") || fallback_label || t("modules.gws/#{type}") %>
-      <% else %>
-        <%= @item.label("menu_#{type}_state") %>
-      <% end %>
+
+        <span>
+          <% if @item.send("menu_#{type}_visible?") %>
+            <%= @item.send("menu_#{type}_label") || fallback_label || t("modules.gws/#{type}") %>
+          <% else %>
+            <%= @item.label("menu_#{type}_state") %>
+          <% end %>
+        </span>
+      </div>
     </dd>
   </dl>
 <% end %>


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

グループウェアのメニューアイコンのスタイル調整

## 変更内容

- `<input>` の表示崩れ修正。
- アイコンを表す `<span>` に `role="img"` と `aria-hidden="true"` を付与。
  https://waic.jp/translations/WCAG21/Techniques/aria/ARIA24

## その他

- _form.html.erb でも `aria-hidden="true"` を付与したが、`aria-label="アイコンの説明文字列"` を付与した方が良いかも。