### PR TITLE
[fixup^8][gws] 汎用DB (#5672)

### DIFF
--- a/app/models/gws/tabular/column/lookup_field.rb
+++ b/app/models/gws/tabular/column/lookup_field.rb
@@ -57,7 +57,7 @@ class Gws::Tabular::Column::LookupField < Gws::Column::Base
     when 'desc'
       index_direction = -1
     end
-    if index_state == "enabled"
+    if %w(enabled asc desc).include?(index_state)
       if lookup_column.i18n_state == "enabled"
         I18n.available_locales.each do |lang|
           file_model.index "#{field_name}.#{lang}" => index_direction

--- a/app/models/gws/tabular/file/generator.rb
+++ b/app/models/gws/tabular/file/generator.rb
@@ -1,0 +1,148 @@
+class Gws::Tabular::File::Generator
+  include ActiveModel::Model
+
+  attr_accessor :form_release
+  attr_writer :site
+
+  def site
+    @site ||= form_release.site
+  end
+
+  def model_name
+    @model_name ||= "File#{form.id}"
+  end
+
+  def target_file_path
+    @target_file_path ||= "#{Gws::Tabular.file_class_dir}/#{model_name.underscore}.rb"
+  end
+
+  def call
+    if ::File.exist?(target_file_path)
+      file_time = ::File.mtime(target_file_path)
+      file_time = file_time.in_time_zone
+      # no need to create. this is up to date.
+      return true if file_time >= form_release.updated.in_time_zone
+    end
+
+    prepare_temp
+
+    puts "class Gws::Tabular::#{model_name}"
+    indent 1 do
+      puts "extend SS::Translation"
+      puts "include SS::Document"
+      puts "include Gws::Referenceable"
+      puts "include Gws::Reference::User"
+      puts "include Gws::Reference::Site"
+      puts "include SS::Relation::File"
+      puts "include Gws::Tabular::File"
+      puts "include Gws::Reference::Tabular::Space"
+      puts "include Gws::Reference::Tabular::Form"
+      puts "include Gws::SitePermission"
+      puts
+      puts "identify_as 'Gws::Tabular::#{model_name}'"
+      puts "store_in collection: 'gws_tabular_file_#{form.id}'"
+      puts "set_permission_name 'gws_tabular_files'"
+      puts
+      puts "load_form_release '#{form.id}', #{form_release.revision}, #{form_release.patch}"
+      if form.workflow_enabled?
+        activate_workflow
+      end
+      puts
+      puts "# 注意: include の順番によっては Workflow::Approver.search が有効化してしまうのでこの位置でオーバーライドする。"
+      puts "include Gws::Tabular::File::Search"
+      puts
+      columns.each do |column|
+        puts "add_column '#{column.id}' # #{column.name} (#{column.class.name})"
+      end
+    end
+    puts "end"
+
+    deploy_temp
+    true
+  ensure
+    finalize_temp
+  end
+
+  private
+
+  def form
+    @form ||= Gws::Tabular.released_form(form_release, site: site) || form_release.form
+  end
+
+  def columns
+    @columns ||= begin
+      Gws::Tabular.released_columns(form_release, site: site) || form.columns.reorder(order: 1, id: 1).to_a
+    end
+  end
+
+  def prepare_temp
+    # ローカルストレージに一時ファイルを作成したいので "#{Rails.root}/tmp" に一時ファイルを作成する
+    @temp_file = Tempfile.open("tabular_file_#{form.id}", "#{Rails.root}/tmp")
+    @indent_level = 0
+  end
+
+  def finalize_temp
+    @temp_file.close if @temp_file
+  end
+
+  def deploy_temp
+    # "#{Rails.root}/private" は NFS でマウントされている可能性がある。
+    # つまり "#{Rails.root}/private" へのコピーはネットワーク転送に他ならない。
+    # 十分注意して "#{Rails.root}/private" へのコピーする
+    @temp_file.flush
+
+    Retriable.retriable do
+      ::FileUtils.mkdir_p(Gws::Tabular.file_class_dir)
+
+      target_temp_file_path = "#{Gws::Tabular.file_class_dir}/.#{model_name.underscore}.#{Process.pid}"
+      ::FileUtils.cp(@temp_file.path, target_temp_file_path)
+      ::FileUtils.mv(target_temp_file_path, target_file_path)
+      ::FileUtils.touch(target_file_path, mtime: form_release.updated.in_time_zone.to_time)
+    end
+  end
+
+  def puts(str = nil)
+    if str.blank?
+      @temp_file.write("\n")
+      return
+    end
+
+    @temp_file.write("  " * @indent_level)
+    @temp_file.write(str)
+    @temp_file.write("\n")
+    nil
+  end
+
+  def indent(n)
+    old_indent_level = @indent_level
+    @indent_level += n
+    begin
+      yield
+    ensure
+      @indent_level = old_indent_level
+    end
+  end
+
+  def activate_workflow
+    puts
+    puts "# workflow is enabled in this file"
+    workflow_addons.each do |addon|
+      puts "include #{addon.name}"
+    end
+    puts "cattr_reader(:approver_user_class) { Gws::User }"
+  end
+
+  def workflow_addons
+    addons = []
+
+    addons << Gws::Addon::Tabular::Inspection
+    addons << Gws::Addon::Tabular::Circulation
+    addons << Gws::Addon::Tabular::DestinationState
+    addons << Gws::Addon::Tabular::Approver
+    addons << Gws::Addon::Tabular::ApproverPrint
+    addons << Gws::Workflow2::DestinationSetting
+    addons << Gws::Tabular::Release
+
+    addons
+  end
+end

--- a/app/models/gws/tabular/file/notification_subject_service.rb
+++ b/app/models/gws/tabular/file/notification_subject_service.rb
@@ -23,7 +23,7 @@ class Gws::Tabular::File::NotificationSubjectService
   def call
     template = SUBJECT_TEMPLATE_MAP[type]
 
-    release = Gws::Tabular.form_release_from_file_model(item.class, site: site)
+    release = item.class.form_release
     form = Gws::Tabular.load_form(release, site: site)
 
     title = Gws::Tabular.item_title(item, site: site)

--- a/app/models/gws/tabular/form/delete_service.rb
+++ b/app/models/gws/tabular/form/delete_service.rb
@@ -9,6 +9,7 @@ class Gws::Tabular::Form::DeleteService
 
     return false unless form.destroy
 
+    delete_class_file(form_release)
     delete_all_files(form_release, file_model)
     delete_all_releases(form_release, file_model)
     true
@@ -19,6 +20,11 @@ class Gws::Tabular::Form::DeleteService
   def find_release
     releases = Gws::Tabular::FormRelease.where(form_id: form.id, revision: form.revision)
     releases.reorder(patch: -1).first
+  end
+
+  def delete_class_file(form_release)
+    generator = Gws::Tabular::File::Generator.new(form_release: form_release)
+    ::FileUtils.rm(generator.target_file_path)
   end
 
   def delete_all_releases(form_release, file_model)

--- a/app/models/gws/tabular/form_migration.rb
+++ b/app/models/gws/tabular/form_migration.rb
@@ -14,7 +14,7 @@ class Gws::Tabular::FormMigration
                             .then { BSON::ByteBuffer.new(_1) }
                             .then { Hash.from_bson(_1) }
 
-    if prev_attrs["index_state"] != current_attrs["index_state"] && prev_attrs["index_state"] == "enabled"
+    if prev_attrs["index_state"] != current_attrs["index_state"] && %w(enabled asc desc).include?(prev_attrs["index_state"])
       @drop_indexes ||= []
       @drop_indexes << { field_name => 1 }
     end

--- a/app/models/gws/tabular/initializer.rb
+++ b/app/models/gws/tabular/initializer.rb
@@ -42,24 +42,4 @@ class Gws::Tabular::Initializer
   Gws.module_usable :tabular do |site, user|
     Gws::Tabular.allowed?(:use, user, site: site)
   end
-
-  # アプリケーションサーバーが、メモリ使用量の超過や処理したリクエスト数の超過などにより
-  # リサイクルされた - つまり Gws::Tabular::FileXXXXXXXX クラスのキャッシュが破棄された - 状況を考える。
-  # このような状況下で、参照 SS::File#owner_item を辿っても Gws::Tabular::FileXXXXXXXX クラスが
-  # 見つからないので、参照を辿れない。
-  # 参照が辿れないのでファイルへアクセスすることができないと判定される。
-  # これでは困るので、起動時に全 Gws::Tabular::FileXXXXXXXX クラスをロードするようにする。
-  Gws::Tabular::Form.all.tap do |criteria|
-    all_ids = criteria.pluck(:id)
-    all_ids.each_slice(20) do |ids|
-      criteria.in(id: ids).to_a.each do |form|
-        release = form.current_release
-        next unless release
-
-        Gws::Tabular::File[release]
-      rescue => e
-        Rails.logger.warn { "#{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}" }
-      end
-    end
-  end
 end

--- a/app/models/ss.rb
+++ b/app/models/ss.rb
@@ -166,13 +166,4 @@ module SS
     return true if err.to_s == HTTP_STATUS_CODE_NOT_FOUND
     false
   end
-
-  def update_const(mod, constant_name, constant)
-    mod.module_eval do
-      remove_const(constant_name) if const_defined?(constant_name)
-      const_set(constant_name, constant)
-    end
-
-    constant
-  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,7 @@ module SS
     config.autoload_paths << "#{config.root}/app/validators"
     config.autoload_paths << "#{config.root}/app/helpers/concerns"
     config.autoload_paths << "#{config.root}/app/jobs/concerns"
+    config.autoload_paths << "#{Rails.root}/private/models"
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/spec/jobs/gws/tabular/form_trash_purge_job_spec.rb
+++ b/spec/jobs/gws/tabular/form_trash_purge_job_spec.rb
@@ -57,6 +57,11 @@ describe Gws::Tabular::FormTrashPurgeJob, dbscope: :example do
     before do
       expect(form1_model.all.count).to be > 0
       expect(form2_model.all.count).to be > 0
+
+      form1_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form1.id}.rb"
+      expect(::File.size(form1_model_class_path)).to be > 0
+      form2_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form2.id}.rb"
+      expect(::File.size(form2_model_class_path)).to be > 0
     end
 
     context '1 form is purged' do
