### PR TITLE
[fix] tasks log_sequence

### DIFF
--- a/app/views/ss/tasks/_box.html.erb
+++ b/app/views/ss/tasks/_box.html.erb
@@ -41,13 +41,16 @@
       <%
         download_path = url_for(action: "download_logs") rescue nil
         download_path ||= begin
+          options = { id: task }
+          options[:log_sequence] = task.log_sequence if task.log_sequence
+
           if @ss_mode == :cms && @cur_site
             if Cms::Tool.allowed?(:edit, @cur_user, site: @cur_site)
-              download_job_cms_task_path(id: task)
+              download_job_cms_task_path(options)
             end
           else
             if SS::User.allowed?(:edit, @cur_user)
-              download_job_sys_task_path(id: task)
+              download_job_sys_task_path(options)
             end
           end
         end

--- a/spec/features/cms/nodes_download_spec.rb
+++ b/spec/features/cms/nodes_download_spec.rb
@@ -50,6 +50,13 @@ describe "cms_nodes", type: :feature, dbscope: :example do
       expect(Cms::Node.count).to eq 7
       expect(item.filename).to eq "ad"
       expect(item.parent).to eq false
+
+      within "#task-form" do
+        click_on I18n.t("job.download_log")
+      end
+      wait_for_download
+      log = ::File.read(downloads.first)
+      expect(log).to include("update")
     end
   end
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

CMSの一括インポートのtask logがダウンロードできない問題の修正