### PR TITLE
[fix][cms] プレビューで承認できない問題の修正

### DIFF
--- a/app/assets/javascripts/cms/preview/main.js.erb
+++ b/app/assets/javascripts/cms/preview/main.js.erb
@@ -17,6 +17,9 @@
 //= require mdn-polyfills/String.prototype.startsWith.js
 //= require mdn-polyfills/String.prototype.trim.js
 
+// for 承認ユーザー選択
+//= require ejs/ejs.min.js
+
 SS_Preview = (function () {
   function SS_Preview(el) {
     this.el = el;

--- a/app/assets/javascripts/cms/preview/main.js.erb
+++ b/app/assets/javascripts/cms/preview/main.js.erb
@@ -195,7 +195,8 @@ SS_Preview = (function () {
       $.colorbox.close();
     }
     if ($frame.closest(".ui-dialog")[0]) {
-      $frame.dialog("close");
+      var $dialog = $frame.closest(".ss-preview-dialog");
+      $dialog.dialog("close");
     }
   }
 
@@ -414,7 +415,8 @@ SS_Preview = (function () {
     var width = frame.contentWindow.document.body.scrollWidth;
     var height = frame.contentWindow.document.body.scrollHeight;
 
-    if ($(frame).closest(".ui-dialog")[0]) {
+    var $frame = $(frame);
+    if ($frame.closest(".ui-dialog")[0]) {
       height += SS_Preview.jqueryDialogMargin.height;
     }
 
@@ -435,15 +437,18 @@ SS_Preview = (function () {
       height = maxHeight;
     }
 
-    if ($(frame).closest("#cboxLoadedContent")[0]) {
+    if ($frame.closest("#cboxLoadedContent")[0]) {
       $.colorbox.resize({ width: width, height: height });
     }
 
-    if ($(frame).closest(".ui-dialog")[0]) {
-      $(frame).dialog("option", "width", width)
+    if ($frame.closest(".ui-dialog")[0]) {
+      var $dialog = $frame.closest(".ss-preview-dialog");
+      $dialog.dialog("option", "width", width)
         .dialog("option", "height", height)
         .css("display", "")
-        .css("width", "100%");
+        .css("width", "");
+
+      $frame.css("width", "100%").css("height", "100%");
     }
   };
 
@@ -566,20 +571,23 @@ SS_Preview = (function () {
       frameborder: "0", allowfullscreen: true,
       src: url
     });
-
     $frame[0].onload = function() { self.initializeFrame($frame[0]); };
 
-    $frame.dialog({
+    var $dialog = $("<div />", { class: "ss-preview-dialog ss-preview-dialog-column" });
+    $dialog.append($frame);
+    $dialog.dialog({
       autoOpen: true,
       width: SS_Preview.initialFrameSize.width,
       height: SS_Preview.initialFrameSize.height,
       minWidth: SS_Preview.minFrameSize.width,
       minHeight: SS_Preview.minFrameSize.height,
       closeOnEscape: false,
-      dialogClass: "ss-preview-dialog ss-preview-dialog-column",
       draggable: true,
       modal: true,
       resizable: true,
+      open: function(_ev, _ui) {
+        window.requestAnimationFrame(function() { $dialog.trigger("ss:previewDialogOpened"); });
+      },
       close: function(_ev, _ui) {
         // explicitly destroy dialog and remove elemtns because dialog elements is still remained
         $(this).dialog('destroy').remove();
@@ -598,22 +606,24 @@ SS_Preview = (function () {
       url: url,
       type: "GET",
       success: function(data, _textStatus, _xhr) {
-        var $frame = $("div#ss-preview-dialog-frame");
-        if (! $frame[0]) {
-          $frame = $("<div></div>", { id: "ss-preview-dialog-frame" });
-        }
+        var $frame = $("<div/>", { id: "ss-preview-dialog-frame" });
         $frame.html(data);
-        $frame.dialog({
+
+        var $dialog = $("<div/>", { class: "ss-preview-dialog ss-preview-dialog-column" });
+        $dialog.append($frame);
+        $dialog.dialog({
           autoOpen: true,
           width: options.width || SS_Preview.initialFrameSize.width,
           height: options.height || SS_Preview.initialFrameSize.height,
           minWidth: options.minWidth || SS_Preview.minFrameSize.width,
           minHeight: options.minHeight || SS_Preview.minFrameSize.height,
           closeOnEscape: false,
-          dialogClass: "ss-preview-dialog ss-preview-dialog-column",
           draggable: true,
           modal: true,
           resizable: true,
+          open: function(_ev, _ui) {
+            window.requestAnimationFrame(function() { $dialog.trigger("ss:previewDialogOpened"); });
+          },
           close: function(_ev, _ui) {
             // explicitly destroy dialog and remove elemtns because dialog elements is still remained
             $(this).dialog('destroy').remove();

--- a/app/assets/javascripts/ss/lib/search_ui.js
+++ b/app/assets/javascripts/ss/lib/search_ui.js
@@ -66,7 +66,13 @@ this.SS_SearchUI = (function () {
       data.name = $data.find(".select-item").text() || $item.text() || $data.text();
     }
 
-    var tr = ejs.render(template, {data: data, attr: attr, label: {delete: i18next.t("ss.buttons.delete")}});
+    var deleteLabel;
+    if ("i18next" in window) {
+      deleteLabel = i18next.t("ss.buttons.delete");
+    } else {
+      deleteLabel = "削除";
+    }
+    var tr = ejs.render(template, {data: data, attr: attr, label: { delete: deleteLabel }});
     var $tr = $(tr);
     var $ajaxSelected;
     if (selectTable === "to") {

--- a/app/views/cms/apis/preview/workflow/wizard/approver_setting.html.erb
+++ b/app/views/cms/apis/preview/workflow/wizard/approver_setting.html.erb
@@ -11,9 +11,10 @@
       height = maxHeight;
     }
 
-    var currentHeight = $frame.dialog("option", "height");
+    var $dialog = $frame.closest(".ss-preview-dialog");
+    var currentHeight = $dialog.dialog("option", "height");
     if (currentHeight < height) {
-      $frame.dialog("option", "height", height);
+      $dialog.dialog("option", "height", height);
     }
   <% end %>
 </div>

--- a/app/views/cms/apis/preview/workflow/wizard/approver_setting_multi.html.erb
+++ b/app/views/cms/apis/preview/workflow/wizard/approver_setting_multi.html.erb
@@ -11,9 +11,10 @@
       height = maxHeight;
     }
 
-    var currentHeight = $frame.dialog("option", "height");
+    var $dialog = $frame.closest(".ss-preview-dialog");
+    var currentHeight = $dialog.dialog("option", "height");
     if (currentHeight < height) {
-      $frame.dialog("option", "height", height);
+      $dialog.dialog("option", "height", height);
     }
   <% end %>
 </div>

--- a/app/views/cms/apis/preview/workflow/wizard/approver_setting_restart.html.erb
+++ b/app/views/cms/apis/preview/workflow/wizard/approver_setting_restart.html.erb
@@ -11,9 +11,10 @@
       height = maxHeight;
     }
 
-    var currentHeight = $frame.dialog("option", "height");
+    var $dialog = $frame.closest(".ss-preview-dialog");
+    var currentHeight = $dialog.dialog("option", "height");
     if (currentHeight < height) {
-      $frame.dialog("option", "height", height);
+      $dialog.dialog("option", "height", height);
     }
   <% end %>
 </div>

--- a/app/views/cms/preview/_tool.html.erb
+++ b/app/views/cms/preview/_tool.html.erb
@@ -115,34 +115,34 @@
     SS_Preview.render(opts);
   </script>
 <% end %>
-  <% if params[:action] == "form_preview" %>
-    <div id="ss-preview" style="position: relative;">
-      <div class="ss-preview-wrap">
-          <div class="ss-preview-wrap-column ss-preview-wrap-column-title-wrap">
-              <div id="ss-preview-title"><%= t("cms.preview_page2") %></div>
-          </div>
-      </div>
-      <div class="ss-preview-notice-wrap" style="display: none;"></div>
+
+<% if params[:action] == "form_preview" %>
+  <div id="ss-preview" style="position: relative;">
+    <div class="ss-preview-wrap">
+        <div class="ss-preview-wrap-column ss-preview-wrap-column-title-wrap">
+            <div id="ss-preview-title"><%= t("cms.preview_page2") %></div>
+        </div>
     </div>
-  <% else %>
-    <div id="ss-preview">
-      <div class="ss-preview-wrap">
-        <% left = render "tool_left", local_assigns %>
-        <% if left.present? %>
-          <div class="ss-preview-wrap-column ss-preview-wrap-column-edit-mode">
-            <%= left %>
-          </div>
-        <% end %>
-        <% right = render "tool_right", local_assigns %>
-        <% if right.present? %>
-          <div class="ss-preview-wrap-column ss-preview-wrap-column-mode-change">
-            <%= right %>
-          </div>
-        <% end %>
-      </div>
-      <div class="ss-preview-notice-wrap" style="display: none;"></div>
-    </div>  
-  <% end %>
-  
+    <div class="ss-preview-notice-wrap" style="display: none;"></div>
+  </div>
+<% else %>
+  <div id="ss-preview">
+    <div class="ss-preview-wrap">
+      <% left = render "tool_left", local_assigns %>
+      <% if left.present? %>
+        <div class="ss-preview-wrap-column ss-preview-wrap-column-edit-mode">
+          <%= left %>
+        </div>
+      <% end %>
+      <% right = render "tool_right", local_assigns %>
+      <% if right.present? %>
+        <div class="ss-preview-wrap-column ss-preview-wrap-column-mode-change">
+          <%= right %>
+        </div>
+      <% end %>
+    </div>
+    <div class="ss-preview-notice-wrap" style="display: none;"></div>
+  </div>
+<% end %>
 
 <%= render "link_errors", local_assigns %>

--- a/app/views/cms/preview/_tool_left.html.erb
+++ b/app/views/cms/preview/_tool_left.html.erb
@@ -79,6 +79,12 @@
           <% end %>
         </div>
       <% end %>
+
+      <%# テスト側で承認を待機する方法がない。承認したら「承認しました。」というnoticeを表示すれば良いのだろうけど、その方法がない。 %>
+      <%# 代わりに hidden 要素にワークフロー状態を出力するようにする。 %>
+      <% if page.is_a?(Workflow::Approver) && page.workflow_state.present? %>
+        <span class="ss-preview-workflow-state" style="display: none;" data-workflow-state="<%= page.workflow_state %>"><%= t("workflow.state.#{page.workflow_state}") %></span>
+      <% end %>
     <% end %>
 
     <% if rendered && (node = rendered[:node]) %>

--- a/spec/features/article/pages/preview_editing/apply_approval_spec.rb
+++ b/spec/features/article/pages/preview_editing/apply_approval_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe "article_pages", type: :feature, dbscope: :example, js: true do
+  let!(:site) { cms_site }
+  let!(:admin) { cms_user }
+  let!(:user1) { create :cms_test_user, group_ids: admin.group_ids, cms_role_ids: admin.cms_role_ids }
+
+  let!(:part) { create :cms_part_free, html: '<div id="part" class="part"><br><br><br>free html part<br><br><br></div>' }
+  let(:layout_html) do
+    <<~HTML.freeze
+      <html>
+      <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=yes,minimum-scale=1.0,maximum-scale=2.0">
+      </head>
+      <body>
+        <br><br><br>
+        {{ part "#{part.filename.sub(/\..*/, '')}" }}
+        <div id="main" class="page">
+          {{ yield }}
+        </div>
+      </body>
+      </html>
+    HTML
+  end
+  let!(:layout) { create :cms_layout, cur_site: site, html: layout_html }
+
+  let!(:node) { create(:article_node_page, cur_site: site, layout: layout) }
+  let(:item_html) do
+    <<~HTML
+      <p class=\"page-body\">#{unique_id}</p>
+    HTML
+  end
+  let!(:item) do
+    create(
+      :article_page, cur_site: site, cur_node: node, layout: layout, html:
+      item_html, state: "closed", group_ids: admin.group_ids)
+  end
+
+  let(:request_comment) { "comment-#{unique_id}" }
+  let(:approve_comment) { "approve-#{unique_id}" }
+
+  it do
+    login_user user1
+    visit cms_preview_path(site: site, path: item.preview_path)
+    wait_for_all_ckeditors_ready
+    wait_for_all_turbo_frames
+
+    within ".ss-preview-wrap-column-edit-mode" do
+      wait_for_event_fired("ss:previewDialogOpened") do
+        click_on I18n.t("workflow.buttons.approve")
+      end
+    end
+    within ".ss-preview-workflow-wizard" do
+      fill_in "workflow[comment]", with: request_comment
+      wait_for_cbox_opened { click_on I18n.t("workflow.search_approvers.index") }
+    end
+    within_cbox do
+      expect(page).to have_content(admin.long_name)
+      wait_for_cbox_closed { click_on admin.long_name }
+    end
+    within ".ss-preview-workflow-wizard" do
+      expect(page).to have_css("[data-id='1,#{admin.id}']", text: admin.long_name)
+      click_on I18n.t("workflow.buttons.request")
+    end
+    expect(page).to have_css(".ss-preview-workflow-notice", text: "申請中です。")
+
+    item.reload
+    expect(item.workflow_state).to eq "request"
+    expect(item.workflow_comment).to eq request_comment
+    expect(item.workflow_approvers).to include(
+      { level: 1, user_id: admin.id, editable: be_blank, state: "request", comment: be_blank }
+    )
+    expect(item.state).to eq "closed"
+
+    login_user admin
+    visit cms_preview_path(site: site, path: item.preview_path)
+    wait_for_all_ckeditors_ready
+    wait_for_all_turbo_frames
+    expect(page).to have_css(".ss-preview-workflow-notice", text: "承認依頼が届いています。")
+    within ".ss-preview-wrap-column-edit-mode" do
+      wait_for_event_fired("ss:previewDialogOpened") do
+        click_on I18n.t("workflow.buttons.approve")
+      end
+    end
+    within "#ss-preview-dialog-frame" do
+      fill_in "comment", with: approve_comment
+      click_on I18n.t("workflow.buttons.approve")
+    end
+
+    # sleep 60
+    expect(page).to have_css(".ss-preview-workflow-state", text: I18n.t("workflow.state.approve"))
+
+    item.reload
+    expect(item.workflow_state).to eq "approve"
+    expect(item.workflow_comment).to eq request_comment
+    expect(item.workflow_approvers).to include(
+      { level: 1, user_id: admin.id, editable: be_blank, state: "approve", comment: approve_comment,
+        file_ids: be_blank, created: be_within(5.minutes).of(Time.zone.now) }
+    )
+    expect(item.state).to eq "public"
+  end
+end

--- a/spec/features/article/pages/preview_editing/basic_body_spec.rb
+++ b/spec/features/article/pages/preview_editing/basic_body_spec.rb
@@ -80,6 +80,9 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
         end
 
         page.within_frame page.first("#ss-preview-dialog-frame") do
+          wait_for_all_ckeditors_ready
+          wait_for_all_turbo_frames
+
           within "#item-form" do
             fill_in_ckeditor "item[html]", with: html2
 


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

Rails 8.0 へ更新時に jQuery UI の廃止された機能やプロパティが既定で利用できなくなった。
このためプレビューでの承認が動作しなくなったのが主たる原因。

プレビューでの承認では、他に問題があったが修正した。