@@ -75,6 +80,11 @@ describe Gws::Tabular::FormTrashPurgeJob, dbscope: :example do
         expect(form2_model.all.count).to eq 0
         expect { attachment1.reload }.not_to raise_error
         expect { attachment2.reload }.to raise_error Mongoid::Errors::DocumentNotFound
+
+        form1_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form1.id}.rb"
+        expect(::File.size(form1_model_class_path)).to be > 0
+        form2_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form2.id}.rb"
+        expect(::File.exist?(form2_model_class_path)).to be_falsey
       end
     end
 
@@ -95,6 +105,11 @@ describe Gws::Tabular::FormTrashPurgeJob, dbscope: :example do
         expect(form2_model.all.count).to eq 0
         expect { attachment1.reload }.to raise_error Mongoid::Errors::DocumentNotFound
         expect { attachment2.reload }.to raise_error Mongoid::Errors::DocumentNotFound
+
+        form1_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form1.id}.rb"
+        expect(::File.exist?(form1_model_class_path)).to be_falsey
+        form2_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form2.id}.rb"
+        expect(::File.exist?(form2_model_class_path)).to be_falsey
       end
     end
 
@@ -115,6 +130,11 @@ describe Gws::Tabular::FormTrashPurgeJob, dbscope: :example do
         expect(form2_model.all.count).to be > 0
         expect { attachment1.reload }.not_to raise_error
         expect { attachment2.reload }.not_to raise_error
