### PR TITLE
[fix]docs-breadcrumb

### DIFF
--- a/app/controllers/cms/agents/parts/crumb_controller.rb
+++ b/app/controllers/cms/agents/parts/crumb_controller.rb
@@ -13,7 +13,7 @@ class Cms::Agents::Parts::CrumbController < ApplicationController
     path.sub!(/^#{@cur_site.translate_url}.+?\//, "/")
     path.sub!(/^\//, "")
 
-    parent_crumb_urls = @cur_item.parent_crumb_urls.select(&:present?) rescue nil
+    parent_crumb_urls = @cur_page.parent_crumb_urls.select(&:present?) rescue nil
     set_items(path, parent_crumb_urls)
   end
 

--- a/spec/features/cms/agents/parts/crumb_spec.rb
+++ b/spec/features/cms/agents/parts/crumb_spec.rb
@@ -39,9 +39,135 @@ describe "cms_agents_parts_crumb", type: :feature, dbscope: :example do
         expect(status_code).to eq 200
         expect(page).to have_css(".crumbs .crumb")
         expect(page).to have_selector(".crumbs .crumb span a")
+        # カテゴリリンクは別セクションに表示される
+        expect(page).to have_css(".categories")
         expect(page).to have_link(category1.name)
         expect(page).to have_link(category2.name)
         expect(page).to have_link(category3.name)
+      end
+    end
+
+    context "with categories and no parent_crumb_urls" do
+      let(:layout) { create_cms_layout part }
+      let(:part) { create :cms_part_crumb }
+      let(:category1) { create :category_node_page, layout_id: layout.id, filename: "oshirase" }
+      let(:category2) { create :category_node_page, layout_id: layout.id, filename: "kurashi" }
+      let(:category3) { create :category_node_page, layout_id: layout.id, filename: "faq" }
+      let(:node) { create :cms_node, layout_id: layout.id }
+      let(:item) do
+        create :cms_page, layout_id: layout.id, filename: "#{node.filename}/page.html",
+        category_ids: [category1.id, category2.id, category3.id],
+        parent_crumb_urls: [] # 空の配列を設定
+      end
+
+      it "#index with empty parent_crumb_urls" do
+        visit item.url
+        expect(status_code).to eq 200
+        expect(page).to have_css(".crumbs .crumb")
+        expect(page).to have_selector(".crumbs .crumb span a")
+        # カテゴリリンクは別セクションに表示される（parent_crumb_urlsとは無関係）
+        expect(page).to have_css(".categories")
+        expect(page).to have_link(category1.name)
+        expect(page).to have_link(category2.name)
+        expect(page).to have_link(category3.name)
+      end
+    end
+
+    context "with categories and nil parent_crumb_urls" do
+      let(:layout) { create_cms_layout part }
+      let(:part) { create :cms_part_crumb }
+      let(:category1) { create :category_node_page, layout_id: layout.id, filename: "oshirase" }
+      let(:category2) { create :category_node_page, layout_id: layout.id, filename: "kurashi" }
+      let(:category3) { create :category_node_page, layout_id: layout.id, filename: "faq" }
+      let(:node) { create :cms_node, layout_id: layout.id }
+      let(:item) do
+        create :cms_page, layout_id: layout.id, filename: "#{node.filename}/page.html",
+        category_ids: [category1.id, category2.id, category3.id],
+        parent_crumb_urls: nil # nilを設定
+      end
+
+      it "#index with nil parent_crumb_urls" do
+        visit item.url
+        expect(status_code).to eq 200
+        expect(page).to have_css(".crumbs .crumb")
+        expect(page).to have_selector(".crumbs .crumb span a")
+        # カテゴリリンクは別セクションに表示される（parent_crumb_urlsとは無関係）
+        expect(page).to have_css(".categories")
+        expect(page).to have_link(category1.name)
+        expect(page).to have_link(category2.name)
+        expect(page).to have_link(category3.name)
+      end
+    end
+
+    context "with categories and mixed parent_crumb_urls" do
+      let(:layout) { create_cms_layout part }
+      let(:part) { create :cms_part_crumb }
+      let(:category1) { create :category_node_page, layout_id: layout.id, filename: "oshirase" }
+      let(:category2) { create :category_node_page, layout_id: layout.id, filename: "kurashi" }
+      let(:category3) { create :category_node_page, layout_id: layout.id, filename: "faq" }
+      let(:node) { create :cms_node, layout_id: layout.id }
+      let(:item) do
+        create :cms_page, layout_id: layout.id, filename: "#{node.filename}/page.html",
+        category_ids: [category1.id, category2.id, category3.id],
+        parent_crumb_urls: [category1.url, "", category3.url] # 空文字を含む
+      end
+
+      it "#index with mixed parent_crumb_urls" do
+        visit item.url
+        expect(status_code).to eq 200
+        expect(page).to have_css(".crumbs .crumb")
+        expect(page).to have_selector(".crumbs .crumb span a")
+        # カテゴリリンクは別セクションに表示される（parent_crumb_urlsとは無関係）
+        expect(page).to have_css(".categories")
+        expect(page).to have_link(category1.name)
+        expect(page).to have_link(category2.name)
+        expect(page).to have_link(category3.name)
+      end
+    end
+
+    context "with nested nodes" do
+      let(:layout) { create_cms_layout part }
+      let(:part) { create :cms_part_crumb }
+      let(:parent_node) { create :cms_node, layout_id: layout.id, filename: "parent" }
+      let(:child_node) { create :cms_node, layout_id: layout.id, filename: "parent/child" }
+      let(:grandchild_node) { create :cms_node, layout_id: layout.id, filename: "parent/child/grandchild" }
+
+      it "#index with nested structure" do
+        visit grandchild_node.url
+        expect(status_code).to eq 200
+        expect(page).to have_css(".crumbs .crumb")
+        expect(page).to have_selector(".crumbs .crumb span a")
+        # 階層構造が正しく表示されることを確認
+        # 実際のパンくずリストにはノード名が表示されないため、基本構造のみ確認
+        expect(page).to have_css(".crumbs .crumb span.page")
+        expect(page).to have_css(".crumbs .crumb span.separator")
+      end
+    end
+
+    context "with page and parent_crumb_urls" do
+      let(:layout) { create_cms_layout part }
+      let(:part) { create :cms_part_crumb }
+      let(:category1) { create :category_node_page, layout_id: layout.id, filename: "oshirase" }
+      let(:category2) { create :category_node_page, layout_id: layout.id, filename: "kurashi" }
+      let(:node) { create :cms_node, layout_id: layout.id }
+      let(:item) do
+        create :cms_page, layout_id: layout.id, filename: "#{node.filename}/page.html",
+        category_ids: [category1.id, category2.id],
+        parent_crumb_urls: [category1.url, category2.url]
+      end
+
+      it "#index with parent_crumb_urls" do
+        visit item.url
+        expect(status_code).to eq 200
+        expect(page).to have_css(".crumbs .crumb")
+        expect(page).to have_selector(".crumbs .crumb span a")
+        # パンくずリストの基本構造を確認
+        expect(page).to have_css(".crumbs .crumb span.page")
+        expect(page).to have_css(".crumbs .crumb span.separator")
+        # カテゴリリンクは別セクションに表示される
+        expect(page).to have_css(".categories")
+        expect(page).to have_link(category1.name)
+        expect(page).to have_link(category2.name)
       end
     end
   end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
記事ページのパンくずの表示修正
<img width="1037" height="687" alt="スクリーンショット 2025-08-05 9 50 21（2）" src="https://github.com/user-attachments/assets/b77073e5-0e89-40f2-88c2-b3f1c2c82894" />

## 変更内容
- 参照オブジェクトを修正
- テストケース追加
