### PR TITLE
[fix][workload] spec failures

### DIFF
--- a/app/controllers/concerns/gws/schedule/calendar_filter.rb
+++ b/app/controllers/concerns/gws/schedule/calendar_filter.rb
@@ -25,7 +25,17 @@ module Gws::Schedule::CalendarFilter
     end
 
     def redirection_date
-      @item.present? ? @item.start_at.to_date.to_s : params.dig(:calendar, :date)
+      if @item.present?
+        return @item.start_at.to_date.to_s
+      end
+
+      date = params.dig(:calendar, :date)
+      if date.present?
+        return date
+      end
+
+      # Timecop で today / now が変更されている可能性があるので、現在年月日を明示する
+      I18n.l(Time.zone.today, format: :iso)
     end
 
     def redirection_view_format

--- a/app/views/gws/schedule/plans/index.html.erb
+++ b/app/views/gws/schedule/plans/index.html.erb
@@ -12,7 +12,8 @@
     calendar_options[:eventStartEditable] = false
   end
 
-  init_options = params[:calendar] || {}
+  # Timecop で today / now が変更されている可能性があるので、現在年月日を明示する
+  init_options = params[:calendar] || { date: I18n.l(Time.zone.today, format: :iso) }
 %>
 <%= jquery do %>
   $(document).on("gws:calendarInitialized", function() {


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

2025年8月1日になったら `spec/features/gws/workload/works/set_due_end_on_spec.rb:414` が失敗するようになった。
その修正。

## 変更内容

Timecop で現在日が変更されていることを考慮して、未指定とはせずに明示的に指定するようにした。
