### PR TITLE
[modify][cms] data url support

### DIFF
--- a/lib/ss/liquid_filters.rb
+++ b/lib/ss/liquid_filters.rb
@@ -131,15 +131,11 @@ module SS::LiquidFilters
   end
 
   def expand_path(input, path)
-    return input if input.blank?
+    return input if input.blank? || path.blank?
 
-    path = path.to_s
-    input = input.to_s
-    if path.start_with?("http://", "https://")
-      ::URI.join(path, input).to_s
-    else
-      ::File.expand_path(input, path)
-    end
+    addressable_path = Addressable::URI.parse(path.to_s)
+    addressable_input = Addressable::URI.parse(input.to_s)
+    addressable_path.join(addressable_input).to_s
   end
 
   def sanitize(input)

--- a/spec/features/article/agents/parts/data_url_spec.rb
+++ b/spec/features/article/agents/parts/data_url_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe "article_pages", type: :feature, dbscope: :example, js: true do
+  let!(:site) { cms_site }
+  let!(:layout1) { create_cms_layout cur_site: site }
+  let!(:article_node) { create :article_node_page, cur_site: site, layout: layout1 }
+  let!(:category_node) { create :category_node_page, cur_site: site, layout: layout1 }
+  let!(:article_page) do
+    html = <<~HTML
+      <p><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D" /></p>
+    HTML
+    create(
+      :article_page, cur_site: site, cur_node: article_node, layout: layout1,
+      html: html, category_ids: [ category_node.id ])
+  end
+  let!(:article_part) do
+    loop_html = <<~HTML
+      <ul class="list">
+        {% for page in pages %}
+        <li class="list-item" data-id="{{ page.id }}" data-filename="{{ page.filename }}">
+          <a class="list-item-link" href="{{ page.url }}">
+            {% assign img_src = page.html | ss_img_src | expand_path: page.parent.url -%}
+            <img src="{{ page.thumb.url | default: img_src }}" alt="{{ page.index_name | default: page.name }}">
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    HTML
+    create(:article_part_page, cur_site: site, cur_node: category_node, loop_format: "liquid", loop_liquid: loop_html)
+  end
+
+  let!(:layout2) { create_cms_layout article_part, cur_site: site }
+  let!(:top_page) do
+    create :cms_page, cur_site: site, layout: layout2
+  end
+
+  before do
+    ::FileUtils.rm_f(article_page.path)
+    ::FileUtils.rm_f(top_page.path)
+  end
+
+  it do
+    visit top_page.full_url
+    within "[data-id='#{article_page.id}']" do
+      expect(first("img")["src"]).to be_start_with "data:image/gif;base64,"
+    end
+  end
+end

--- a/spec/lib/ss/liquid_filters_spec.rb
+++ b/spec/lib/ss/liquid_filters_spec.rb
@@ -225,25 +225,62 @@ describe SS::LiquidFilters, dbscope: :example do
       let(:value) { "<img src=\"/one.png\"><img src=\"/two.png\">" }
       it { is_expected.to eq "/one.png" }
     end
+
+    context "with data-url" do
+      let(:value) { "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D\" />" }
+      it { is_expected.to eq "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D" }
+    end
   end
 
   describe "expand_path" do
-    let(:path) { "http://www.example.jp/" }
-    let(:source) { "{{ value || expand_path: \"#{path}\"}}" }
+    context "with full url like node's full_url" do
+      let(:path) { "https://www.example.jp/#{unique_id}/" }
+      let(:source) { "{{ value || expand_path: \"#{path}\"}}" }
 
-    context "with blank" do
-      let(:value) { "" }
-      it { is_expected.to eq "" }
+      context "with blank" do
+        let(:value) { "" }
+        it { is_expected.to eq "" }
+      end
+
+      context "with relative path" do
+        let(:value) { "img/cover.png" }
+        it { is_expected.to eq "#{path}img/cover.png" }
+      end
+
+      context "with absolute path" do
+        let(:value) { "/img/cover.png" }
+        it { is_expected.to eq "https://www.example.jp/img/cover.png" }
+      end
+
+      context "with data-url" do
+        let(:value) { "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D" }
+        it { is_expected.to eq "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D" }
+      end
     end
 
-    context "with relative path" do
-      let(:value) { "img/cover.png" }
-      it { is_expected.to eq "http://www.example.jp/img/cover.png" }
-    end
+    context "with simple path like node's url" do
+      let(:path) { "/#{unique_id}/" }
+      let(:source) { "{{ value || expand_path: \"#{path}\"}}" }
 
-    context "with absolute path" do
-      let(:value) { "/img/cover.png" }
-      it { is_expected.to eq "http://www.example.jp/img/cover.png" }
+      context "with blank" do
+        let(:value) { "" }
+        it { is_expected.to eq "" }
+      end
+
+      context "with relative path" do
+        let(:value) { "img/cover.png" }
+        it { is_expected.to eq "#{path}img/cover.png" }
+      end
+
+      context "with absolute path" do
+        let(:value) { "/img/cover.png" }
+        it { is_expected.to eq "/img/cover.png" }
+      end
+
+      context "with data-url" do
+        let(:value) { "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D" }
+        it { is_expected.to eq "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D" }
+      end
     end
   end
 


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

data url 形式の改善

## 変更内容

Liquidフィルター `ss_img_src` と `expand_path` とを data-url 形式の画像に適用すると、不正なURL（ブラウザが異常状態になるようなURL）を生成する問題の改善。

## その他

なお、そもそもの原因はページに data url 形式の画像があることが問題。
画像はファイルに添付し、それを参照するようにすれば問題は起きない。