+
+        form1_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form1.id}.rb"
+        expect(::File.size(form1_model_class_path)).to be > 0
+        form2_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form2.id}.rb"
+        expect(::File.size(form2_model_class_path)).to be > 0
       end
     end
 
@@ -140,6 +160,11 @@ describe Gws::Tabular::FormTrashPurgeJob, dbscope: :example do
         expect(form2_model.all.count).to eq 0
         expect { attachment1.reload }.to raise_error Mongoid::Errors::DocumentNotFound
         expect { attachment2.reload }.to raise_error Mongoid::Errors::DocumentNotFound
+
+        form1_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form1.id}.rb"
+        expect(::File.exist?(form1_model_class_path)).to be_falsey
+        form2_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form2.id}.rb"
+        expect(::File.exist?(form2_model_class_path)).to be_falsey
       end
     end
 
@@ -164,6 +189,11 @@ describe Gws::Tabular::FormTrashPurgeJob, dbscope: :example do
         expect(form2_model.all.count).to be > 0
         expect { attachment1.reload }.not_to raise_error
         expect { attachment2.reload }.not_to raise_error
+
+        form1_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form1.id}.rb"
+        expect(::File.size(form1_model_class_path)).to be > 0
+        form2_model_class_path = "#{Gws::Tabular.file_class_dir}/file#{form2.id}.rb"
+        expect(::File.size(form2_model_class_path)).to be > 0
       end
     end
   end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

Gws::Tabular::FileXXXXX のロード方法が不味くて、汎用DBにアップロードしたファイルを閲覧できない問題の修正。

Gws::Tabular::FileXXXXX のロード方法を一度修正したが、とある環境で `Mongo::Error::OperationFailure ([225:TransactionTooOld]: Retryable write with txnNumber 368 is prohibited on session ` という謎のエラーに遭遇。
そこで、Gws::Tabular::FileXXXXX のロード方法を抜本的に見直し。
