### PR TITLE
[fix]gws-custom-group-setting-error-message

### DIFF
--- a/config/locales/gws/ja.yml
+++ b/config/locales/gws/ja.yml
@@ -102,7 +102,9 @@ ja:
       change_menu_icon: アイコン変更
     confirm:
       readable_setting:
-        empty: 閲覧者が入力されていません。\n全員に表示されますがよろしいですか？
+        empty: |
+          閲覧者が入力されていません。
+          全員に表示されますがよろしいですか？
     notice:
       delay_download_with_message: |-
         ファイル数が多い、またはファイル容量が大きいためバックグランドでファイルを準備します。


### PR DESCRIPTION
- [ ] 動作確認をしたか？
- [ ] ドキュメントやコメントを書いたか？

## 概要
GW＞設定＞カスタムグループ
閲覧権限を全公開にして保存する際に出るエラーメッセージの改行を修正

**修正前**
<img width="1053" height="340" alt="スクリーンショット 2025-08-05 14 49 39" src="https://github.com/user-attachments/assets/8865e869-d9bf-4d3d-a60a-1735805699c2" />

**修正後**
<img width="448" height="187" alt="スクリーンショット 2025-08-05 15 06 23（2）" src="https://github.com/user-attachments/assets/01d91cf6-acb6-424e-9854-8531dfb251cd" />

