### PR TITLE
[fix] gws/schedule : comment permission

### DIFF
--- a/app/views/gws/agents/addons/schedule/comments/_show.html.erb
+++ b/app/views/gws/agents/addons/schedule/comments/_show.html.erb
@@ -22,7 +22,7 @@
   </ul>
   <% end %>
 
-  <% if @item.member?(@cur_user) || @item.allowed_for_managers?(:edit, @cur_user, site: @cur_site) %>
+  <% if @item.member_include?(@cur_user) || @item.allowed_for_managers?(:edit, @cur_user, site: @cur_site) %>
     <%= form_tag(gws_schedule_comments_path(plan_id: @item), id: 'comment-form', method: :post) do %>
       <%= text_field_tag 'item[text]' %>
       <%= hidden_field_tag('redirect_to', request.fullpath, id: nil) %>


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

権限がない場合にスケジュールのコメントフォームを非表示にする