### PR TITLE
[fix][gws][report] 通知が文字化けする問題の修正

### DIFF
--- a/config/defaults/mail.yml
+++ b/config/defaults/mail.yml
@@ -16,14 +16,14 @@ production: &production
 
   # message settings
   default_from: noreply@example.jp
-  default_charset: iso-2022-jp
+  default_charset: utf-8
 
 test:
   delivery_method: test
   default_from: noreply@example.jp
-  default_charset: iso-2022-jp
+  default_charset: utf-8
 
 development:
   delivery_method: file
   default_from: noreply@example.jp
-  default_charset: iso-2022-jp
+  default_charset: utf-8

--- a/config/defaults/mail.yml
+++ b/config/defaults/mail.yml
@@ -16,14 +16,14 @@ production: &production
 
   # message settings
   default_from: noreply@example.jp
-  default_charset: utf-8
+  default_charset: iso-2022-jp
 
 test:
   delivery_method: test
   default_from: noreply@example.jp
-  default_charset: utf-8
+  default_charset: iso-2022-jp
 
 development:
   delivery_method: file
   default_from: noreply@example.jp
-  default_charset: utf-8
+  default_charset: iso-2022-jp

--- a/spec/features/ezine/member_page/main_spec.rb
+++ b/spec/features/ezine/member_page/main_spec.rb
@@ -204,7 +204,7 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
         expect(mail.to.first).to eq email
         expect(mail_subject(mail)).to eq item.name
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include(item.text)
+        expect(mail_body(mail)).to include(item.text)
 
         expect(Ezine::SentLog.count).to eq 0
       end
@@ -303,7 +303,7 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(mail.to.first).to eq email
           expect(mail_subject(mail)).to eq item.name
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(item.text)
+          expect(mail_body(mail)).to include(item.text)
 
           expect(Ezine::SentLog.count).to eq 1
           Ezine::SentLog.first.tap do |log|
@@ -400,7 +400,7 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(first_mail.to.first).to eq email0
           expect(mail_subject(first_mail)).to eq item0.name
           expect(first_mail.body.multipart?).to be_falsey
-          expect(first_mail.body.raw_source).to include(item0.text)
+          expect(mail_body(first_mail)).to include(item0.text)
 
           last_mail = ActionMailer::Base.deliveries.last
           expect(last_mail).not_to be_nil
@@ -428,7 +428,7 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(first_mail.to.first).to eq email1
           expect(mail_subject(first_mail)).to eq item1.name
           expect(first_mail.body.multipart?).to be_falsey
-          expect(first_mail.body.raw_source).to include(item1.text)
+          expect(mail_body(first_mail)).to include(item1.text)
 
           last_mail = ActionMailer::Base.deliveries.last
           expect(last_mail).not_to be_nil
@@ -456,7 +456,7 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(first_mail.to.first).to eq email2
           expect(mail_subject(first_mail)).to eq item2.name
           expect(first_mail.body.multipart?).to be_falsey
-          expect(first_mail.body.raw_source).to include(item2.text)
+          expect(mail_body(first_mail)).to include(item2.text)
 
           last_mail = ActionMailer::Base.deliveries.last
           expect(last_mail).not_to be_nil

--- a/spec/features/ezine/member_page/main_spec.rb
+++ b/spec/features/ezine/member_page/main_spec.rb
@@ -202,9 +202,9 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
         expect(mail).not_to be_nil
         # expect(mail.from.first).to eq "test@example.jp"
         expect(mail.to.first).to eq email
-        expect(mail.subject).to eq item.name
+        expect(mail_subject(mail)).to eq item.name
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(item.text)
+        expect(mail.decoded.to_s).to include(item.text)
 
         expect(Ezine::SentLog.count).to eq 0
       end
@@ -249,7 +249,7 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
         expect(mail).not_to be_nil
         # expect(mail.from.first).to eq "test@example.jp"
         expect(mail.to.first).to eq email
-        expect(mail.subject).to eq item.name
+        expect(mail_subject(mail)).to eq item.name
         expect(mail.body.multipart?).to be_truthy
         expect(mail.body.parts.count).to eq 2
         expect(mail.body.parts[0].body).to include(item.text)
@@ -301,9 +301,9 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(mail).not_to be_nil
           # expect(mail.from.first).to eq "test@example.jp"
           expect(mail.to.first).to eq email
-          expect(mail.subject).to eq item.name
+          expect(mail_subject(mail)).to eq item.name
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item.text)
+          expect(mail.decoded.to_s).to include(item.text)
 
           expect(Ezine::SentLog.count).to eq 1
           Ezine::SentLog.first.tap do |log|
@@ -344,7 +344,7 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(mail).not_to be_nil
           # expect(mail.from.first).to eq "test@example.jp"
           expect(mail.to.first).to eq email
-          expect(mail.subject).to eq item.name
+          expect(mail_subject(mail)).to eq item.name
           expect(mail.body.multipart?).to be_truthy
           expect(mail.body.parts.count).to eq 2
           expect(mail.body.parts[0].body).to include(item.text)
@@ -398,14 +398,14 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(first_mail).not_to be_nil
           # expect(mail.from.first).to eq "test@example.jp"
           expect(first_mail.to.first).to eq email0
-          expect(first_mail.subject).to eq item0.name
+          expect(mail_subject(first_mail)).to eq item0.name
           expect(first_mail.body.multipart?).to be_falsey
           expect(first_mail.body.raw_source).to include(item0.text)
 
           last_mail = ActionMailer::Base.deliveries.last
           expect(last_mail).not_to be_nil
           expect(last_mail.to.first).to eq email3
-          expect(last_mail.subject).to eq item0.name
+          expect(mail_subject(last_mail)).to eq item0.name
           expect(last_mail.body.multipart?).to be_truthy
           expect(last_mail.body.parts.count).to eq 2
           expect(last_mail.body.parts[0].body).to include(item0.text)
@@ -426,14 +426,14 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(first_mail).not_to be_nil
           # expect(mail.from.first).to eq "test@example.jp"
           expect(first_mail.to.first).to eq email1
-          expect(first_mail.subject).to eq item1.name
+          expect(mail_subject(first_mail)).to eq item1.name
           expect(first_mail.body.multipart?).to be_falsey
           expect(first_mail.body.raw_source).to include(item1.text)
 
           last_mail = ActionMailer::Base.deliveries.last
           expect(last_mail).not_to be_nil
           expect(last_mail.to.first).to eq email4
-          expect(last_mail.subject).to eq item1.name
+          expect(mail_subject(last_mail)).to eq item1.name
           expect(last_mail.body.multipart?).to be_truthy
           expect(last_mail.body.parts.count).to eq 2
           expect(last_mail.body.parts[0].body).to include(item1.text)
@@ -454,14 +454,14 @@ describe "ezine_member_page_main", type: :feature, dbscope: :example do
           expect(first_mail).not_to be_nil
           # expect(mail.from.first).to eq "test@example.jp"
           expect(first_mail.to.first).to eq email2
-          expect(first_mail.subject).to eq item2.name
+          expect(mail_subject(first_mail)).to eq item2.name
           expect(first_mail.body.multipart?).to be_falsey
           expect(first_mail.body.raw_source).to include(item2.text)
 
           last_mail = ActionMailer::Base.deliveries.last
           expect(last_mail).not_to be_nil
           expect(last_mail.to.first).to eq email5
-          expect(last_mail.subject).to eq item2.name
+          expect(mail_subject(last_mail)).to eq item2.name
           expect(last_mail.body.multipart?).to be_truthy
           expect(last_mail.body.parts.count).to eq 2
           expect(last_mail.body.parts[0].body).to include(item2.text)

--- a/spec/features/gws/board/topics/basic_crud_spec.rb
+++ b/spec/features/gws/board/topics/basic_crud_spec.rb
@@ -78,9 +78,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
         # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -129,9 +129,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           mail = ActionMailer::Base.deliveries.first
           expect(mail.from.first).to eq site.sender_address
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-          expect(mail.subject).to eq notice.subject
+          expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail.subject, url)
+          expect(mail.decoded.to_s).to include(mail_subject(mail), url)
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -177,9 +177,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           mail = ActionMailer::Base.deliveries.first
           expect(mail.from.first).to eq site.sender_address
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-          expect(mail.subject).to eq notice.subject
+          expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail.subject, url)
+          expect(mail.decoded.to_s).to include(mail_subject(mail), url)
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -257,9 +257,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           mail = ActionMailer::Base.deliveries.first
           expect(mail.from.first).to eq site.sender_address
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-          expect(mail.subject).to eq notice.subject
+          expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail.subject, url)
+          expect(mail.decoded.to_s).to include(mail_subject(mail), url)
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -306,9 +306,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           mail = ActionMailer::Base.deliveries.first
           expect(mail.from.first).to eq site.sender_address
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-          expect(mail.subject).to eq notice.subject
+          expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail.subject, url)
+          expect(mail.decoded.to_s).to include(mail_subject(mail))
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786

--- a/spec/features/gws/board/topics/basic_crud_spec.rb
+++ b/spec/features/gws/board/topics/basic_crud_spec.rb
@@ -80,7 +80,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
         # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -131,7 +131,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
           expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+          expect(mail_body(mail)).to include(mail_subject(mail), url)
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -179,7 +179,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
           expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+          expect(mail_body(mail)).to include(mail_subject(mail), url)
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -259,7 +259,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
           expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+          expect(mail_body(mail)).to include(mail_subject(mail), url)
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786
@@ -308,7 +308,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
           expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
           expect(mail_subject(mail)).to eq notice.subject
           url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-          expect(mail.decoded.to_s).to include(mail_subject(mail))
+          expect(mail_body(mail)).to include(mail_subject(mail))
           expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
 
           # #3786: https://github.com/shirasagi/shirasagi/issues/3786

--- a/spec/features/gws/board/topics/comments_spec.rb
+++ b/spec/features/gws/board/topics/comments_spec.rb
@@ -96,7 +96,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -136,7 +136,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -174,7 +174,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
       end
     end
 
@@ -252,7 +252,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Create comment to comment
@@ -308,7 +308,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -348,7 +348,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -386,7 +386,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
       end
     end
   end

--- a/spec/features/gws/board/topics/comments_spec.rb
+++ b/spec/features/gws/board/topics/comments_spec.rb
@@ -94,9 +94,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -134,9 +134,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -172,9 +172,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
       end
     end
 
@@ -250,9 +250,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Create comment to comment
@@ -306,9 +306,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -346,9 +346,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -384,9 +384,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
       end
     end
   end

--- a/spec/features/gws/board/topics/with_release_spec.rb
+++ b/spec/features/gws/board/topics/with_release_spec.rb
@@ -111,7 +111,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
       end
     end
   end

--- a/spec/features/gws/board/topics/with_release_spec.rb
+++ b/spec/features/gws/board/topics/with_release_spec.rb
@@ -109,9 +109,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
       end
     end
   end

--- a/spec/features/gws/discussion/portal/comment_notification_spec.rb
+++ b/spec/features/gws/discussion/portal/comment_notification_spec.rb
@@ -67,9 +67,9 @@ describe "gws_discussion_forum_thread_comments", type: :feature, dbscope: :examp
     mail = ActionMailer::Base.deliveries.first
     expect(mail.from.first).to eq site.sender_address
     expect(mail.bcc.first).to eq discussion_member.send_notice_mail_addresses.first
-    expect(mail.subject).to eq notification.subject
+    expect(mail_subject(mail)).to eq notification.subject
     url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}/.g#{site.id}/memo/notices/#{notification.id}"
-    expect(mail.decoded.to_s).to include(mail.subject, url)
+    expect(mail.decoded.to_s).to include(mail_subject(mail), url)
     expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
   end
 end

--- a/spec/features/gws/discussion/portal/comment_notification_spec.rb
+++ b/spec/features/gws/discussion/portal/comment_notification_spec.rb
@@ -69,7 +69,7 @@ describe "gws_discussion_forum_thread_comments", type: :feature, dbscope: :examp
     expect(mail.bcc.first).to eq discussion_member.send_notice_mail_addresses.first
     expect(mail_subject(mail)).to eq notification.subject
     url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}/.g#{site.id}/memo/notices/#{notification.id}"
-    expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+    expect(mail_body(mail)).to include(mail_subject(mail), url)
     expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
   end
 end

--- a/spec/features/gws/discussion/portal/topic_notification_spec.rb
+++ b/spec/features/gws/discussion/portal/topic_notification_spec.rb
@@ -82,7 +82,7 @@ describe "gws_discussion_forum_portal", type: :feature, dbscope: :example, js: t
     expect(mail.bcc.first).to eq discussion_member.send_notice_mail_addresses.first
     expect(mail_subject(mail)).to eq notification.subject
     url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}/.g#{site.id}/memo/notices/#{notification.id}"
-    expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+    expect(mail_body(mail)).to include(mail_subject(mail), url)
     expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
   end
 

--- a/spec/features/gws/discussion/portal/topic_notification_spec.rb
+++ b/spec/features/gws/discussion/portal/topic_notification_spec.rb
@@ -80,9 +80,9 @@ describe "gws_discussion_forum_portal", type: :feature, dbscope: :example, js: t
     mail = ActionMailer::Base.deliveries.first
     expect(mail.from.first).to eq site.sender_address
     expect(mail.bcc.first).to eq discussion_member.send_notice_mail_addresses.first
-    expect(mail.subject).to eq notification.subject
+    expect(mail_subject(mail)).to eq notification.subject
     url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}/.g#{site.id}/memo/notices/#{notification.id}"
-    expect(mail.decoded.to_s).to include(mail.subject, url)
+    expect(mail.decoded.to_s).to include(mail_subject(mail), url)
     expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
   end
 

--- a/spec/features/gws/memo/messages/export_messages_spec.rb
+++ b/spec/features/gws/memo/messages/export_messages_spec.rb
@@ -102,7 +102,7 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail["X-Shirasagi-Exported"].decoded).to be_present
           expect(mail.in_reply_to).to be_nil
           expect(mail.references).to be_nil
-          expect(mail.subject).to eq memo.subject
+          expect(mail_subject(mail)).to eq memo.subject
           expect(mail.mime_type).to eq "text/plain"
           expect(mail.multipart?).to be_falsey
           expect(mail.parts).to be_blank
@@ -143,7 +143,7 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail["X-Shirasagi-Exported"].decoded).to be_present
           expect(mail.in_reply_to).to be_nil
           expect(mail.references).to be_nil
-          expect(mail.subject).to eq memo.subject
+          expect(mail_subject(mail)).to eq memo.subject
           expect(mail.mime_type).to eq "text/plain"
           expect(mail.multipart?).to be_falsey
           expect(mail.parts).to be_blank
@@ -184,7 +184,7 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail["X-Shirasagi-Exported"].decoded).to be_present
           expect(mail.in_reply_to).to be_nil
           expect(mail.references).to be_nil
-          expect(mail.subject).to eq memo.subject
+          expect(mail_subject(mail)).to eq memo.subject
           expect(mail.mime_type).to eq "text/plain"
           expect(mail.multipart?).to be_falsey
           expect(mail.parts).to be_blank
@@ -224,7 +224,7 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail["X-Shirasagi-Exported"].decoded).to be_present
           expect(mail.in_reply_to).to be_nil
           expect(mail.references).to be_nil
-          expect(mail.subject).to eq memo.subject
+          expect(mail_subject(mail)).to eq memo.subject
           expect(mail.mime_type).to eq "text/html"
           expect(mail.multipart?).to be_falsey
           expect(mail.parts).to be_blank
@@ -270,7 +270,7 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
             expect(mail["X-Shirasagi-Exported"].decoded).to be_present
             expect(mail.in_reply_to).to be_nil
             expect(mail.references).to be_nil
-            expect(mail.subject).to eq memo.subject
+            expect(mail_subject(mail)).to eq memo.subject
             expect(mail.mime_type).to eq "text/plain"
             expect(mail.multipart?).to be_falsey
             expect(mail.parts).to be_blank

--- a/spec/features/gws/memo/messages/with_forward_spec.rb
+++ b/spec/features/gws/memo/messages/with_forward_spec.rb
@@ -90,16 +90,16 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail.bcc.first).to eq forward_email1
           expect(mail.bcc.second).to eq forward_email2
           expect(mail.mime_type).to eq "text/plain"
-          expect(mail.subject).to eq forward_subject
+          expect(mail_subject(mail)).to eq forward_subject
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(subject)
-          expect(mail.body.raw_source).to include(texts.join("\r\n"))
+          expect(mail.decoded.to_s).to include(subject)
+          expect(mail.decoded.to_s).to include(texts.join("\r\n"))
           url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}"
           url += "/.g#{site.id}/memo/messages/REDIRECT/#{message.id}"
-          expect(mail.body.raw_source).to include(url)
+          expect(mail.decoded.to_s).to include(url)
 
           if target != 'bcc'
-            expect(mail.body.raw_source).to include(recipient.name + "\r\n")
+            expect(mail.decoded.to_s).to include(recipient.name + "\r\n")
           end
           expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
         end
@@ -284,9 +284,9 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail.bcc.first).to eq forward_email1
           expect(mail.bcc.second).to eq forward_email2
           expect(mail.mime_type).to eq "text/html"
-          expect(mail.subject).to eq forward_subject
+          expect(mail_subject(mail)).to eq forward_subject
           expect(mail.body.multipart?).to be_falsey
-          mail.body.raw_source.tap do |body|
+          mail.decoded.to_s.tap do |body|
             expect(body).to include(subject)
             expect(body).to include(html.gsub("\n", "\r\n\r\n"))
             url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}"

--- a/spec/features/gws/memo/messages/with_forward_spec.rb
+++ b/spec/features/gws/memo/messages/with_forward_spec.rb
@@ -92,14 +92,14 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail.mime_type).to eq "text/plain"
           expect(mail_subject(mail)).to eq forward_subject
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(subject)
-          expect(mail.decoded.to_s).to include(texts.join("\r\n"))
+          expect(mail_body(mail)).to include(subject)
+          expect(mail_body(mail)).to include(texts.join("\r\n"))
           url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}"
           url += "/.g#{site.id}/memo/messages/REDIRECT/#{message.id}"
-          expect(mail.decoded.to_s).to include(url)
+          expect(mail_body(mail)).to include(url)
 
           if target != 'bcc'
-            expect(mail.decoded.to_s).to include(recipient.name + "\r\n")
+            expect(mail_body(mail)).to include(recipient.name + "\r\n")
           end
           expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
         end
@@ -286,7 +286,7 @@ describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
           expect(mail.mime_type).to eq "text/html"
           expect(mail_subject(mail)).to eq forward_subject
           expect(mail.body.multipart?).to be_falsey
-          mail.decoded.to_s.tap do |body|
+          mail_body(mail).tap do |body|
             expect(body).to include(subject)
             expect(body).to include(html.gsub("\n", "\r\n\r\n"))
             url = "#{SS.config.gws.canonical_scheme}://#{SS.config.gws.canonical_domain}"

--- a/spec/features/gws/qna/topics/basic_crud_spec.rb
+++ b/spec/features/gws/qna/topics/basic_crud_spec.rb
@@ -82,7 +82,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end
@@ -127,7 +127,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
       expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
       expect(mail_subject(mail)).to eq notice.subject
       url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-      expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+      expect(mail_body(mail)).to include(mail_subject(mail), url)
       expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
     end
 
@@ -162,7 +162,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
       expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
       expect(mail_subject(mail)).to eq notice.subject
       url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-      expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+      expect(mail_body(mail)).to include(mail_subject(mail), url)
       expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
     end
   end

--- a/spec/features/gws/qna/topics/basic_crud_spec.rb
+++ b/spec/features/gws/qna/topics/basic_crud_spec.rb
@@ -80,9 +80,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end
@@ -125,9 +125,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
       mail = ActionMailer::Base.deliveries.first
       expect(mail.from.first).to eq site.sender_address
       expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-      expect(mail.subject).to eq notice.subject
+      expect(mail_subject(mail)).to eq notice.subject
       url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-      expect(mail.decoded.to_s).to include(mail.subject, url)
+      expect(mail.decoded.to_s).to include(mail_subject(mail), url)
       expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
     end
 
@@ -160,9 +160,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
       mail = ActionMailer::Base.deliveries.first
       expect(mail.from.first).to eq site.sender_address
       expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-      expect(mail.subject).to eq notice.subject
+      expect(mail_subject(mail)).to eq notice.subject
       url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-      expect(mail.decoded.to_s).to include(mail.subject, url)
+      expect(mail.decoded.to_s).to include(mail_subject(mail), url)
       expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
     end
   end

--- a/spec/features/gws/qna/topics/comments_spec.rb
+++ b/spec/features/gws/qna/topics/comments_spec.rb
@@ -79,7 +79,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -120,7 +120,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -158,7 +158,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
       end
     end
 
@@ -217,7 +217,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Create (another way)
@@ -265,7 +265,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -306,7 +306,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -344,7 +344,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
       end
     end
   end

--- a/spec/features/gws/qna/topics/comments_spec.rb
+++ b/spec/features/gws/qna/topics/comments_spec.rb
@@ -77,9 +77,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -118,9 +118,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -156,9 +156,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
       end
     end
 
@@ -215,9 +215,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Create (another way)
@@ -263,9 +263,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Update
@@ -304,9 +304,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
 
         #
         # Delete
@@ -342,9 +342,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example do
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
+        expect(mail_subject(mail)).to eq notice.subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
       end
     end
   end

--- a/spec/features/gws/report/files/publish_and_notice_spec.rb
+++ b/spec/features/gws/report/files/publish_and_notice_spec.rb
@@ -86,8 +86,13 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         title = "[#{Gws::Report::File.model_name.human(locale: I18n.default_locale)}] 「#{subject.name}」が届きました。"
-        expect(mail.subject).to eq title
-        expect(mail.decoded.to_s).to include(mail.subject)
+        mail.subject.tap do |subject|
+          if subject.start_with?("=?ISO-2022-JP?")
+            subject = NKF.nkf("-w", subject)
+          end
+          expect(subject).to eq title
+          expect(mail.decoded.to_s).to include(subject)
+        end
         notice_url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
         expect(mail.decoded.to_s).to include(notice_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
@@ -150,8 +155,13 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq notice.subject
-        expect(mail.decoded.to_s).to include(mail.subject)
+        mail.subject.tap do |subject|
+          if subject.start_with?("=?ISO-2022-JP?")
+            subject = NKF.nkf("-w", subject)
+          end
+          expect(subject).to eq title
+          expect(mail.decoded.to_s).to include(subject)
+        end
         notice_url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
         expect(mail.decoded.to_s).to include(notice_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")

--- a/spec/features/gws/report/files/publish_and_notice_spec.rb
+++ b/spec/features/gws/report/files/publish_and_notice_spec.rb
@@ -150,13 +150,8 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        mail_subject(mail).tap do |subject|
-          if subject.start_with?("=?ISO-2022-JP?")
-            subject = NKF.nkf("-w", subject)
-          end
-          expect(subject).to eq title
-          expect(mail_body(mail)).to include(subject)
-        end
+        expect(mail_subject(mail)).to eq title
+        expect(mail_body(mail)).to include(mail_subject(mail))
         notice_url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
         expect(mail_body(mail)).to include(notice_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")

--- a/spec/features/gws/report/files/publish_and_notice_spec.rb
+++ b/spec/features/gws/report/files/publish_and_notice_spec.rb
@@ -86,13 +86,8 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         title = "[#{Gws::Report::File.model_name.human(locale: I18n.default_locale)}] 「#{subject.name}」が届きました。"
-        mail.subject.tap do |subject|
-          if subject.start_with?("=?ISO-2022-JP?")
-            subject = NKF.nkf("-w", subject)
-          end
-          expect(subject).to eq title
-          expect(mail.decoded.to_s).to include(subject)
-        end
+        expect(mail_subject(mail)).to eq title
+        expect(mail.decoded.to_s).to include(mail_subject(mail))
         notice_url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
         expect(mail.decoded.to_s).to include(notice_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
@@ -155,7 +150,7 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        mail.subject.tap do |subject|
+        mail_subject(mail).tap do |subject|
           if subject.start_with?("=?ISO-2022-JP?")
             subject = NKF.nkf("-w", subject)
           end

--- a/spec/features/gws/report/files/publish_and_notice_spec.rb
+++ b/spec/features/gws/report/files/publish_and_notice_spec.rb
@@ -87,9 +87,9 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         title = "[#{Gws::Report::File.model_name.human(locale: I18n.default_locale)}] 「#{subject.name}」が届きました。"
         expect(mail_subject(mail)).to eq title
-        expect(mail.decoded.to_s).to include(mail_subject(mail))
+        expect(mail_body(mail)).to include(mail_subject(mail))
         notice_url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(notice_url)
+        expect(mail_body(mail)).to include(notice_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 
@@ -155,10 +155,10 @@ describe "gws_report_files", type: :feature, dbscope: :example, js: true do
             subject = NKF.nkf("-w", subject)
           end
           expect(subject).to eq title
-          expect(mail.decoded.to_s).to include(subject)
+          expect(mail_body(mail)).to include(subject)
         end
         notice_url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice.id}"
-        expect(mail.decoded.to_s).to include(notice_url)
+        expect(mail_body(mail)).to include(notice_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end

--- a/spec/features/gws/schedule/plans/notification_spec.rb
+++ b/spec/features/gws/schedule/plans/notification_spec.rb
@@ -127,8 +127,8 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
-        expect(mail.subject).to eq I18n.t("gws_notification.gws/schedule/plan.subject", name: plan_name)
-        expect(mail.decoded.to_s).to include(mail.subject)
+        expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan.subject", name: plan_name)
+        expect(mail.decoded.to_s).to include(mail_subject(mail))
         expect(mail.decoded.to_s).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
@@ -237,8 +237,8 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
-        expect(mail.subject).to eq I18n.t("gws_notification.gws/schedule/plan.subject", name: plan_name)
-        expect(mail.decoded.to_s).to include(mail.subject)
+        expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan.subject", name: plan_name)
+        expect(mail.decoded.to_s).to include(mail_subject(mail))
         expect(mail.decoded.to_s).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
@@ -353,7 +353,7 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
-        expect(mail.subject).to eq I18n.t("gws_notification.gws/schedule/plan/destroy.subject", name: item.name)
+        expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan/destroy.subject", name: item.name)
         expect(mail.decoded.to_s).to include(item.name)
         expect(mail.decoded.to_s).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
@@ -544,7 +544,7 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
-        expect(mail.subject).to eq I18n.t("gws_notification.gws/schedule/plan/undo_delete.subject", name: item.name)
+        expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan/undo_delete.subject", name: item.name)
         expect(mail.decoded.to_s).to include(item.name)
         expect(mail.decoded.to_s).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")

--- a/spec/features/gws/schedule/plans/notification_spec.rb
+++ b/spec/features/gws/schedule/plans/notification_spec.rb
@@ -128,8 +128,8 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan.subject", name: plan_name)
-        expect(mail.decoded.to_s).to include(mail_subject(mail))
-        expect(mail.decoded.to_s).to include(mail_url)
+        expect(mail_body(mail)).to include(mail_subject(mail))
+        expect(mail_body(mail)).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end
@@ -238,8 +238,8 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan.subject", name: plan_name)
-        expect(mail.decoded.to_s).to include(mail_subject(mail))
-        expect(mail.decoded.to_s).to include(mail_url)
+        expect(mail_body(mail)).to include(mail_subject(mail))
+        expect(mail_body(mail)).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end
@@ -354,8 +354,8 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan/destroy.subject", name: item.name)
-        expect(mail.decoded.to_s).to include(item.name)
-        expect(mail.decoded.to_s).to include(mail_url)
+        expect(mail_body(mail)).to include(item.name)
+        expect(mail_body(mail)).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end
@@ -545,8 +545,8 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq member_user.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/schedule/plan/undo_delete.subject", name: item.name)
-        expect(mail.decoded.to_s).to include(item.name)
-        expect(mail.decoded.to_s).to include(mail_url)
+        expect(mail_body(mail)).to include(item.name)
+        expect(mail_body(mail)).to include(mail_url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end

--- a/spec/features/gws/schedule/plans/reminder_spec.rb
+++ b/spec/features/gws/schedule/plans/reminder_spec.rb
@@ -202,13 +202,13 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
             "gws/reminder.notification.subject",
             model: I18n.t("mongoid.models.#{reminder.model}"), name: reminder.name
           )
-          expect(mail.subject).to eq subject
+          expect(mail_subject(mail)).to eq subject
           expect(mail.to.length).to eq 1
           expect(mail.to).to include reminder.user.email
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include "[#{reminder.item.class.t :name}] #{reminder.item.name}"
-          expect(mail.body.raw_source).to include "[#{reminder.item.class.t :term}] #{term(reminder.item)}"
-          expect(mail.body.raw_source).to include reminder.user.long_name
+          expect(mail.decoded.to_s).to include "[#{reminder.item.class.t :name}] #{reminder.item.name}"
+          expect(mail.decoded.to_s).to include "[#{reminder.item.class.t :term}] #{term(reminder.item)}"
+          expect(mail.decoded.to_s).to include reminder.user.long_name
         end
       end
     end

--- a/spec/features/gws/schedule/plans/reminder_spec.rb
+++ b/spec/features/gws/schedule/plans/reminder_spec.rb
@@ -206,9 +206,9 @@ describe "gws_schedule_plans", type: :feature, dbscope: :example, js: true do
           expect(mail.to.length).to eq 1
           expect(mail.to).to include reminder.user.email
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include "[#{reminder.item.class.t :name}] #{reminder.item.name}"
-          expect(mail.decoded.to_s).to include "[#{reminder.item.class.t :term}] #{term(reminder.item)}"
-          expect(mail.decoded.to_s).to include reminder.user.long_name
+          expect(mail_body(mail)).to include "[#{reminder.item.class.t :name}] #{reminder.item.name}"
+          expect(mail_body(mail)).to include "[#{reminder.item.class.t :term}] #{term(reminder.item)}"
+          expect(mail_body(mail)).to include reminder.user.long_name
         end
       end
     end

--- a/spec/features/gws/tabular/files/approve_all_spec.rb
+++ b/spec/features/gws/tabular/files/approve_all_spec.rb
@@ -189,7 +189,7 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
           "gws_notification.gws/tabular/file.approve", form: form.i18n_name, name: column1_value1)
         expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 

--- a/spec/features/gws/tabular/files/approve_all_spec.rb
+++ b/spec/features/gws/tabular/files/approve_all_spec.rb
@@ -187,9 +187,9 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         subject = I18n.t(
           "gws_notification.gws/tabular/file.approve", form: form.i18n_name, name: column1_value1)
-        expect(mail.subject).to eq subject
+        expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 

--- a/spec/features/gws/tabular/files/approve_spec.rb
+++ b/spec/features/gws/tabular/files/approve_spec.rb
@@ -243,9 +243,9 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user2.send_notice_mail_addresses.first
         subject = I18n.t("gws_notification.gws/tabular/file.request", form: form.i18n_name, name: column1_value1)
-        expect(mail.subject).to eq subject
+        expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 
@@ -440,9 +440,9 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
         expect(mail.bcc.first).to eq user3.send_notice_mail_addresses.first
         subject = I18n.t(
           "gws_notification.gws/tabular/file.circular", form: form.i18n_name, name: column1_value2)
-        expect(mail.subject).to eq subject
+        expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
       ActionMailer::Base.deliveries[-2].tap do |mail|
@@ -450,9 +450,9 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         subject = I18n.t(
           "gws_notification.gws/tabular/file.approve", form: form.i18n_name, name: column1_value2)
-        expect(mail.subject).to eq subject
+        expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 
@@ -577,9 +577,9 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         subject = I18n.t(
           "gws_notification.gws/tabular/file.comment", form: form.i18n_name, name: column1_value2)
-        expect(mail.subject).to eq subject
+        expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end

--- a/spec/features/gws/tabular/files/approve_spec.rb
+++ b/spec/features/gws/tabular/files/approve_spec.rb
@@ -245,7 +245,7 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
         subject = I18n.t("gws_notification.gws/tabular/file.request", form: form.i18n_name, name: column1_value1)
         expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 
@@ -442,7 +442,7 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
           "gws_notification.gws/tabular/file.circular", form: form.i18n_name, name: column1_value2)
         expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
       ActionMailer::Base.deliveries[-2].tap do |mail|
@@ -452,7 +452,7 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
           "gws_notification.gws/tabular/file.approve", form: form.i18n_name, name: column1_value2)
         expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 
@@ -579,7 +579,7 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
           "gws_notification.gws/tabular/file.comment", form: form.i18n_name, name: column1_value2)
         expect(mail_subject(mail)).to eq subject
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end

--- a/spec/features/gws/workflow/files/approves_spec.rb
+++ b/spec/features/gws/workflow/files/approves_spec.rb
@@ -117,7 +117,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/workflow/file.request", name: item.name)
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice1.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 
@@ -200,7 +200,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
         expect(mail.bcc.first).to eq gws_user.send_notice_mail_addresses.first
         expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/workflow/file.approve", name: item.name)
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice3.id}"
-        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+        expect(mail_body(mail)).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end

--- a/spec/features/gws/workflow/files/approves_spec.rb
+++ b/spec/features/gws/workflow/files/approves_spec.rb
@@ -115,9 +115,9 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq user1.send_notice_mail_addresses.first
-        expect(mail.subject).to eq I18n.t("gws_notification.gws/workflow/file.request", name: item.name)
+        expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/workflow/file.request", name: item.name)
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice1.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
 
@@ -198,9 +198,9 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq site.sender_address
         expect(mail.bcc.first).to eq gws_user.send_notice_mail_addresses.first
-        expect(mail.subject).to eq I18n.t("gws_notification.gws/workflow/file.approve", name: item.name)
+        expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/workflow/file.approve", name: item.name)
         url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice3.id}"
-        expect(mail.decoded.to_s).to include(mail.subject, url)
+        expect(mail.decoded.to_s).to include(mail_subject(mail), url)
         expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
       end
     end

--- a/spec/features/gws/workflow2/files/approves_spec.rb
+++ b/spec/features/gws/workflow2/files/approves_spec.rb
@@ -102,9 +102,9 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
             ActionMailer::Base.deliveries.last.tap do |mail|
               expect(mail.from.first).to eq site.sender_address
               expect(mail.bcc.first).to eq user2.send_notice_mail_addresses.first
-              expect(mail.subject).to eq I18n.t("gws_notification.gws/workflow/file.request", name: item.name)
+              expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/workflow/file.request", name: item.name)
               url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice1.id}"
-              expect(mail.decoded.to_s).to include(mail.subject, url)
+              expect(mail.decoded.to_s).to include(mail_subject(mail), url)
               expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
             end
           else

--- a/spec/features/gws/workflow2/files/approves_spec.rb
+++ b/spec/features/gws/workflow2/files/approves_spec.rb
@@ -104,7 +104,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
               expect(mail.bcc.first).to eq user2.send_notice_mail_addresses.first
               expect(mail_subject(mail)).to eq I18n.t("gws_notification.gws/workflow/file.request", name: item.name)
               url = "#{site.canonical_scheme}://#{site.canonical_domain}/.g#{site.id}/memo/notices/#{notice1.id}"
-              expect(mail.decoded.to_s).to include(mail_subject(mail), url)
+              expect(mail_body(mail)).to include(mail_subject(mail), url)
               expect(mail.message_id).to end_with("@#{site.canonical_domain}.mail")
             end
           else

--- a/spec/features/inquiry/agents/nodes/form/date_field_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/date_field_spec.rb
@@ -85,14 +85,14 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_date
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include(date_iso8601)
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include(date_iso8601)
         # inquiry_column_datetime
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include(datetime_iso8601)
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include(datetime_iso8601)
       end
     end
   end
@@ -156,14 +156,14 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_date
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include(date_iso8601)
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include(date_iso8601)
         # inquiry_column_datetime
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include(datetime_iso8601)
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include(datetime_iso8601)
       end
     end
   end

--- a/spec/features/inquiry/agents/nodes/form/date_field_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/date_field_spec.rb
@@ -83,7 +83,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -154,7 +154,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))

--- a/spec/features/inquiry/agents/nodes/form/include_answers_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/include_answers_spec.rb
@@ -117,35 +117,35 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
         # inquiry_column_number
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[8].name)
-        expect(notify_mail.body.raw_source).to include("123")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[8].name)
+        expect(mail_body(notify_mail)).to include("123")
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -153,35 +153,35 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
         # inquiry_column_number
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[8].name)
-        expect(notify_mail.body.raw_source).to include("123")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[8].name)
+        expect(mail_body(notify_mail)).to include("123")
       end
     end
 

--- a/spec/features/inquiry/agents/nodes/form/include_answers_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/include_answers_spec.rb
@@ -115,7 +115,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -151,7 +151,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))

--- a/spec/features/inquiry/agents/nodes/form/kintone_app_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/kintone_app_spec.rb
@@ -126,32 +126,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -159,32 +159,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
     end
 
@@ -281,32 +281,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
           expect(notify_mail.to.first).to eq 'notice@example.jp'
           expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
           expect(notify_mail.body.multipart?).to be_falsey
-          expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-          expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+          expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+          expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
           # inquiry_column_name
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-          expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+          expect(mail_body(notify_mail)).to include("シラサギ太郎")
           # inquiry_column_optional
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-          expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+          expect(mail_body(notify_mail)).to include("株式会社シラサギ")
           # inquiry_column_transfers
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-          expect(notify_mail.body.raw_source).to include('キーワード')
+          expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+          expect(mail_body(notify_mail)).to include('キーワード')
           # inquiry_column_email
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-          expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+          expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
           # inquiry_column_radio
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-          expect(notify_mail.body.raw_source).to include("男性")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+          expect(mail_body(notify_mail)).to include("男性")
           # inquiry_column_select
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-          expect(notify_mail.body.raw_source).to include("50代")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+          expect(mail_body(notify_mail)).to include("50代")
           # inquiry_column_check
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-          expect(notify_mail.body.raw_source).to include("申請について")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+          expect(mail_body(notify_mail)).to include("申請について")
           # inquiry_column_upload_file
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-          expect(notify_mail.body.raw_source).to include("logo.png")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+          expect(mail_body(notify_mail)).to include("logo.png")
         end
 
         ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -314,32 +314,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
           expect(notify_mail.to.first).to eq 'transfers@example.jp'
           expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
           expect(notify_mail.body.multipart?).to be_falsey
-          expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-          expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+          expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+          expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
           # inquiry_column_name
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-          expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+          expect(mail_body(notify_mail)).to include("シラサギ太郎")
           # inquiry_column_optional
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-          expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+          expect(mail_body(notify_mail)).to include("株式会社シラサギ")
           # inquiry_column_transfers
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-          expect(notify_mail.body.raw_source).to include('キーワード')
+          expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+          expect(mail_body(notify_mail)).to include('キーワード')
           # inquiry_column_email
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-          expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+          expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
           # inquiry_column_radio
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-          expect(notify_mail.body.raw_source).to include("男性")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+          expect(mail_body(notify_mail)).to include("男性")
           # inquiry_column_select
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-          expect(notify_mail.body.raw_source).to include("50代")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+          expect(mail_body(notify_mail)).to include("50代")
           # inquiry_column_check
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-          expect(notify_mail.body.raw_source).to include("申請について")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+          expect(mail_body(notify_mail)).to include("申請について")
           # inquiry_column_upload_file
-          expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-          expect(notify_mail.body.raw_source).to include("logo.png")
+          expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+          expect(mail_body(notify_mail)).to include("logo.png")
         end
       end
     end
@@ -434,32 +434,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -467,32 +467,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
     end
   end
@@ -607,32 +607,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -640,32 +640,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
     end
   end
@@ -763,32 +763,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -796,32 +796,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
     end
   end
@@ -922,32 +922,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -955,32 +955,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(notify_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).to include("男性")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).to include("50代")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).to include("申請について")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).to include("logo.png")
       end
     end
   end

--- a/spec/features/inquiry/agents/nodes/form/kintone_app_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/kintone_app_spec.rb
@@ -124,7 +124,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -157,7 +157,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -279,7 +279,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         ActionMailer::Base.deliveries.first.tap do |notify_mail|
           expect(notify_mail.from.first).to eq 'admin@example.jp'
           expect(notify_mail.to.first).to eq 'notice@example.jp'
-          expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+          expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
           expect(notify_mail.body.multipart?).to be_falsey
           expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
           expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -312,7 +312,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         ActionMailer::Base.deliveries[1].tap do |notify_mail|
           expect(notify_mail.from.first).to eq 'admin@example.jp'
           expect(notify_mail.to.first).to eq 'transfers@example.jp'
-          expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+          expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
           expect(notify_mail.body.multipart?).to be_falsey
           expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
           expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -432,7 +432,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -465,7 +465,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -605,7 +605,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -638,7 +638,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -761,7 +761,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -794,7 +794,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -920,7 +920,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -953,7 +953,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))

--- a/spec/features/inquiry/agents/nodes/form/lgwan_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/lgwan_spec.rb
@@ -118,8 +118,8 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -127,17 +127,17 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
       end
 
       ActionMailer::Base.deliveries.last.tap do |reply_mail|
         expect(reply_mail.from.first).to eq 'admin@example.jp'
         expect(reply_mail.to.first).to eq 'shirasagi@example.jp'
-        expect(reply_mail.subject).to eq 'お問い合わせを受け付けました'
+        expect(mail_subject(reply_mail)).to eq 'お問い合わせを受け付けました'
         expect(reply_mail.body.multipart?).to be_falsey
-        expect(reply_mail.body.raw_source).to include('上部テキスト')
-        expect(reply_mail.body.raw_source).to include('下部テキスト')
+        expect(mail_body(reply_mail)).to include('上部テキスト')
+        expect(mail_body(reply_mail)).to include('下部テキスト')
       end
     end
 

--- a/spec/features/inquiry/agents/nodes/form/lgwan_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/lgwan_spec.rb
@@ -116,7 +116,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -125,7 +125,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))

--- a/spec/features/inquiry/agents/nodes/form/link_only_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/link_only_spec.rb
@@ -110,7 +110,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -143,7 +143,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))

--- a/spec/features/inquiry/agents/nodes/form/link_only_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/link_only_spec.rb
@@ -112,32 +112,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).not_to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).not_to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).not_to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).not_to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).not_to include('キーワード')
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).not_to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).not_to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).not_to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).not_to include("男性")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).not_to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).not_to include("50代")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).not_to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).not_to include("申請について")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).not_to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).not_to include("logo.png")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).not_to include("logo.png")
       end
 
       ActionMailer::Base.deliveries[1].tap do |notify_mail|
@@ -145,32 +145,32 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
         expect(notify_mail.to.first).to eq 'transfers@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).not_to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).not_to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).not_to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).not_to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[2].name)
-        expect(notify_mail.body.raw_source).not_to include('キーワード')
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[2].name)
+        expect(mail_body(notify_mail)).not_to include('キーワード')
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).not_to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).not_to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[4].name)
-        expect(notify_mail.body.raw_source).not_to include("男性")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[4].name)
+        expect(mail_body(notify_mail)).not_to include("男性")
         # inquiry_column_select
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[5].name)
-        expect(notify_mail.body.raw_source).not_to include("50代")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[5].name)
+        expect(mail_body(notify_mail)).not_to include("50代")
         # inquiry_column_check
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[6].name)
-        expect(notify_mail.body.raw_source).not_to include("申請について")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[6].name)
+        expect(mail_body(notify_mail)).not_to include("申請について")
         # inquiry_column_upload_file
-        expect(notify_mail.body.raw_source).not_to include("- " + node.columns[7].name)
-        expect(notify_mail.body.raw_source).not_to include("logo.png")
+        expect(mail_body(notify_mail)).not_to include("- " + node.columns[7].name)
+        expect(mail_body(notify_mail)).not_to include("logo.png")
       end
     end
   end

--- a/spec/features/inquiry/agents/nodes/form/notice_emails_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/notice_emails_spec.rb
@@ -98,7 +98,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq from_email
         expect(notify_mail.to.to_a).to eq notice_emails
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -148,7 +148,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
       notify_mails.each_with_index do |notify_mail, idx|
         expect(notify_mail.from.first).to eq from_email
         expect(notify_mail.to.to_a).to eq [notice_emails[idx]]
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))

--- a/spec/features/inquiry/agents/nodes/form/notice_emails_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/notice_emails_spec.rb
@@ -100,8 +100,8 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
         expect(notify_mail.to.to_a).to eq notice_emails
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
       end
     end
   end
@@ -150,8 +150,8 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
         expect(notify_mail.to.to_a).to eq [notice_emails[idx]]
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
       end
     end
   end

--- a/spec/features/inquiry/agents/nodes/form/reply_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/reply_spec.rb
@@ -111,38 +111,38 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.last.tap do |reply_mail|
         expect(reply_mail.from.first).to eq 'admin@example.jp'
         expect(reply_mail.to.first).to eq 'shirasagi@example.jp'
-        expect(reply_mail.subject).to eq 'お問い合わせを受け付けました'
+        expect(mail_subject(reply_mail)).to eq 'お問い合わせを受け付けました'
         expect(reply_mail.body.multipart?).to be_falsey
         # upper
-        expect(reply_mail.body.raw_source).to include('上部テキスト')
+        expect(mail_body(reply_mail)).to include('上部テキスト')
         # inquiry_column_name
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(reply_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(reply_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(reply_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(reply_mail)).to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[2].name)
-        expect(reply_mail.body.raw_source).to include('キーワード')
+        expect(mail_body(reply_mail)).to include("- " + node.columns[2].name)
+        expect(mail_body(reply_mail)).to include('キーワード')
         # inquiry_column_email
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(reply_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(reply_mail)).to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[4].name)
-        expect(reply_mail.body.raw_source).to include("男性")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[4].name)
+        expect(mail_body(reply_mail)).to include("男性")
         # inquiry_column_select
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[5].name)
-        expect(reply_mail.body.raw_source).to include("50代")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[5].name)
+        expect(mail_body(reply_mail)).to include("50代")
         # inquiry_column_check
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[6].name)
-        expect(reply_mail.body.raw_source).to include("申請について")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[6].name)
+        expect(mail_body(reply_mail)).to include("申請について")
         # inquiry_column_upload_file
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[7].name)
-        expect(reply_mail.body.raw_source).to include("logo.png")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[7].name)
+        expect(mail_body(reply_mail)).to include("logo.png")
         # static
-        expect(reply_mail.body.raw_source).not_to include(I18n.t("inquiry.default_reply_content_static"))
+        expect(mail_body(reply_mail)).not_to include(I18n.t("inquiry.default_reply_content_static"))
         # lower
-        expect(reply_mail.body.raw_source).to include('下部テキスト')
+        expect(mail_body(reply_mail)).to include('下部テキスト')
       end
     end
   end
@@ -216,38 +216,38 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example do
       ActionMailer::Base.deliveries.last.tap do |reply_mail|
         expect(reply_mail.from.first).to eq 'admin@example.jp'
         expect(reply_mail.to.first).to eq 'shirasagi@example.jp'
-        expect(reply_mail.subject).to eq 'お問い合わせを受け付けました'
+        expect(mail_subject(reply_mail)).to eq 'お問い合わせを受け付けました'
         expect(reply_mail.body.multipart?).to be_falsey
         # upper
-        expect(reply_mail.body.raw_source).to include('上部テキスト')
+        expect(mail_body(reply_mail)).to include('上部テキスト')
         # inquiry_column_name
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[0].name)
-        expect(reply_mail.body.raw_source).not_to include("シラサギ太郎")
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[0].name)
+        expect(mail_body(reply_mail)).not_to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[1].name)
-        expect(reply_mail.body.raw_source).not_to include("株式会社シラサギ")
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[1].name)
+        expect(mail_body(reply_mail)).not_to include("株式会社シラサギ")
         # inquiry_column_transfers
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[2].name)
-        expect(reply_mail.body.raw_source).not_to include('キーワード')
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[2].name)
+        expect(mail_body(reply_mail)).not_to include('キーワード')
         # inquiry_column_email
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[3].name)
-        expect(reply_mail.body.raw_source).not_to include("shirasagi@example.jp")
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[3].name)
+        expect(mail_body(reply_mail)).not_to include("shirasagi@example.jp")
         # inquiry_column_radio
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[4].name)
-        expect(reply_mail.body.raw_source).not_to include("男性")
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[4].name)
+        expect(mail_body(reply_mail)).not_to include("男性")
         # inquiry_column_select
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[5].name)
-        expect(reply_mail.body.raw_source).not_to include("50代")
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[5].name)
+        expect(mail_body(reply_mail)).not_to include("50代")
         # inquiry_column_check
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[6].name)
-        expect(reply_mail.body.raw_source).not_to include("申請について")
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[6].name)
+        expect(mail_body(reply_mail)).not_to include("申請について")
         # inquiry_column_upload_file
-        expect(reply_mail.body.raw_source).not_to include("- " + node.columns[7].name)
-        expect(reply_mail.body.raw_source).not_to include("logo.png")
+        expect(mail_body(reply_mail)).not_to include("- " + node.columns[7].name)
+        expect(mail_body(reply_mail)).not_to include("logo.png")
         # static
-        expect(reply_mail.body.raw_source).to include(I18n.t("inquiry.default_reply_content_static").gsub("\n", "\r\n"))
+        expect(mail_body(reply_mail)).to include(I18n.t("inquiry.default_reply_content_static").gsub("\n", "\r\n"))
         # lower
-        expect(reply_mail.body.raw_source).to include('下部テキスト')
+        expect(mail_body(reply_mail)).to include('下部テキスト')
       end
     end
   end

--- a/spec/features/inquiry/agents/nodes/form/site_inquiry_form_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/site_inquiry_form_spec.rb
@@ -82,12 +82,12 @@ describe "inquiry_form", type: :feature, dbscope: :example, js: true do
         expect(mail.to.first).to eq inquiry_form.notice_emails.first
         expect(mail_subject(mail)).to eq "[自動通知]#{inquiry_form.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include("「#{inquiry_form.name}」に入力がありました。")
+        expect(mail_body(mail)).to include("「#{inquiry_form.name}」に入力がありました。")
         answer_url = Rails.application.routes.url_helpers.inquiry_answer_url(
           protocol: "http", host: site.domain, site: site, cid: inquiry_form, id: answer
         )
-        expect(mail.body.raw_source).to include(answer_url)
-        expect(mail.body.raw_source).not_to include(name)
+        expect(mail_body(mail)).to include(answer_url)
+        expect(mail_body(mail)).not_to include(name)
       end
     end
   end
@@ -133,12 +133,12 @@ describe "inquiry_form", type: :feature, dbscope: :example, js: true do
         expect(mail.to.first).to eq group1.contact_email
         expect(mail_subject(mail)).to eq "[自動通知]#{inquiry_form.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include("「#{inquiry_form.name}」に入力がありました。")
+        expect(mail_body(mail)).to include("「#{inquiry_form.name}」に入力がありました。")
         answer_url = Rails.application.routes.url_helpers.inquiry_answer_url(
           protocol: "http", host: site.domain, site: site, cid: inquiry_form, id: answer
         )
-        expect(mail.body.raw_source).to include(answer_url)
-        expect(mail.body.raw_source).not_to include(name)
+        expect(mail_body(mail)).to include(answer_url)
+        expect(mail_body(mail)).not_to include(name)
       end
     end
   end

--- a/spec/features/inquiry/agents/nodes/form/site_inquiry_form_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/site_inquiry_form_spec.rb
@@ -80,9 +80,9 @@ describe "inquiry_form", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.first.tap do |mail|
         expect(mail.from.first).to eq inquiry_form.from_email
         expect(mail.to.first).to eq inquiry_form.notice_emails.first
-        expect(mail.subject).to eq "[自動通知]#{inquiry_form.name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[自動通知]#{inquiry_form.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include("「#{inquiry_form.name}」に入力がありました。")
+        expect(mail.decoded.to_s).to include("「#{inquiry_form.name}」に入力がありました。")
         answer_url = Rails.application.routes.url_helpers.inquiry_answer_url(
           protocol: "http", host: site.domain, site: site, cid: inquiry_form, id: answer
         )
@@ -131,7 +131,7 @@ describe "inquiry_form", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.first.tap do |mail|
         expect(mail.from.first).to eq inquiry_form.from_email
         expect(mail.to.first).to eq group1.contact_email
-        expect(mail.subject).to eq "[自動通知]#{inquiry_form.name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[自動通知]#{inquiry_form.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
         expect(mail.body.raw_source).to include("「#{inquiry_form.name}」に入力がありました。")
         answer_url = Rails.application.routes.url_helpers.inquiry_answer_url(

--- a/spec/features/inquiry/agents/nodes/form/xss_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/xss_spec.rb
@@ -109,43 +109,43 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
         expect(notify_mail.to.first).to eq 'notice@example.jp'
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
-        expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
+        expect(mail_body(notify_mail)).to include("「#{node.name}」に入力がありました。")
+        expect(mail_body(notify_mail)).to include(inquiry_answer_path(site: site, cid: node, id: answer))
         # inquiry_column_name
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(notify_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(notify_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(notify_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(notify_mail)).to include("株式会社シラサギ")
         # inquiry_column_email
-        expect(notify_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(notify_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(notify_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(notify_mail)).to include("shirasagi@example.jp")
         # no tags
-        expect(notify_mail.body.raw_source).not_to include('<script')
-        expect(notify_mail.body.raw_source).not_to include('<a')
+        expect(mail_body(notify_mail)).not_to include('<script')
+        expect(mail_body(notify_mail)).not_to include('<a')
       end
 
       ActionMailer::Base.deliveries.last.tap do |reply_mail|
         expect(reply_mail.from.first).to eq node.from_email
         expect(reply_mail.to.first).to eq 'shirasagi@example.jp'
-        expect(reply_mail.subject).to eq node.reply_subject
+        expect(mail_subject(reply_mail)).to eq node.reply_subject
         expect(reply_mail.body.multipart?).to be_falsey
         # upper
-        expect(reply_mail.body.raw_source).to include('上部テキスト')
+        expect(mail_body(reply_mail)).to include('上部テキスト')
         # inquiry_column_name
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[0].name)
-        expect(reply_mail.body.raw_source).to include("シラサギ太郎")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[0].name)
+        expect(mail_body(reply_mail)).to include("シラサギ太郎")
         # inquiry_column_optional
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[1].name)
-        expect(reply_mail.body.raw_source).to include("株式会社シラサギ")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[1].name)
+        expect(mail_body(reply_mail)).to include("株式会社シラサギ")
         # inquiry_column_email
-        expect(reply_mail.body.raw_source).to include("- " + node.columns[3].name)
-        expect(reply_mail.body.raw_source).to include("shirasagi@example.jp")
+        expect(mail_body(reply_mail)).to include("- " + node.columns[3].name)
+        expect(mail_body(reply_mail)).to include("shirasagi@example.jp")
         # lower
-        expect(reply_mail.body.raw_source).to include('下部テキスト')
+        expect(mail_body(reply_mail)).to include('下部テキスト')
         # no tags
-        expect(reply_mail.body.raw_source).not_to include('<script')
-        expect(reply_mail.body.raw_source).not_to include('<a')
+        expect(mail_body(reply_mail)).not_to include('<script')
+        expect(mail_body(reply_mail)).not_to include('<a')
       end
 
       login_cms_user
@@ -193,18 +193,18 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
         expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         # no tags
-        expect(notify_mail.body.raw_source).not_to include('<script')
-        expect(notify_mail.body.raw_source).not_to include('<a')
+        expect(mail_body(notify_mail)).not_to include('<script')
+        expect(mail_body(notify_mail)).not_to include('<a')
       end
 
       ActionMailer::Base.deliveries.last.tap do |reply_mail|
         expect(reply_mail.from.first).to eq node.from_email
         expect(reply_mail.to.first).to eq 'shirasagi@example.jp'
-        expect(reply_mail.subject).to eq node.reply_subject
+        expect(mail_subject(reply_mail)).to eq node.reply_subject
         expect(reply_mail.body.multipart?).to be_falsey
         # no tags
-        expect(reply_mail.body.raw_source).not_to include('<script')
-        expect(reply_mail.body.raw_source).not_to include('<a')
+        expect(mail_body(reply_mail)).not_to include('<script')
+        expect(mail_body(reply_mail)).not_to include('<a')
       end
     end
   end

--- a/spec/features/inquiry/agents/nodes/form/xss_spec.rb
+++ b/spec/features/inquiry/agents/nodes/form/xss_spec.rb
@@ -107,7 +107,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("「#{node.name}」に入力がありました。")
         expect(notify_mail.body.raw_source).to include(inquiry_answer_path(site: site, cid: node, id: answer))
@@ -190,7 +190,7 @@ describe "inquiry_agents_nodes_form", type: :feature, dbscope: :example, js: tru
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq 'admin@example.jp'
         expect(notify_mail.to.first).to eq 'notice@example.jp'
-        expect(notify_mail.subject).to eq "[自動通知]#{node.name} - #{site.name}"
+        expect(mail_subject(notify_mail)).to eq "[自動通知]#{node.name} - #{site.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         # no tags
         expect(notify_mail.body.raw_source).not_to include('<script')

--- a/spec/features/member/agents/nodes/my_group_spec.rb
+++ b/spec/features/member/agents/nodes/my_group_spec.rb
@@ -139,11 +139,11 @@ describe 'members/agents/nodes/my_group', type: :feature, dbscope: :example, js:
         expect(mail.to.first).to eq invitee_email
         expect(mail_subject(mail)).to eq '会員招待'
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include(cms_member.name)
-        expect(mail.decoded.to_s).to include(invitation_message)
-        expect(mail.decoded.to_s).to include(member_invitation_signature.gsub("\n", "\r\n"))
+        expect(mail_body(mail)).to include(cms_member.name)
+        expect(mail_body(mail)).to include(invitation_message)
+        expect(mail_body(mail)).to include(member_invitation_signature.gsub("\n", "\r\n"))
 
-        mail.decoded.to_s =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
+        mail_body(mail) =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
         url = $1
         expect(url).not_to be_nil
         visit url
@@ -229,11 +229,11 @@ describe 'members/agents/nodes/my_group', type: :feature, dbscope: :example, js:
         expect(mail.to.first).to eq invitee.email
         expect(mail_subject(mail)).to eq 'グループ招待'
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include(cms_member.name)
-        expect(mail.decoded.to_s).to include(invitation_message)
-        expect(mail.decoded.to_s).to include(group_invitation_signature.gsub("\n", "\r\n"))
+        expect(mail_body(mail)).to include(cms_member.name)
+        expect(mail_body(mail)).to include(invitation_message)
+        expect(mail_body(mail)).to include(group_invitation_signature.gsub("\n", "\r\n"))
 
-        mail.decoded.to_s =~ /(#{::Regexp.escape(node_my_group.full_url)}[^ \t\r\n]+\/accept)/
+        mail_body(mail) =~ /(#{::Regexp.escape(node_my_group.full_url)}[^ \t\r\n]+\/accept)/
         url = $1
         expect(url).not_to be_nil
 
@@ -330,11 +330,11 @@ describe 'members/agents/nodes/my_group', type: :feature, dbscope: :example, js:
         expect(mail.to.first).to eq invitee.email
         expect(mail_subject(mail)).to eq 'グループ招待'
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(cms_member.name)
-        expect(mail.body.raw_source).to include(invitation_message)
-        expect(mail.body.raw_source).to include(group_invitation_signature.gsub("\n", "\r\n"))
+        expect(mail_body(mail)).to include(cms_member.name)
+        expect(mail_body(mail)).to include(invitation_message)
+        expect(mail_body(mail)).to include(group_invitation_signature.gsub("\n", "\r\n"))
 
-        mail.body.raw_source =~ /(#{::Regexp.escape(node_my_group.full_url)}[^ \t\r\n]+\/accept)/
+        mail_body(mail) =~ /(#{::Regexp.escape(node_my_group.full_url)}[^ \t\r\n]+\/accept)/
         url = $1
         expect(url).not_to be_nil
 

--- a/spec/features/member/agents/nodes/my_group_spec.rb
+++ b/spec/features/member/agents/nodes/my_group_spec.rb
@@ -137,13 +137,13 @@ describe 'members/agents/nodes/my_group', type: :feature, dbscope: :example, js:
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq 'admin@example.jp'
         expect(mail.to.first).to eq invitee_email
-        expect(mail.subject).to eq '会員招待'
+        expect(mail_subject(mail)).to eq '会員招待'
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(cms_member.name)
-        expect(mail.body.raw_source).to include(invitation_message)
-        expect(mail.body.raw_source).to include(member_invitation_signature.gsub("\n", "\r\n"))
+        expect(mail.decoded.to_s).to include(cms_member.name)
+        expect(mail.decoded.to_s).to include(invitation_message)
+        expect(mail.decoded.to_s).to include(member_invitation_signature.gsub("\n", "\r\n"))
 
-        mail.body.raw_source =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
+        mail.decoded.to_s =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
         url = $1
         expect(url).not_to be_nil
         visit url
@@ -227,13 +227,13 @@ describe 'members/agents/nodes/my_group', type: :feature, dbscope: :example, js:
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq 'admin@example.jp'
         expect(mail.to.first).to eq invitee.email
-        expect(mail.subject).to eq 'グループ招待'
+        expect(mail_subject(mail)).to eq 'グループ招待'
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(cms_member.name)
-        expect(mail.body.raw_source).to include(invitation_message)
-        expect(mail.body.raw_source).to include(group_invitation_signature.gsub("\n", "\r\n"))
+        expect(mail.decoded.to_s).to include(cms_member.name)
+        expect(mail.decoded.to_s).to include(invitation_message)
+        expect(mail.decoded.to_s).to include(group_invitation_signature.gsub("\n", "\r\n"))
 
-        mail.body.raw_source =~ /(#{::Regexp.escape(node_my_group.full_url)}[^ \t\r\n]+\/accept)/
+        mail.decoded.to_s =~ /(#{::Regexp.escape(node_my_group.full_url)}[^ \t\r\n]+\/accept)/
         url = $1
         expect(url).not_to be_nil
 
@@ -328,7 +328,7 @@ describe 'members/agents/nodes/my_group', type: :feature, dbscope: :example, js:
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq 'admin@example.jp'
         expect(mail.to.first).to eq invitee.email
-        expect(mail.subject).to eq 'グループ招待'
+        expect(mail_subject(mail)).to eq 'グループ招待'
         expect(mail.body.multipart?).to be_falsey
         expect(mail.body.raw_source).to include(cms_member.name)
         expect(mail.body.raw_source).to include(invitation_message)

--- a/spec/features/member/agents/nodes/registration_spec.rb
+++ b/spec/features/member/agents/nodes/registration_spec.rb
@@ -153,9 +153,9 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       expect(mail.to.first).to eq email
       expect(mail_subject(mail)).to eq '登録確認'
       expect(mail.body.multipart?).to be_falsey
-      expect(mail.decoded.to_s).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
-      expect(mail.decoded.to_s).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
-      expect(mail.decoded.to_s).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
 
       member = Cms::Member.where(email: email).first
       expect(member.name).to eq name
@@ -170,7 +170,7 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       expect(member.sex).to eq sex
       expect(member.birthday).to eq birthday
 
-      mail.decoded.to_s =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
+      mail_body(mail) =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
       url = $1
       expect(url).not_to be_nil
       visit url
@@ -193,11 +193,11 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       expect(mail.to.first).to eq email
       expect(mail_subject(mail)).to eq '登録完了'
       expect(mail.body.multipart?).to be_falsey
-      expect(mail.body.raw_source).to include(node_registration.completed_upper_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.completed_lower_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(email)
-      expect(mail.body.raw_source).to include(name)
+      expect(mail_body(mail)).to include(node_registration.completed_upper_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.completed_lower_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(email)
+      expect(mail_body(mail)).to include(name)
 
       member = Cms::Member.where(email: email).first
       expect(member.name).to eq name
@@ -328,9 +328,9 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       expect(mail.to.first).to eq email
       expect(mail_subject(mail)).to eq '登録確認'
       expect(mail.body.multipart?).to be_falsey
-      expect(mail.body.raw_source).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
 
       member = Cms::Member.where(email: email).first
       expect(member.name).to eq name
@@ -434,11 +434,11 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       expect(mail.to.first).to eq member.email
       expect(mail_subject(mail)).to eq 'パスワード再設定案内'
       expect(mail.body.multipart?).to be_falsey
-      expect(mail.body.raw_source).to include(node_registration.reset_password_upper_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.reset_password_lower_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reset_password_upper_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reset_password_lower_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
 
-      mail.body.raw_source =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
+      mail_body(mail) =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
       url = $1
       expect(url).not_to be_nil
       visit url
@@ -484,9 +484,9 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       expect(mail.to.first).to eq member.email
       expect(mail_subject(mail)).to eq '登録確認'
       expect(mail.body.multipart?).to be_falsey
-      expect(mail.body.raw_source).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
+      expect(mail_body(mail)).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
     end
   end
 end

--- a/spec/features/member/agents/nodes/registration_spec.rb
+++ b/spec/features/member/agents/nodes/registration_spec.rb
@@ -151,11 +151,11 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       mail = ActionMailer::Base.deliveries.first
       expect(mail.from.first).to eq "admin@example.jp"
       expect(mail.to.first).to eq email
-      expect(mail.subject).to eq '登録確認'
+      expect(mail_subject(mail)).to eq '登録確認'
       expect(mail.body.multipart?).to be_falsey
-      expect(mail.body.raw_source).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
-      expect(mail.body.raw_source).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
+      expect(mail.decoded.to_s).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
+      expect(mail.decoded.to_s).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
+      expect(mail.decoded.to_s).to include(node_registration.sender_signature.gsub("\n", "\r\n"))
 
       member = Cms::Member.where(email: email).first
       expect(member.name).to eq name
@@ -170,7 +170,7 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       expect(member.sex).to eq sex
       expect(member.birthday).to eq birthday
 
-      mail.body.raw_source =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
+      mail.decoded.to_s =~ /(#{::Regexp.escape(node_registration.full_url)}[^ \t\r\n]+)/
       url = $1
       expect(url).not_to be_nil
       visit url
@@ -191,7 +191,7 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       mail = ActionMailer::Base.deliveries.last
       expect(mail.from.first).to eq "admin@example.jp"
       expect(mail.to.first).to eq email
-      expect(mail.subject).to eq '登録完了'
+      expect(mail_subject(mail)).to eq '登録完了'
       expect(mail.body.multipart?).to be_falsey
       expect(mail.body.raw_source).to include(node_registration.completed_upper_text.gsub("\n", "\r\n"))
       expect(mail.body.raw_source).to include(node_registration.completed_lower_text.gsub("\n", "\r\n"))
@@ -269,7 +269,7 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       mail = ActionMailer::Base.deliveries.first
 
       expect(mail.to.first).to eq "sys@example.jp"
-      expect(mail.subject).to start_with '[会員登録申請]'
+      expect(mail_subject(mail)).to start_with '[会員登録申請]'
       expect(mail.body.multipart?).to be_falsey
     end
   end
@@ -326,7 +326,7 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
 
       expect(mail.from.first).to eq "admin@example.jp"
       expect(mail.to.first).to eq email
-      expect(mail.subject).to eq '登録確認'
+      expect(mail_subject(mail)).to eq '登録確認'
       expect(mail.body.multipart?).to be_falsey
       expect(mail.body.raw_source).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
       expect(mail.body.raw_source).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))
@@ -432,7 +432,7 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       mail = ActionMailer::Base.deliveries.first
       expect(mail.from.first).to eq node_registration.sender_email
       expect(mail.to.first).to eq member.email
-      expect(mail.subject).to eq 'パスワード再設定案内'
+      expect(mail_subject(mail)).to eq 'パスワード再設定案内'
       expect(mail.body.multipart?).to be_falsey
       expect(mail.body.raw_source).to include(node_registration.reset_password_upper_text.gsub("\n", "\r\n"))
       expect(mail.body.raw_source).to include(node_registration.reset_password_lower_text.gsub("\n", "\r\n"))
@@ -482,7 +482,7 @@ describe 'members/agents/nodes/registration', type: :feature, dbscope: :example 
       mail = ActionMailer::Base.deliveries.first
       expect(mail.from.first).to eq "admin@example.jp"
       expect(mail.to.first).to eq member.email
-      expect(mail.subject).to eq '登録確認'
+      expect(mail_subject(mail)).to eq '登録確認'
       expect(mail.body.multipart?).to be_falsey
       expect(mail.body.raw_source).to include(node_registration.reply_upper_text.gsub("\n", "\r\n"))
       expect(mail.body.raw_source).to include(node_registration.reply_lower_text.gsub("\n", "\r\n"))

--- a/spec/features/member/blogs/release_page_spec.rb
+++ b/spec/features/member/blogs/release_page_spec.rb
@@ -67,9 +67,9 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user1.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(cms_user.name)
-          expect(mail.decoded.to_s).to include(item.name)
-          expect(mail.decoded.to_s).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -100,7 +100,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(item.name)
+          expect(mail_body(mail)).to include(item.name)
         end
       end
     end

--- a/spec/features/member/blogs/release_page_spec.rb
+++ b/spec/features/member/blogs/release_page_spec.rb
@@ -65,11 +65,11 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user1.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail.decoded.to_s).to include(cms_user.name)
+          expect(mail.decoded.to_s).to include(item.name)
+          expect(mail.decoded.to_s).to include(workflow_comment)
         end
 
         #
@@ -98,9 +98,9 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user1.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item.name)
+          expect(mail.decoded.to_s).to include(item.name)
         end
       end
     end

--- a/spec/features/member/photos/release_page_spec.rb
+++ b/spec/features/member/photos/release_page_spec.rb
@@ -58,11 +58,11 @@ describe "member_photos", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq cms_user.email
         expect(mail.to.first).to eq user.email
-        expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(cms_user.name)
-        expect(mail.body.raw_source).to include(item.name)
-        expect(mail.body.raw_source).to include(workflow_comment)
+        expect(mail.decoded.to_s).to include(cms_user.name)
+        expect(mail.decoded.to_s).to include(item.name)
+        expect(mail.decoded.to_s).to include(workflow_comment)
       end
 
       login_user user, to: show_path
@@ -88,9 +88,9 @@ describe "member_photos", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq user.email
         expect(mail.to.first).to eq cms_user.email
-        expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(item.name)
+        expect(mail.decoded.to_s).to include(item.name)
       end
     end
   end

--- a/spec/features/member/photos/release_page_spec.rb
+++ b/spec/features/member/photos/release_page_spec.rb
@@ -60,9 +60,9 @@ describe "member_photos", type: :feature, dbscope: :example, js: true do
         expect(mail.to.first).to eq user.email
         expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include(cms_user.name)
-        expect(mail.decoded.to_s).to include(item.name)
-        expect(mail.decoded.to_s).to include(workflow_comment)
+        expect(mail_body(mail)).to include(cms_user.name)
+        expect(mail_body(mail)).to include(item.name)
+        expect(mail_body(mail)).to include(workflow_comment)
       end
 
       login_user user, to: show_path
@@ -90,7 +90,7 @@ describe "member_photos", type: :feature, dbscope: :example, js: true do
         expect(mail.to.first).to eq cms_user.email
         expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include(item.name)
+        expect(mail_body(mail)).to include(item.name)
       end
     end
   end

--- a/spec/features/opendata/agents/nodes/mypage/app/my_app_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/app/my_app_spec.rb
@@ -208,9 +208,9 @@ describe "opendata_agents_nodes_my_app", type: :feature, dbscope: :example, js: 
       expect(ActionMailer::Base.deliveries.length).to eq 1
       ActionMailer::Base.deliveries.first.tap do |mail|
         expect(mail.to.first).to eq cms_user.email
-        expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(member.name)
+        expect(mail.decoded.to_s).to include(member.name)
         expect(mail.body.raw_source).to include(item_name)
         expect(mail.body.raw_source).to include(Opendata::App.first.private_show_path)
       end

--- a/spec/features/opendata/agents/nodes/mypage/app/my_app_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/app/my_app_spec.rb
@@ -210,9 +210,9 @@ describe "opendata_agents_nodes_my_app", type: :feature, dbscope: :example, js: 
         expect(mail.to.first).to eq cms_user.email
         expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include(member.name)
-        expect(mail.body.raw_source).to include(item_name)
-        expect(mail.body.raw_source).to include(Opendata::App.first.private_show_path)
+        expect(mail_body(mail)).to include(member.name)
+        expect(mail_body(mail)).to include(item_name)
+        expect(mail_body(mail)).to include(Opendata::App.first.private_show_path)
       end
 
       login_cms_user

--- a/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset/resources_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset/resources_spec.rb
@@ -154,7 +154,7 @@ describe "opendata_agents_nodes_my_dataset_resources", type: :feature, dbscope: 
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{dataset.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{dataset.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(member.name)
           expect(mail.body.raw_source).to include(dataset.name)

--- a/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset/resources_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset/resources_spec.rb
@@ -156,8 +156,8 @@ describe "opendata_agents_nodes_my_dataset_resources", type: :feature, dbscope: 
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{dataset.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(member.name)
-          expect(mail.body.raw_source).to include(dataset.name)
+          expect(mail_body(mail)).to include(member.name)
+          expect(mail_body(mail)).to include(dataset.name)
         end
 
         within "table.opendata-dataset-resources" do

--- a/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset_spec.rb
@@ -161,7 +161,7 @@ describe "opendata_agents_nodes_my_dataset", type: :feature, dbscope: :example, 
       expect(ActionMailer::Base.deliveries.length).to eq 1
       ActionMailer::Base.deliveries.first.tap do |mail|
         expect(mail.to.first).to eq cms_user.email
-        expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
         expect(mail.body.raw_source).to include(member.name)
         expect(mail.body.raw_source).to include(item_name)

--- a/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/dataset/my_dataset_spec.rb
@@ -163,9 +163,9 @@ describe "opendata_agents_nodes_my_dataset", type: :feature, dbscope: :example, 
         expect(mail.to.first).to eq cms_user.email
         expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(member.name)
-        expect(mail.body.raw_source).to include(item_name)
-        expect(mail.body.raw_source).to include(Opendata::Dataset.first.private_show_path)
+        expect(mail_body(mail)).to include(member.name)
+        expect(mail_body(mail)).to include(item_name)
+        expect(mail_body(mail)).to include(Opendata::Dataset.first.private_show_path)
       end
 
       login_cms_user

--- a/spec/features/opendata/agents/nodes/mypage/idea/my_idea_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/idea/my_idea_spec.rb
@@ -122,9 +122,9 @@ describe "opendata_agents_nodes_my_idea", type: :feature, dbscope: :example, js:
         expect(mail.to.first).to eq cms_user.email
         expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).to include(opendata_member(site: site).name)
-        expect(mail.body.raw_source).to include(item_name)
-        expect(mail.body.raw_source).to include(Opendata::Idea.first.private_show_path)
+        expect(mail_body(mail)).to include(opendata_member(site: site).name)
+        expect(mail_body(mail)).to include(item_name)
+        expect(mail_body(mail)).to include(Opendata::Idea.first.private_show_path)
       end
 
       login_cms_user

--- a/spec/features/opendata/agents/nodes/mypage/idea/my_idea_spec.rb
+++ b/spec/features/opendata/agents/nodes/mypage/idea/my_idea_spec.rb
@@ -120,9 +120,9 @@ describe "opendata_agents_nodes_my_idea", type: :feature, dbscope: :example, js:
       expect(ActionMailer::Base.deliveries.length).to eq 1
       ActionMailer::Base.deliveries.first.tap do |mail|
         expect(mail.to.first).to eq cms_user.email
-        expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item_name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(opendata_member(site: site).name)
+        expect(mail.decoded.to_s).to include(opendata_member(site: site).name)
         expect(mail.body.raw_source).to include(item_name)
         expect(mail.body.raw_source).to include(Opendata::Idea.first.private_show_path)
       end

--- a/spec/features/sys/diag/main_spec.rb
+++ b/spec/features/sys/diag/main_spec.rb
@@ -29,7 +29,7 @@ describe "sys_test", type: :feature, dbscope: :example do
       mail = ActionMailer::Base.deliveries.first
       expect(mail.from.first).to eq sys_user.email
       expect(mail.to.first).to eq sys_user.email
-      expect(mail.subject).to eq "TEST MAIL"
+      expect(mail_subject(mail)).to eq "TEST MAIL"
       expect(mail.decoded.to_s).to include("Message")
     end
   end

--- a/spec/features/sys/diag/main_spec.rb
+++ b/spec/features/sys/diag/main_spec.rb
@@ -30,7 +30,7 @@ describe "sys_test", type: :feature, dbscope: :example do
       expect(mail.from.first).to eq sys_user.email
       expect(mail.to.first).to eq sys_user.email
       expect(mail_subject(mail)).to eq "TEST MAIL"
-      expect(mail.decoded.to_s).to include("Message")
+      expect(mail_body(mail)).to include("Message")
     end
   end
 end

--- a/spec/features/webmail/gws_messages_spec.rb
+++ b/spec/features/webmail/gws_messages_spec.rb
@@ -43,9 +43,9 @@ describe "webmail_gws_messages", type: :feature, dbscope: :example, imap: true, 
         expect(ActionMailer::Base.deliveries).to have(1).items
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_title
+          expect(mail_subject(mail)).to eq item_title
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail.decoded.to_s).to include(item_texts.join("\r\n"))
         end
         webmail_import_mail(user, ActionMailer::Base.deliveries.first)
 

--- a/spec/features/webmail/gws_messages_spec.rb
+++ b/spec/features/webmail/gws_messages_spec.rb
@@ -45,7 +45,7 @@ describe "webmail_gws_messages", type: :feature, dbscope: :example, imap: true, 
           expect(mail.to.first).to eq user.email
           expect(mail_subject(mail)).to eq item_title
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
         webmail_import_mail(user, ActionMailer::Base.deliveries.first)
 

--- a/spec/features/webmail/mails/bcc_spec.rb
+++ b/spec/features/webmail/mails/bcc_spec.rb
@@ -79,9 +79,9 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.to.first).to eq user2.email
           expect(mail.cc.first).to eq user3.email
           expect(mail.bcc.first).to eq user4.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail.decoded.to_s).to include(item_texts.join("\r\n"))
         end
 
         # confirm sent box

--- a/spec/features/webmail/mails/bcc_spec.rb
+++ b/spec/features/webmail/mails/bcc_spec.rb
@@ -81,7 +81,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.bcc.first).to eq user4.email
           expect(mail_subject(mail)).to eq item_subject
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
 
         # confirm sent box

--- a/spec/features/webmail/mails/edit_as_new_spec.rb
+++ b/spec/features/webmail/mails/edit_as_new_spec.rb
@@ -59,10 +59,10 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.to).to include(address, *item_tos)
           expect(mail.cc).to have(item_ccs.length).items
           expect(mail.cc).to include(*item_ccs)
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.body.multipart?).to be_truthy
           expect(mail.body.parts).to have(3).items
-          expect(mail.body.parts[0].content_type).to eq "text/plain; charset=utf-8"
+          expect(mail.body.parts[0].content_type).to include "text/plain;"
           expect(mail.body.parts[0].decoded).to eq item_texts.join("\n") + "\n"
           expect(mail.body.parts[1].filename).to eq attachment1_name
           expect(mail.body.parts[1].content_type).to eq "image/png; filename=#{attachment1_name}"

--- a/spec/features/webmail/mails/eml_attachment_spec.rb
+++ b/spec/features/webmail/mails/eml_attachment_spec.rb
@@ -43,7 +43,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq address
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.multipart?).to be_truthy
           expect(mail.content_type).to include("multipart/mixed")
           expect(mail.parts.length).to eq 2

--- a/spec/features/webmail/mails/forward_spec.rb
+++ b/spec/features/webmail/mails/forward_spec.rb
@@ -63,7 +63,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.body.multipart?).to be_truthy
           expect(mail.body.parts).to have(3).items
           expect(mail.body.parts[0].content_type).to include "text/plain;"
-          expect(mail.body.parts[0].decoded).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
+          expect(mail_body(mail.body.parts[0])).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
           expect(mail.body.parts[1].filename).to eq attachment1_name
           expect(mail.body.parts[1].content_type).to eq "image/png; filename=#{attachment1_name}"
           expect(mail.body.parts[2].filename).to eq attachment2_name

--- a/spec/features/webmail/mails/forward_spec.rb
+++ b/spec/features/webmail/mails/forward_spec.rb
@@ -59,10 +59,10 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.to).to have(1).items
           expect(mail.to.first).to eq user.email
           expect(mail.cc).to be_nil
-          expect(mail.subject).to eq "Fw: #{item_subject}"
+          expect(mail_subject(mail)).to eq "Fw: #{item_subject}"
           expect(mail.body.multipart?).to be_truthy
           expect(mail.body.parts).to have(3).items
-          expect(mail.body.parts[0].content_type).to eq "text/plain; charset=utf-8"
+          expect(mail.body.parts[0].content_type).to include "text/plain;"
           expect(mail.body.parts[0].decoded).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
           expect(mail.body.parts[1].filename).to eq attachment1_name
           expect(mail.body.parts[1].content_type).to eq "image/png; filename=#{attachment1_name}"

--- a/spec/features/webmail/mails/html_spec.rb
+++ b/spec/features/webmail/mails/html_spec.rb
@@ -5,7 +5,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
     let(:user) { webmail_imap }
     let(:item) do
       mail = Mail.read(Rails.root.join("spec/fixtures/webmail/mail-3.eml"))
-      mail.subject = "#{mail.subject} - #{unique_id}"
+      mail.subject = "#{mail_subject(mail)} - #{unique_id}"
       mail
     end
 
@@ -48,10 +48,10 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
 
         expect(ActionMailer::Base.deliveries).to have(1).items
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq "Re: #{item.subject}"
+          expect(mail_subject(mail)).to eq "Re: #{item.subject}"
           expect(mail.content_type).to include("text/html")
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include("<b>test</b>")
+          expect(mail.decoded.to_s).to include("<b>test</b>")
         end
 
         visit index_path
@@ -72,7 +72,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
 
         expect(ActionMailer::Base.deliveries).to have(2).items
         ActionMailer::Base.deliveries.last.tap do |mail|
-          expect(mail.subject).to eq "Fw: #{item.subject}"
+          expect(mail_subject(mail)).to eq "Fw: #{item.subject}"
           expect(mail.content_type).to include("text/html")
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include("<b>test</b>")

--- a/spec/features/webmail/mails/html_spec.rb
+++ b/spec/features/webmail/mails/html_spec.rb
@@ -51,7 +51,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail_subject(mail)).to eq "Re: #{item.subject}"
           expect(mail.content_type).to include("text/html")
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include("<b>test</b>")
+          expect(mail_body(mail)).to include("<b>test</b>")
         end
 
         visit index_path
@@ -75,7 +75,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail_subject(mail)).to eq "Fw: #{item.subject}"
           expect(mail.content_type).to include("text/html")
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include("<b>test</b>")
+          expect(mail_body(mail)).to include("<b>test</b>")
         end
       end
     end

--- a/spec/features/webmail/mails/inlined_content_disposition_spec.rb
+++ b/spec/features/webmail/mails/inlined_content_disposition_spec.rb
@@ -5,7 +5,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true do
     let(:user) { webmail_imap }
     let(:item) do
       mail = Mail.read(Rails.root.join("spec/fixtures/webmail/inlined_content_disposition.eml"))
-      mail.subject = "#{mail.subject} - #{unique_id}"
+      mail.subject = "#{mail_subject(mail)} - #{unique_id}"
       mail
     end
 

--- a/spec/features/webmail/mails/mdn_spec.rb
+++ b/spec/features/webmail/mails/mdn_spec.rb
@@ -33,12 +33,12 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
       ActionMailer::Base.deliveries.first.tap do |mdn_reply_mail|
         expect(mdn_reply_mail.from.first).to eq mdn_mail.to.first
         expect(mdn_reply_mail.to.first).to eq mdn_mail[:disposition_notification_to].to_s
-        expect(mdn_reply_mail.subject).to eq "開封済み：#{mdn_mail.subject}"
+        expect(mail_subject(mdn_reply_mail)).to eq "開封済み：#{mdn_mail.subject}"
         expect(mdn_reply_mail.body.multipart?).to be_truthy
         expect(mdn_reply_mail.parts.length).to eq 3
         mdn_reply_mail.parts[0].tap do |part|
           expect(part.content_type).to include("text/plain")
-          body = part.body.raw_source.encode("UTF-8", "iso-2022-jp")
+          body = mail_body(part)
           expect(body).to include(mdn_mail.to.first, "メッセージが開封されました。", I18n.l(now, format: :picker))
         end
         mdn_reply_mail.parts[1].tap do |part|

--- a/spec/features/webmail/mails/new_file_attachment_spec.rb
+++ b/spec/features/webmail/mails/new_file_attachment_spec.rb
@@ -63,7 +63,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq address
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.multipart?).to be_truthy
           expect(mail.content_type).to include("multipart/mixed")
           expect(mail.parts.length).to eq 2

--- a/spec/features/webmail/mails/reply_all_spec.rb
+++ b/spec/features/webmail/mails/reply_all_spec.rb
@@ -61,7 +61,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.cc).to include(*item_ccs)
           expect(mail_subject(mail)).to eq "Re: #{item_subject}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
         end
       end
     end

--- a/spec/features/webmail/mails/reply_all_spec.rb
+++ b/spec/features/webmail/mails/reply_all_spec.rb
@@ -59,9 +59,9 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.to).not_to include(address)
           expect(mail.cc).to have(item_ccs.length).items
           expect(mail.cc).to include(*item_ccs)
-          expect(mail.subject).to eq "Re: #{item_subject}"
+          expect(mail_subject(mail)).to eq "Re: #{item_subject}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
+          expect(mail.decoded.to_s).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
         end
       end
     end

--- a/spec/features/webmail/mails/reply_spec.rb
+++ b/spec/features/webmail/mails/reply_spec.rb
@@ -41,7 +41,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true do
           expect(mail.cc).to be_nil
           expect(mail_subject(mail)).to eq "Re: #{item_subject}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
         end
       end
     end

--- a/spec/features/webmail/mails/reply_spec.rb
+++ b/spec/features/webmail/mails/reply_spec.rb
@@ -39,9 +39,9 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true do
           expect(mail.to).to have(1).items
           expect(mail.to.first).to eq item_from
           expect(mail.cc).to be_nil
-          expect(mail.subject).to eq "Re: #{item_subject}"
+          expect(mail_subject(mail)).to eq "Re: #{item_subject}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
+          expect(mail.decoded.to_s).to include(item_texts.map { |t| "> #{t}" }.join("\r\n"))
         end
       end
     end

--- a/spec/features/webmail/mails/send_spec.rb
+++ b/spec/features/webmail/mails/send_spec.rb
@@ -36,9 +36,9 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq address
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail.decoded.to_s).to include(item_texts.join("\r\n"))
         end
       end
     end

--- a/spec/features/webmail/mails/send_spec.rb
+++ b/spec/features/webmail/mails/send_spec.rb
@@ -38,7 +38,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
           expect(mail.to.first).to eq user.email
           expect(mail_subject(mail)).to eq item_subject
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.decoded.to_s).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end

--- a/spec/features/webmail/mails/sjis_attachment_spec.rb
+++ b/spec/features/webmail/mails/sjis_attachment_spec.rb
@@ -47,7 +47,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq address
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.multipart?).to be_truthy
           expect(mail.parts.length).to eq 2
           expect(mail.parts[0].body.raw_source).to include(item_texts.join("\r\n"))

--- a/spec/features/webmail/mails/unk_ext_attachment_spec.rb
+++ b/spec/features/webmail/mails/unk_ext_attachment_spec.rb
@@ -51,7 +51,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq address
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.multipart?).to be_truthy
           expect(mail.parts.length).to eq 2
           expect(mail.parts[0].body.raw_source).to include(item_texts.join("\r\n"))

--- a/spec/features/webmail/mails/user_file_attachment_spec.rb
+++ b/spec/features/webmail/mails/user_file_attachment_spec.rb
@@ -82,7 +82,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq address
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.multipart?).to be_truthy
           expect(mail.content_type).to include("multipart/mixed")
           expect(mail.parts.length).to eq 2

--- a/spec/features/webmail/mails/zip_attachment_spec.rb
+++ b/spec/features/webmail/mails/zip_attachment_spec.rb
@@ -47,7 +47,7 @@ describe "webmail_mails", type: :feature, dbscope: :example, imap: true, js: tru
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq address
           expect(mail.to.first).to eq user.email
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.multipart?).to be_truthy
           expect(mail.parts.length).to eq 2
           expect(mail.parts[0].body.raw_source).to include(item_texts.join("\r\n"))

--- a/spec/features/webmail/multi_checkbox_spec.rb
+++ b/spec/features/webmail/multi_checkbox_spec.rb
@@ -81,7 +81,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(address3.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -144,7 +144,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(address1.email, address2.email, address3.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -184,7 +184,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(address1.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -247,7 +247,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(user3.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -310,7 +310,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(user1.email, user2.email, user3.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -350,7 +350,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(user1.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -422,7 +422,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(address3.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -485,7 +485,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(address1.email, address2.email, address3.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end
@@ -525,7 +525,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
             expect(addresses).to include(address1.email)
           end
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item_texts.join("\r\n"))
+          expect(mail_body(mail)).to include(item_texts.join("\r\n"))
         end
       end
     end

--- a/spec/features/webmail/multi_checkbox_spec.rb
+++ b/spec/features/webmail/multi_checkbox_spec.rb
@@ -66,7 +66,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(1).items
@@ -129,7 +129,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(3).items
@@ -177,7 +177,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(1).items
@@ -232,7 +232,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(1).items
@@ -295,7 +295,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have_at_least(3).items
@@ -343,7 +343,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(1).items
@@ -407,7 +407,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(1).items
@@ -470,7 +470,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(3).items
@@ -518,7 +518,7 @@ describe 'webmail_multi_heckbox', type: :feature, dbscope: :example, imap: true,
 
         expect(ActionMailer::Base.deliveries.length).to eq 1
         ActionMailer::Base.deliveries.first.tap do |mail|
-          expect(mail.subject).to eq item_subject
+          expect(mail_subject(mail)).to eq item_subject
           expect(mail.from.first).to eq user.email
           mail.to.map(&:to_s).tap do |addresses|
             expect(addresses).to have(1).items

--- a/spec/features/workflow/close_page_spec.rb
+++ b/spec/features/workflow/close_page_spec.rb
@@ -69,7 +69,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq cms_user.email
         expect(mail.to.first).to eq user1.email
-        expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
         expect(mail.body.raw_source).to include(cms_user.name)
         expect(mail.body.raw_source).to include(item.name)
@@ -106,7 +106,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
       ActionMailer::Base.deliveries.last.tap do |mail|
         expect(mail.from.first).to eq user1.email
         expect(mail.to.first).to eq cms_user.email
-        expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+        expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
         expect(mail.body.raw_source).to include(item.name)
       end

--- a/spec/features/workflow/close_page_spec.rb
+++ b/spec/features/workflow/close_page_spec.rb
@@ -71,9 +71,9 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(mail.to.first).to eq user1.email
         expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(cms_user.name)
-        expect(mail.body.raw_source).to include(item.name)
-        expect(mail.body.raw_source).to include(workflow_comment)
+        expect(mail_body(mail)).to include(cms_user.name)
+        expect(mail_body(mail)).to include(item.name)
+        expect(mail_body(mail)).to include(workflow_comment)
       end
 
       #
@@ -108,7 +108,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         expect(mail.to.first).to eq cms_user.email
         expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source).to include(item.name)
+        expect(mail_body(mail)).to include(item.name)
       end
     end
   end

--- a/spec/features/workflow/multi_stage_spec.rb
+++ b/spec/features/workflow/multi_stage_spec.rb
@@ -94,9 +94,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user1.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -142,9 +142,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user2.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -191,9 +191,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user3.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -241,7 +241,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item.name)
+          expect(mail_body(mail)).to include(item.name)
         end
       end
     end
@@ -299,18 +299,18 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user1.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
         ActionMailer::Base.deliveries.find { |mail| mail.to.first == user2.email }.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user2.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -379,9 +379,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user3.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -421,7 +421,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item.name)
+          expect(mail_body(mail)).to include(item.name)
         end
       end
     end
@@ -487,9 +487,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user1.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -534,9 +534,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user2.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -582,9 +582,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user3.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -631,9 +631,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(user3.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(remand_comment3)
+          expect(mail_body(mail)).to include(user3.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(remand_comment3)
         end
       end
     end
@@ -693,18 +693,18 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user1.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
         ActionMailer::Base.deliveries.find{ |mail| mail.to.first == user2.email }.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user2.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -743,9 +743,9 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user3.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -785,7 +785,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item.name)
+          expect(mail_body(mail)).to include(item.name)
         end
       end
     end

--- a/spec/features/workflow/multi_stage_spec.rb
+++ b/spec/features/workflow/multi_stage_spec.rb
@@ -92,7 +92,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user1.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -140,7 +140,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user2.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -189,7 +189,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user3.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -239,7 +239,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user3.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(item.name)
         end
@@ -297,7 +297,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.find { |mail| mail.to.first == user1.email }.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user1.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -306,7 +306,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.find { |mail| mail.to.first == user2.email }.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user2.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -377,7 +377,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user3.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -419,7 +419,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user3.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(item.name)
         end
@@ -485,7 +485,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user1.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -532,7 +532,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user2.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -580,7 +580,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user3.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -629,7 +629,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user3.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(user3.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -691,7 +691,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.find{ |mail| mail.to.first == user1.email }.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user1.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -700,7 +700,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.find{ |mail| mail.to.first == user2.email }.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user2.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -741,7 +741,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user3.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -783,7 +783,7 @@ describe "multi_stage", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user3.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(item.name)
         end

--- a/spec/features/workflow/my_group_spec.rb
+++ b/spec/features/workflow/my_group_spec.rb
@@ -85,18 +85,18 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
         ActionMailer::Base.deliveries.second.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         History::Log.unscoped.reorder(_id: -1).first.tap do |log|
@@ -205,7 +205,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item.name)
+          expect(mail_body(mail)).to include(item.name)
         end
 
         History::Log.unscoped.reorder(_id: -1).first.tap do |log|
@@ -273,18 +273,18 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
         ActionMailer::Base.deliveries.second.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         History::Log.unscoped.reorder(_id: -1).first.tap do |log|
@@ -341,9 +341,9 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(remand_comment1)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(remand_comment1)
         end
 
         History::Log.unscoped.reorder(_id: -1).first.tap do |log|
@@ -514,9 +514,9 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(remand_comment2)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(remand_comment2)
         end
 
         History::Log.unscoped.reorder(_id: -1).first.tap do |log|

--- a/spec/features/workflow/my_group_spec.rb
+++ b/spec/features/workflow/my_group_spec.rb
@@ -83,7 +83,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -92,7 +92,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.second.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -203,7 +203,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user2.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(item.name)
         end
@@ -271,7 +271,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.first.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -280,7 +280,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.second.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq(user1.email).or(eq(user2.email))
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -339,7 +339,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user1.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -512,7 +512,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user2.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.remand')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)

--- a/spec/features/workflow/release_page_spec.rb
+++ b/spec/features/workflow/release_page_spec.rb
@@ -67,7 +67,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq cms_user.email
           expect(mail.to.first).to eq user1.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(cms_user.name)
           expect(mail.body.raw_source).to include(item.name)
@@ -102,7 +102,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
         ActionMailer::Base.deliveries.last.tap do |mail|
           expect(mail.from.first).to eq user1.email
           expect(mail.to.first).to eq cms_user.email
-          expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+          expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
           expect(mail.body.raw_source).to include(item.name)
         end
@@ -166,7 +166,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           ActionMailer::Base.deliveries.last.tap do |mail|
             expect(mail.from.first).to eq cms_user.email
             expect(mail.to.first).to eq user1.email
-            expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
+            expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
             expect(mail.body.multipart?).to be_falsey
             expect(mail.body.raw_source).to include(cms_user.name)
             expect(mail.body.raw_source).to include(item.name)
@@ -201,7 +201,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           ActionMailer::Base.deliveries.last.tap do |mail|
             expect(mail.from.first).to eq user1.email
             expect(mail.to.first).to eq cms_user.email
-            expect(mail.subject).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
+            expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
             expect(mail.body.multipart?).to be_falsey
             expect(mail.body.raw_source).to include(item.name)
           end

--- a/spec/features/workflow/release_page_spec.rb
+++ b/spec/features/workflow/release_page_spec.rb
@@ -69,9 +69,9 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq user1.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(cms_user.name)
-          expect(mail.body.raw_source).to include(item.name)
-          expect(mail.body.raw_source).to include(workflow_comment)
+          expect(mail_body(mail)).to include(cms_user.name)
+          expect(mail_body(mail)).to include(item.name)
+          expect(mail_body(mail)).to include(workflow_comment)
         end
 
         #
@@ -104,7 +104,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
           expect(mail.to.first).to eq cms_user.email
           expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
           expect(mail.body.multipart?).to be_falsey
-          expect(mail.body.raw_source).to include(item.name)
+          expect(mail_body(mail)).to include(item.name)
         end
 
         expect do
@@ -168,9 +168,9 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             expect(mail.to.first).to eq user1.email
             expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.request')}]#{item.name} - #{site.name}"
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.body.raw_source).to include(cms_user.name)
-            expect(mail.body.raw_source).to include(item.name)
-            expect(mail.body.raw_source).to include(workflow_comment)
+            expect(mail_body(mail)).to include(cms_user.name)
+            expect(mail_body(mail)).to include(item.name)
+            expect(mail_body(mail)).to include(workflow_comment)
           end
 
           #
@@ -203,7 +203,7 @@ describe "my_group", type: :feature, dbscope: :example, js: true do
             expect(mail.to.first).to eq cms_user.email
             expect(mail_subject(mail)).to eq "[#{I18n.t('workflow.mail.subject.approve')}]#{item.name} - #{site.name}"
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.body.raw_source).to include(item.name)
+            expect(mail_body(mail)).to include(item.name)
           end
 
           expect do

--- a/spec/jobs/cms/check_links_job_spec.rb
+++ b/spec/jobs/cms/check_links_job_spec.rb
@@ -97,14 +97,14 @@ describe Cms::CheckLinksJob, dbscope: :example do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.check_links_default_sender_address
         expect(mail.to.first).to eq email1
-        expect(mail.subject).to eq "[#{site.name}] Link Check: 3 errors"
-        expect(mail.body.raw_source).to include "[3 errors]"
-        expect(mail.body.raw_source).to include "#{site_url}/"
-        expect(mail.body.raw_source).to include "  - #{site_url}/notfound1.html"
-        expect(mail.body.raw_source).to include "#{site_url}/index.html"
-        expect(mail.body.raw_source).to include "  - #{site_url}/notfound1.html"
-        expect(mail.body.raw_source).to include "#{site_url}/docs/page1.html"
-        expect(mail.body.raw_source).to include "  - #{site_url}/notfound2.html"
+        expect(mail_subject(mail)).to eq "[#{site.name}] Link Check: 3 errors"
+        expect(mail.decoded.to_s).to include "[3 errors]"
+        expect(mail.decoded.to_s).to include "#{site_url}/"
+        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
+        expect(mail.decoded.to_s).to include "#{site_url}/index.html"
+        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
+        expect(mail.decoded.to_s).to include "#{site_url}/docs/page1.html"
+        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound2.html"
       end
     end
 
@@ -125,7 +125,7 @@ describe Cms::CheckLinksJob, dbscope: :example do
         expect(mail.from.first).to eq site.check_links_default_sender_address
         expect(mail.to.first).to eq email1
 
-        expect(mail.subject).to eq "[#{site.name}] Link Check: 3 errors"
+        expect(mail_subject(mail)).to eq "[#{site.name}] Link Check: 3 errors"
         expect(mail.multipart?).to be_truthy
         expect(mail.parts[0].body.raw_source).to include "[3 errors]"
         expect(mail.parts[0].body.raw_source).to include "error details are in the attached csv"
@@ -157,14 +157,14 @@ describe Cms::CheckLinksJob, dbscope: :example do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.from.first).to eq site.check_links_default_sender_address
         expect(mail.to.first).to eq email2
-        expect(mail.subject).to eq "[#{site.name}] Link Check: 3 errors"
-        expect(mail.body.raw_source).to include "[3 errors]"
-        expect(mail.body.raw_source).to include "#{site_url}/"
-        expect(mail.body.raw_source).to include "  - #{site_url}/notfound1.html"
-        expect(mail.body.raw_source).to include "#{site_url}/index.html"
-        expect(mail.body.raw_source).to include "  - #{site_url}/notfound1.html"
-        expect(mail.body.raw_source).to include "#{site_url}/docs/page1.html"
-        expect(mail.body.raw_source).to include "  - #{site_url}/notfound2.html"
+        expect(mail_subject(mail)).to eq "[#{site.name}] Link Check: 3 errors"
+        expect(mail.decoded.to_s).to include "[3 errors]"
+        expect(mail.decoded.to_s).to include "#{site_url}/"
+        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
+        expect(mail.decoded.to_s).to include "#{site_url}/index.html"
+        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
+        expect(mail.decoded.to_s).to include "#{site_url}/docs/page1.html"
+        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound2.html"
       end
     end
   end

--- a/spec/jobs/cms/check_links_job_spec.rb
+++ b/spec/jobs/cms/check_links_job_spec.rb
@@ -98,13 +98,13 @@ describe Cms::CheckLinksJob, dbscope: :example do
         expect(mail.from.first).to eq site.check_links_default_sender_address
         expect(mail.to.first).to eq email1
         expect(mail_subject(mail)).to eq "[#{site.name}] Link Check: 3 errors"
-        expect(mail.decoded.to_s).to include "[3 errors]"
-        expect(mail.decoded.to_s).to include "#{site_url}/"
-        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
-        expect(mail.decoded.to_s).to include "#{site_url}/index.html"
-        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
-        expect(mail.decoded.to_s).to include "#{site_url}/docs/page1.html"
-        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound2.html"
+        expect(mail_body(mail)).to include "[3 errors]"
+        expect(mail_body(mail)).to include "#{site_url}/"
+        expect(mail_body(mail)).to include "  - #{site_url}/notfound1.html"
+        expect(mail_body(mail)).to include "#{site_url}/index.html"
+        expect(mail_body(mail)).to include "  - #{site_url}/notfound1.html"
+        expect(mail_body(mail)).to include "#{site_url}/docs/page1.html"
+        expect(mail_body(mail)).to include "  - #{site_url}/notfound2.html"
       end
     end
 
@@ -158,13 +158,13 @@ describe Cms::CheckLinksJob, dbscope: :example do
         expect(mail.from.first).to eq site.check_links_default_sender_address
         expect(mail.to.first).to eq email2
         expect(mail_subject(mail)).to eq "[#{site.name}] Link Check: 3 errors"
-        expect(mail.decoded.to_s).to include "[3 errors]"
-        expect(mail.decoded.to_s).to include "#{site_url}/"
-        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
-        expect(mail.decoded.to_s).to include "#{site_url}/index.html"
-        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound1.html"
-        expect(mail.decoded.to_s).to include "#{site_url}/docs/page1.html"
-        expect(mail.decoded.to_s).to include "  - #{site_url}/notfound2.html"
+        expect(mail_body(mail)).to include "[3 errors]"
+        expect(mail_body(mail)).to include "#{site_url}/"
+        expect(mail_body(mail)).to include "  - #{site_url}/notfound1.html"
+        expect(mail_body(mail)).to include "#{site_url}/index.html"
+        expect(mail_body(mail)).to include "  - #{site_url}/notfound1.html"
+        expect(mail_body(mail)).to include "#{site_url}/docs/page1.html"
+        expect(mail_body(mail)).to include "  - #{site_url}/notfound2.html"
       end
     end
   end

--- a/spec/jobs/cms/page/expiration_notice_job_spec.rb
+++ b/spec/jobs/cms/page/expiration_notice_job_spec.rb
@@ -84,8 +84,8 @@ describe Cms::Page::ExpirationNoticeJob, dbscope: :example do
           expect(mail).not_to be_nil
           expect(mail.from.first).to eq SS.config.mail.default_from
           expect(mail_subject(mail)).to eq I18n.t("cms.page_expiration_mail.default_subject")
-          expect(mail.decoded.to_s).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
-          expect(mail.decoded.to_s).to include(page2.name, page2.private_show_path)
+          expect(mail_body(mail)).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
+          expect(mail_body(mail)).to include(page2.name, page2.private_show_path)
         end
       end
     end
@@ -120,8 +120,8 @@ describe Cms::Page::ExpirationNoticeJob, dbscope: :example do
           expect(mail).not_to be_nil
           expect(mail.from.first).to eq SS.config.mail.default_from
           expect(mail_subject(mail)).to eq I18n.t("cms.page_expiration_mail.default_subject")
-          expect(mail.body.raw_source).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
-          expect(mail.body.raw_source).to include(page2.name, page2.private_show_path)
+          expect(mail_body(mail)).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
+          expect(mail_body(mail)).to include(page2.name, page2.private_show_path)
         end
       end
     end
@@ -156,8 +156,8 @@ describe Cms::Page::ExpirationNoticeJob, dbscope: :example do
           expect(mail).not_to be_nil
           expect(mail.from.first).to eq SS.config.mail.default_from
           expect(mail_subject(mail)).to eq I18n.t("cms.page_expiration_mail.default_subject")
-          expect(mail.body.raw_source).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
-          expect(mail.body.raw_source).to include(page2.name, page2.private_show_path)
+          expect(mail_body(mail)).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
+          expect(mail_body(mail)).to include(page2.name, page2.private_show_path)
         end
       end
     end

--- a/spec/jobs/cms/page/expiration_notice_job_spec.rb
+++ b/spec/jobs/cms/page/expiration_notice_job_spec.rb
@@ -83,9 +83,9 @@ describe Cms::Page::ExpirationNoticeJob, dbscope: :example do
         ActionMailer::Base.deliveries.each do |mail|
           expect(mail).not_to be_nil
           expect(mail.from.first).to eq SS.config.mail.default_from
-          expect(mail.subject).to eq I18n.t("cms.page_expiration_mail.default_subject")
-          expect(mail.body.raw_source).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
-          expect(mail.body.raw_source).to include(page2.name, page2.private_show_path)
+          expect(mail_subject(mail)).to eq I18n.t("cms.page_expiration_mail.default_subject")
+          expect(mail.decoded.to_s).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
+          expect(mail.decoded.to_s).to include(page2.name, page2.private_show_path)
         end
       end
     end
@@ -119,7 +119,7 @@ describe Cms::Page::ExpirationNoticeJob, dbscope: :example do
         ActionMailer::Base.deliveries.each do |mail|
           expect(mail).not_to be_nil
           expect(mail.from.first).to eq SS.config.mail.default_from
-          expect(mail.subject).to eq I18n.t("cms.page_expiration_mail.default_subject")
+          expect(mail_subject(mail)).to eq I18n.t("cms.page_expiration_mail.default_subject")
           expect(mail.body.raw_source).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
           expect(mail.body.raw_source).to include(page2.name, page2.private_show_path)
         end
@@ -155,7 +155,7 @@ describe Cms::Page::ExpirationNoticeJob, dbscope: :example do
         ActionMailer::Base.deliveries.each do |mail|
           expect(mail).not_to be_nil
           expect(mail.from.first).to eq SS.config.mail.default_from
-          expect(mail.subject).to eq I18n.t("cms.page_expiration_mail.default_subject")
+          expect(mail_subject(mail)).to eq I18n.t("cms.page_expiration_mail.default_subject")
           expect(mail.body.raw_source).to include(*I18n.t("cms.page_expiration_mail.default_upper_text"))
           expect(mail.body.raw_source).to include(page2.name, page2.private_show_path)
         end

--- a/spec/jobs/ezine/deliver_reserved_job_spec.rb
+++ b/spec/jobs/ezine/deliver_reserved_job_spec.rb
@@ -64,7 +64,7 @@ describe Ezine::DeliverReservedJob, dbscope: :example do
     end
     expect(ActionMailer::Base.deliveries.length).to eq 2
     ActionMailer::Base.deliveries[0].tap do |mail|
-      expect(mail.subject).to eq page1.name
+      expect(mail_subject(mail)).to eq page1.name
       expect(mail.from).to have(1).items
       expect(mail.from).to include(node.sender_email)
       expect(mail.to).to have(1).items
@@ -72,7 +72,7 @@ describe Ezine::DeliverReservedJob, dbscope: :example do
       expect(mail.bcc).to be_blank
     end
     ActionMailer::Base.deliveries[1].tap do |mail|
-      expect(mail.subject).to eq page1.name
+      expect(mail_subject(mail)).to eq page1.name
       expect(mail.from).to have(1).items
       expect(mail.from).to include(node.sender_email)
       expect(mail.to).to have(1).items
@@ -96,7 +96,7 @@ describe Ezine::DeliverReservedJob, dbscope: :example do
     end
     expect(ActionMailer::Base.deliveries.length).to eq 4
     ActionMailer::Base.deliveries[2].tap do |mail|
-      expect(mail.subject).to eq page2.name
+      expect(mail_subject(mail)).to eq page2.name
       expect(mail.from).to have(1).items
       expect(mail.from).to include(node.sender_email)
       expect(mail.to).to have(1).items
@@ -104,7 +104,7 @@ describe Ezine::DeliverReservedJob, dbscope: :example do
       expect(mail.bcc).to be_blank
     end
     ActionMailer::Base.deliveries[3].tap do |mail|
-      expect(mail.subject).to eq page2.name
+      expect(mail_subject(mail)).to eq page2.name
       expect(mail.from).to have(1).items
       expect(mail.from).to include(node.sender_email)
       expect(mail.to).to have(1).items

--- a/spec/jobs/gws/memo/message_export_job_spec.rb
+++ b/spec/jobs/gws/memo/message_export_job_spec.rb
@@ -60,7 +60,7 @@ describe Gws::Memo::MessageExportJob, dbscope: :example do
           expect(mail.message_id.to_s).to eq "#{message.id}@#{canonical_domain}"
           expect(mail.sender).to be_nil
           expect(mail.date.to_s).to eq message.created.to_s
-          expect(mail.subject).to eq message.subject
+          expect(mail_subject(mail)).to eq message.subject
           expect(mail.mime_type).to eq "text/plain"
           expect(mail.multipart?).to be_falsey
           mail[:from].to_s.tap do |rfc2822_address|
@@ -170,7 +170,7 @@ describe Gws::Memo::MessageExportJob, dbscope: :example do
         expect(mail.message_id.to_s).to eq "#{message.id}@#{canonical_domain}"
         expect(mail.sender).to be_nil
         expect(mail.date.to_s).to eq message.created.to_s
-        expect(mail.subject).to eq message.subject
+        expect(mail_subject(mail)).to eq message.subject
         expect(mail.mime_type).to eq "text/plain"
         expect(mail.multipart?).to be_falsey
         mail[:from].to_s.tap do |rfc2822_address|
@@ -244,7 +244,7 @@ describe Gws::Memo::MessageExportJob, dbscope: :example do
         expect(mail.message_id.to_s).to eq "#{message.id}@#{canonical_domain}"
         expect(mail.sender).to be_nil
         expect(mail.date.to_s).to eq message.created.to_s
-        expect(mail.subject).to eq message.subject
+        expect(mail_subject(mail)).to eq message.subject
         expect(mail.mime_type).to eq "text/plain"
         expect(mail.multipart?).to be_falsey
         mail[:from].to_s.tap do |rfc2822_address|
@@ -308,7 +308,7 @@ describe Gws::Memo::MessageExportJob, dbscope: :example do
         expect(mail.message_id.to_s).to eq "#{message.id}@#{canonical_domain}"
         expect(mail.sender).to be_nil
         expect(mail.date.to_s).to eq message.created.to_s
-        expect(mail.subject).to eq message.subject
+        expect(mail_subject(mail)).to eq message.subject
         expect(mail.mime_type).to eq "multipart/mixed"
         expect(mail.multipart?).to be_truthy
         mail[:from].to_s.tap do |rfc2822_address|
@@ -380,7 +380,7 @@ describe Gws::Memo::MessageExportJob, dbscope: :example do
         expect(mail.message_id.to_s).to eq "#{message.id}@#{canonical_domain}"
         expect(mail.sender).to be_nil
         expect(mail.date.to_s).to eq message.created.to_s
-        expect(mail.subject).to eq message.subject
+        expect(mail_subject(mail)).to eq message.subject
         expect(mail.mime_type).to eq "text/plain"
         expect(mail.multipart?).to be_falsey
         mail[:from].to_s.tap do |rfc2822_address|
@@ -437,7 +437,7 @@ describe Gws::Memo::MessageExportJob, dbscope: :example do
         expect(mail.message_id.to_s).to eq "#{message.id}@#{canonical_domain}"
         expect(mail.sender).to be_nil
         expect(mail.date.to_s).to eq message.created.to_s
-        expect(mail.subject).to eq message.subject
+        expect(mail_subject(mail)).to eq message.subject
         expect(mail.mime_type).to eq "text/plain"
         expect(mail.multipart?).to be_falsey
         mail[:from].to_s.tap do |rfc2822_address|

--- a/spec/jobs/gws/notice/notification_job_spec.rb
+++ b/spec/jobs/gws/notice/notification_job_spec.rb
@@ -80,7 +80,7 @@ describe Gws::Notice::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq site.sender_email
         expect(notify_mail.bcc.first).to eq recipient1.email
-        expect(notify_mail.subject).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
+        expect(notify_mail_subject(mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("/.g#{site.id}/memo/notices/#{notice.id}")
       end
@@ -124,7 +124,7 @@ describe Gws::Notice::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq site.sender_email
         expect(notify_mail.bcc.first).to eq recipient1.email
-        expect(notify_mail.subject).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
+        expect(notify_mail_subject(mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("/.g#{site.id}/memo/notices/#{notice.id}")
       end
@@ -192,7 +192,7 @@ describe Gws::Notice::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq site.sender_email
         expect(notify_mail.bcc.first).not_to be_nil
-        expect(notify_mail.subject).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
+        expect(notify_mail_subject(mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("/.g#{site.id}/memo/notices/#{notice.id}")
       end

--- a/spec/jobs/gws/notice/notification_job_spec.rb
+++ b/spec/jobs/gws/notice/notification_job_spec.rb
@@ -80,9 +80,9 @@ describe Gws::Notice::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq site.sender_email
         expect(notify_mail.bcc.first).to eq recipient1.email
-        expect(notify_mail_subject(mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
+        expect(mail_subject(notify_mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("/.g#{site.id}/memo/notices/#{notice.id}")
+        expect(mail_body(notify_mail)).to include("/.g#{site.id}/memo/notices/#{notice.id}")
       end
     end
   end
@@ -124,9 +124,9 @@ describe Gws::Notice::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq site.sender_email
         expect(notify_mail.bcc.first).to eq recipient1.email
-        expect(notify_mail_subject(mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
+        expect(mail_subject(notify_mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("/.g#{site.id}/memo/notices/#{notice.id}")
+        expect(mail_body(notify_mail)).to include("/.g#{site.id}/memo/notices/#{notice.id}")
       end
     end
   end
@@ -192,9 +192,9 @@ describe Gws::Notice::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq site.sender_email
         expect(notify_mail.bcc.first).not_to be_nil
-        expect(notify_mail_subject(mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
+        expect(mail_subject(notify_mail)).to eq I18n.t('gws_notification.gws/notice/post.subject', name: notice.name)
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("/.g#{site.id}/memo/notices/#{notice.id}")
+        expect(mail_body(notify_mail)).to include("/.g#{site.id}/memo/notices/#{notice.id}")
       end
     end
   end

--- a/spec/jobs/gws/reminder/notification/mail_job_spec.rb
+++ b/spec/jobs/gws/reminder/notification/mail_job_spec.rb
@@ -41,7 +41,7 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq default_from
         expect(notify_mail.to.first).to eq reminder.user.email
-        expect(notify_mail.subject).to eq "[リマインダー] スケジュール - #{schedule.name}"
+        expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
         expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
@@ -79,7 +79,7 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq default_from
         expect(notify_mail.to.first).to eq reminder.user.email
-        expect(notify_mail.subject).to eq "[リマインダー] スケジュール - #{schedule.name}"
+        expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
         expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
@@ -118,7 +118,7 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq sender_email
         expect(notify_mail.to.first).to eq reminder.user.email
-        expect(notify_mail.subject).to eq "[リマインダー] スケジュール - #{schedule.name}"
+        expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
         expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
@@ -146,7 +146,7 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
       ActionMailer::Base.deliveries.first.tap do |notify_mail|
         expect(notify_mail.from.first).to eq default_from
         expect(notify_mail.to.first).to eq reminder.user.email
-        expect(notify_mail.subject).to eq "[リマインダー] スケジュール - #{schedule.name}"
+        expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
         expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
         expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")

--- a/spec/jobs/gws/reminder/notification/mail_job_spec.rb
+++ b/spec/jobs/gws/reminder/notification/mail_job_spec.rb
@@ -43,10 +43,10 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
         expect(notify_mail.to.first).to eq reminder.user.email
         expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
-        expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
-        expect(notify_mail.body.raw_source).to include("[参加ユーザー]\r\n")
-        expect(notify_mail.body.raw_source).to include(schedule.members.first.long_name)
+        expect(mail_body(notify_mail)).to include("[タイトル] #{schedule.name}")
+        expect(mail_body(notify_mail)).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
+        expect(mail_body(notify_mail)).to include("[参加ユーザー]\r\n")
+        expect(mail_body(notify_mail)).to include(schedule.members.first.long_name)
       end
     end
 
@@ -81,10 +81,10 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
         expect(notify_mail.to.first).to eq reminder.user.email
         expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
-        expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
-        expect(notify_mail.body.raw_source).to include("[参加ユーザー]\r\n")
-        expect(notify_mail.body.raw_source).to include(schedule.members.first.long_name)
+        expect(mail_body(notify_mail)).to include("[タイトル] #{schedule.name}")
+        expect(mail_body(notify_mail)).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
+        expect(mail_body(notify_mail)).to include("[参加ユーザー]\r\n")
+        expect(mail_body(notify_mail)).to include(schedule.members.first.long_name)
       end
 
       expect(Gws::Job::Log.count).to eq 2
@@ -120,10 +120,10 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
         expect(notify_mail.to.first).to eq reminder.user.email
         expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
-        expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
-        expect(notify_mail.body.raw_source).to include("[参加ユーザー]\r\n")
-        expect(notify_mail.body.raw_source).to include(schedule.members.first.long_name)
+        expect(mail_body(notify_mail)).to include("[タイトル] #{schedule.name}")
+        expect(mail_body(notify_mail)).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
+        expect(mail_body(notify_mail)).to include("[参加ユーザー]\r\n")
+        expect(mail_body(notify_mail)).to include(schedule.members.first.long_name)
       end
     end
   end
@@ -148,10 +148,10 @@ describe Gws::Reminder::NotificationJob, dbscope: :example do
         expect(notify_mail.to.first).to eq reminder.user.email
         expect(mail_subject(notify_mail)).to eq "[リマインダー] スケジュール - #{schedule.name}"
         expect(notify_mail.body.multipart?).to be_falsey
-        expect(notify_mail.body.raw_source).to include("[タイトル] #{schedule.name}")
-        expect(notify_mail.body.raw_source).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
-        expect(notify_mail.body.raw_source).to include("[参加ユーザー]\r\n")
-        expect(notify_mail.body.raw_source).to include(schedule.members.first.long_name)
+        expect(mail_body(notify_mail)).to include("[タイトル] #{schedule.name}")
+        expect(mail_body(notify_mail)).to include("[日時] #{I18n.l(schedule.start_at.to_date, format: :gws_long)}")
+        expect(mail_body(notify_mail)).to include("[参加ユーザー]\r\n")
+        expect(mail_body(notify_mail)).to include(schedule.members.first.long_name)
       end
     end
   end

--- a/spec/jobs/opendata/notify_dataset_plan_job_spec.rb
+++ b/spec/jobs/opendata/notify_dataset_plan_job_spec.rb
@@ -113,8 +113,8 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(today) do
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
       end
     end
 
@@ -198,7 +198,7 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(today.tomorrow) do
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset.private_show_path)
+        expect(mail_body(mail)).to include(dataset.private_show_path)
       end
     end
 
@@ -337,11 +337,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
 
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -356,11 +356,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
 
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).to include(dataset2.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -375,11 +375,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
 
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
   end
@@ -502,11 +502,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2019/2/28")) do #2019/2/28
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path) #2019/2/28
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path) #2019/3/31
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path) #2020/1/31
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path) #2019/2/28
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path) #2019/3/31
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path) #2020/1/31
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -520,11 +520,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2019/3/28")) do #2019/3/28
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path) #2019/2/28
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path) #2019/3/31
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path) #2020/1/31
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path) #2019/2/28
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path) #2019/3/31
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path) #2020/1/31
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
 
       ActionMailer::Base.deliveries.clear
@@ -532,11 +532,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2019/3/31")) do #2019/3/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).not_to include(dataset1.private_show_path) #2019/2/28
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path) #2019/3/31
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path) #2020/1/31
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset1.private_show_path) #2019/2/28
+        expect(mail_body(mail)).to include(dataset2.private_show_path) #2019/3/31
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path) #2020/1/31
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -550,11 +550,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2020/1/28")) do #2020/1/28
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path) #2019/2/28
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path) #2019/3/31
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path) #2020/1/31
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path) #2019/2/28
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path) #2019/3/31
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path) #2020/1/31
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
 
       ActionMailer::Base.deliveries.clear
@@ -562,11 +562,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2020/1/31")) do #2020/1/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).not_to include(dataset1.private_show_path) #2019/2/28
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path) #2019/3/31
-        expect(mail.decoded.to_s).to include(dataset3.private_show_path) #2020/1/31
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset1.private_show_path) #2019/2/28
+        expect(mail_body(mail)).to include(dataset2.private_show_path) #2019/3/31
+        expect(mail_body(mail)).to include(dataset3.private_show_path) #2020/1/31
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -580,11 +580,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2020/2/28")) do #2020/2/28
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path) #2019/2/28
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path) #2019/3/31
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path) #2020/1/31
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path) #2019/2/28
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path) #2019/3/31
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path) #2020/1/31
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
 
       ActionMailer::Base.deliveries.clear
@@ -592,11 +592,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2020/2/29")) do #2020/2/29
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).not_to include(dataset1.private_show_path) #2019/2/28
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path) #2019/3/31
-        expect(mail.decoded.to_s).to include(dataset3.private_show_path) #2020/1/31
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset1.private_show_path) #2019/2/28
+        expect(mail_body(mail)).to include(dataset2.private_show_path) #2019/3/31
+        expect(mail_body(mail)).to include(dataset3.private_show_path) #2020/1/31
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
   end
@@ -675,8 +675,8 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2019/11/30")) do #2019/11/30
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path) #2019/11/30
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path) #2019/11/30
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
       end
     end
 
@@ -709,8 +709,8 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2020/2/29")) do #2020/2/29
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path) #2019/11/30
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path) #2019/11/30
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
       end
     end
 
@@ -743,8 +743,8 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2020/5/30")) do #2020/5/30
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path) #2019/11/30
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path) #2019/11/30
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
       end
 
       ActionMailer::Base.deliveries.clear
@@ -873,11 +873,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2020/10/31")) do #2020/10/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset3.private_show_path)
+        expect(mail_body(mail)).to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -905,11 +905,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2022/10/31")) do #2022/10/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -923,11 +923,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2023/10/31")) do #2021/10/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).not_to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset1.private_show_path)
+        expect(mail_body(mail)).to include(dataset2.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -941,11 +941,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2024/10/31")) do #2024/10/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -959,11 +959,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2025/10/31")) do #2021/10/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).not_to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset1.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path)
+        expect(mail_body(mail)).to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -977,11 +977,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2026/10/31")) do #2026/10/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).to include(dataset2.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
 
@@ -1009,11 +1009,11 @@ describe Opendata::NotifyDatasetPlanJob, dbscope: :example do
       Timecop.travel(Date.parse("2028/10/31")) do #2028/10/31
         described_class.bind(site_id: site.id).perform_now
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.decoded.to_s).to include(dataset1.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset2.private_show_path)
-        expect(mail.decoded.to_s).to include(dataset3.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset4.private_show_path)
-        expect(mail.decoded.to_s).not_to include(dataset5.private_show_path)
+        expect(mail_body(mail)).to include(dataset1.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset2.private_show_path)
+        expect(mail_body(mail)).to include(dataset3.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset4.private_show_path)
+        expect(mail_body(mail)).not_to include(dataset5.private_show_path)
       end
     end
   end

--- a/spec/jobs/rss/import_weather_xml_job_spec.rb
+++ b/spec/jobs/rss/import_weather_xml_job_spec.rb
@@ -241,10 +241,10 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
         expect(mail.from.first).to eq "test@example.jp"
         expect(Cms::Member.site(site).map(&:email)).to include mail.to.first
         expect(mail_subject(mail)).to eq '2016年3月8日 13時32分 ころ地震がありました'
-        expect(mail.decoded.to_s).to include('2016年3月8日 13時32分 ころ地震がありました。')
-        expect(mail.decoded.to_s).to include('日高地方東部：3')
-        expect(mail.decoded.to_s).to include(node_my_anpi_post.full_url)
-        expect(mail.decoded.to_s).to end_with("\r\n--------\r\ntest@example.jp\r\n")
+        expect(mail_body(mail)).to include('2016年3月8日 13時32分 ころ地震がありました。')
+        expect(mail_body(mail)).to include('日高地方東部：3')
+        expect(mail_body(mail)).to include(node_my_anpi_post.full_url)
+        expect(mail_body(mail)).to end_with("\r\n--------\r\ntest@example.jp\r\n")
       end
     end
   end
@@ -343,8 +343,8 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
         expect(mail.from).to eq [ action2.sender_email ]
         expect(mail.to.first.to_s).to eq user1.email
         expect(mail_subject(mail)).to eq '奈良県気象警報・注意報'
-        expect(mail.decoded.to_s).to include('【特別警報（大雨）】')
-        expect(mail.decoded.to_s).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
+        expect(mail_body(mail)).to include('【特別警報（大雨）】')
+        expect(mail_body(mail)).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
       end
     end
   end
@@ -449,13 +449,13 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
           expect(mail.from.first).to eq "test@example.jp"
           expect(Cms::Member.site(site).map(&:email)).to include mail.to.first
           expect(mail_subject(mail)).to eq '2011年3月11日 14時46分 ころ地震がありました'
-          expect(mail.decoded.to_s).to include('2011年3月11日 14時46分 ころ地震がありました。')
-          expect(mail.decoded.to_s).to include('岩手県沿岸南部：6弱')
-          expect(mail.decoded.to_s).to include('岩手県内陸南部：6弱')
-          expect(mail.decoded.to_s).to include('岩手県沿岸北部：5強')
-          expect(mail.decoded.to_s).to include('岩手県内陸北部：5強')
-          expect(mail.decoded.to_s).to include(node_my_anpi_post.full_url)
-          expect(mail.decoded.to_s).to end_with("\r\n--------\r\ntest@example.jp\r\n")
+          expect(mail_body(mail)).to include('2011年3月11日 14時46分 ころ地震がありました。')
+          expect(mail_body(mail)).to include('岩手県沿岸南部：6弱')
+          expect(mail_body(mail)).to include('岩手県内陸南部：6弱')
+          expect(mail_body(mail)).to include('岩手県沿岸北部：5強')
+          expect(mail_body(mail)).to include('岩手県内陸北部：5強')
+          expect(mail_body(mail)).to include(node_my_anpi_post.full_url)
+          expect(mail_body(mail)).to end_with("\r\n--------\r\ntest@example.jp\r\n")
         end
       end
     end
@@ -580,13 +580,13 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
           expect(mail.from).to eq [ action3.sender_email ]
           expect(mail.to.first.to_s).to eq user1.email
           expect(mail_subject(mail)).to eq '震度速報'
-          expect(mail.decoded.to_s).to include('2011年3月11日 14時48分　気象庁発表')
-          expect(mail.decoded.to_s).to include('2011年3月11日 14時46分ごろ地震がありました。')
-          expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度６弱')
-          expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６弱')
-          expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度５強')
-          expect(mail.decoded.to_s).to include('岩手県内陸北部：震度５強')
-          expect(mail.decoded.to_s).to end_with("\r\n#{action3.signature_text.gsub("\n", "\r\n")}\r\n")
+          expect(mail_body(mail)).to include('2011年3月11日 14時48分　気象庁発表')
+          expect(mail_body(mail)).to include('2011年3月11日 14時46分ごろ地震がありました。')
+          expect(mail_body(mail)).to include('岩手県沿岸南部：震度６弱')
+          expect(mail_body(mail)).to include('岩手県内陸南部：震度６弱')
+          expect(mail_body(mail)).to include('岩手県沿岸北部：震度５強')
+          expect(mail_body(mail)).to include('岩手県内陸北部：震度５強')
+          expect(mail_body(mail)).to end_with("\r\n#{action3.signature_text.gsub("\n", "\r\n")}\r\n")
         end
       end
     end

--- a/spec/jobs/rss/import_weather_xml_job_spec.rb
+++ b/spec/jobs/rss/import_weather_xml_job_spec.rb
@@ -240,11 +240,11 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
         expect(mail).not_to be_nil
         expect(mail.from.first).to eq "test@example.jp"
         expect(Cms::Member.site(site).map(&:email)).to include mail.to.first
-        expect(mail.subject).to eq '2016年3月8日 13時32分 ころ地震がありました'
-        expect(mail.body.raw_source).to include('2016年3月8日 13時32分 ころ地震がありました。')
-        expect(mail.body.raw_source).to include('日高地方東部：3')
-        expect(mail.body.raw_source).to include(node_my_anpi_post.full_url)
-        expect(mail.body.raw_source).to end_with("\r\n--------\r\ntest@example.jp\r\n")
+        expect(mail_subject(mail)).to eq '2016年3月8日 13時32分 ころ地震がありました'
+        expect(mail.decoded.to_s).to include('2016年3月8日 13時32分 ころ地震がありました。')
+        expect(mail.decoded.to_s).to include('日高地方東部：3')
+        expect(mail.decoded.to_s).to include(node_my_anpi_post.full_url)
+        expect(mail.decoded.to_s).to end_with("\r\n--------\r\ntest@example.jp\r\n")
       end
     end
   end
@@ -342,9 +342,9 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
         expect(mail).not_to be_nil
         expect(mail.from).to eq [ action2.sender_email ]
         expect(mail.to.first.to_s).to eq user1.email
-        expect(mail.subject).to eq '奈良県気象警報・注意報'
-        expect(mail.body.raw_source).to include('【特別警報（大雨）】')
-        expect(mail.body.raw_source).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
+        expect(mail_subject(mail)).to eq '奈良県気象警報・注意報'
+        expect(mail.decoded.to_s).to include('【特別警報（大雨）】')
+        expect(mail.decoded.to_s).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
       end
     end
   end
@@ -448,14 +448,14 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
           expect(mail).not_to be_nil
           expect(mail.from.first).to eq "test@example.jp"
           expect(Cms::Member.site(site).map(&:email)).to include mail.to.first
-          expect(mail.subject).to eq '2011年3月11日 14時46分 ころ地震がありました'
-          expect(mail.body.raw_source).to include('2011年3月11日 14時46分 ころ地震がありました。')
-          expect(mail.body.raw_source).to include('岩手県沿岸南部：6弱')
-          expect(mail.body.raw_source).to include('岩手県内陸南部：6弱')
-          expect(mail.body.raw_source).to include('岩手県沿岸北部：5強')
-          expect(mail.body.raw_source).to include('岩手県内陸北部：5強')
-          expect(mail.body.raw_source).to include(node_my_anpi_post.full_url)
-          expect(mail.body.raw_source).to end_with("\r\n--------\r\ntest@example.jp\r\n")
+          expect(mail_subject(mail)).to eq '2011年3月11日 14時46分 ころ地震がありました'
+          expect(mail.decoded.to_s).to include('2011年3月11日 14時46分 ころ地震がありました。')
+          expect(mail.decoded.to_s).to include('岩手県沿岸南部：6弱')
+          expect(mail.decoded.to_s).to include('岩手県内陸南部：6弱')
+          expect(mail.decoded.to_s).to include('岩手県沿岸北部：5強')
+          expect(mail.decoded.to_s).to include('岩手県内陸北部：5強')
+          expect(mail.decoded.to_s).to include(node_my_anpi_post.full_url)
+          expect(mail.decoded.to_s).to end_with("\r\n--------\r\ntest@example.jp\r\n")
         end
       end
     end
@@ -579,14 +579,14 @@ describe Rss::ImportWeatherXmlJob, dbscope: :example do
           expect(mail).not_to be_nil
           expect(mail.from).to eq [ action3.sender_email ]
           expect(mail.to.first.to_s).to eq user1.email
-          expect(mail.subject).to eq '震度速報'
-          expect(mail.body.raw_source).to include('2011年3月11日 14時48分　気象庁発表')
-          expect(mail.body.raw_source).to include('2011年3月11日 14時46分ごろ地震がありました。')
-          expect(mail.body.raw_source).to include('岩手県沿岸南部：震度６弱')
-          expect(mail.body.raw_source).to include('岩手県内陸南部：震度６弱')
-          expect(mail.body.raw_source).to include('岩手県沿岸北部：震度５強')
-          expect(mail.body.raw_source).to include('岩手県内陸北部：震度５強')
-          expect(mail.body.raw_source).to end_with("\r\n#{action3.signature_text.gsub("\n", "\r\n")}\r\n")
+          expect(mail_subject(mail)).to eq '震度速報'
+          expect(mail.decoded.to_s).to include('2011年3月11日 14時48分　気象庁発表')
+          expect(mail.decoded.to_s).to include('2011年3月11日 14時46分ごろ地震がありました。')
+          expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度６弱')
+          expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６弱')
+          expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度５強')
+          expect(mail.decoded.to_s).to include('岩手県内陸北部：震度５強')
+          expect(mail.decoded.to_s).to end_with("\r\n#{action3.signature_text.gsub("\n", "\r\n")}\r\n")
         end
       end
     end

--- a/spec/jobs/workflow/reminder_job_spec.rb
+++ b/spec/jobs/workflow/reminder_job_spec.rb
@@ -162,7 +162,7 @@ describe Workflow::ReminderJob, dbscope: :example do
             expect(mail.to.first).to eq user2.email
             expect(mail_subject(mail)).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.decoded.to_s).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
+            expect(mail_body(mail)).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
           end
           expect(SS::Notification.all.count).to eq 1
           SS::Notification.all.first.tap do |notifiction|
@@ -271,7 +271,7 @@ describe Workflow::ReminderJob, dbscope: :example do
             expect(mail.to.first).to eq user2.email
             expect(mail_subject(mail)).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.decoded.to_s).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
+            expect(mail_body(mail)).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
           end
           expect(SS::Notification.all.count).to eq 1
           SS::Notification.all.first.tap do |notifiction|
@@ -346,7 +346,7 @@ describe Workflow::ReminderJob, dbscope: :example do
             expect(mail.to.first).to eq user3.email
             expect(mail_subject(mail)).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.decoded.to_s).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
+            expect(mail_body(mail)).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
           end
           expect(SS::Notification.all.count).to eq 1
           SS::Notification.all.first.tap do |notifiction|

--- a/spec/jobs/workflow/reminder_job_spec.rb
+++ b/spec/jobs/workflow/reminder_job_spec.rb
@@ -160,9 +160,9 @@ describe Workflow::ReminderJob, dbscope: :example do
           ActionMailer::Base.deliveries.first.tap do |mail|
             expect(mail.from.first).to eq user1.email
             expect(mail.to.first).to eq user2.email
-            expect(mail.subject).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
+            expect(mail_subject(mail)).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.body.raw_source).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
+            expect(mail.decoded.to_s).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
           end
           expect(SS::Notification.all.count).to eq 1
           SS::Notification.all.first.tap do |notifiction|
@@ -269,9 +269,9 @@ describe Workflow::ReminderJob, dbscope: :example do
           ActionMailer::Base.deliveries.first.tap do |mail|
             expect(mail.from.first).to eq user1.email
             expect(mail.to.first).to eq user2.email
-            expect(mail.subject).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
+            expect(mail_subject(mail)).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.body.raw_source).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
+            expect(mail.decoded.to_s).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
           end
           expect(SS::Notification.all.count).to eq 1
           SS::Notification.all.first.tap do |notifiction|
@@ -344,9 +344,9 @@ describe Workflow::ReminderJob, dbscope: :example do
           ActionMailer::Base.deliveries.first.tap do |mail|
             expect(mail.from.first).to eq user1.email
             expect(mail.to.first).to eq user3.email
-            expect(mail.subject).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
+            expect(mail_subject(mail)).to eq I18n.t("workflow.notice.remind.subject", page_name: page1.name, site_name: site.name)
             expect(mail.body.multipart?).to be_falsey
-            expect(mail.body.raw_source).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
+            expect(mail.decoded.to_s).to include(user1.name, page1.name, site.mypage_domain, page1.private_show_path)
           end
           expect(SS::Notification.all.count).to eq 1
           SS::Notification.all.first.tap do |notifiction|

--- a/spec/mailers/ezine/mailer_spec.rb
+++ b/spec/mailers/ezine/mailer_spec.rb
@@ -11,7 +11,7 @@ describe Ezine::Mailer, type: :mailer, dbscope: :example do
     it "mail attributes" do
       expect(mail.from.first).to eq node.sender_email
       expect(mail.to.first).to eq "entry@example.jp"
-      expect(mail.subject.to_s).not_to eq ""
+      expect(mail_subject(mail).to_s).not_to eq ""
       expect(mail.body.to_s).not_to eq ""
       expect(mail.message_id).to end_with("@#{site.domain}.mail")
     end
@@ -27,9 +27,9 @@ describe Ezine::Mailer, type: :mailer, dbscope: :example do
       it "mail attributes" do
         expect(mail.from.first).to eq node.sender_email
         expect(mail.to.first).to eq "member@example.jp"
-        expect(mail.subject.to_s).not_to eq ""
+        expect(mail_subject(mail).to_s).not_to eq ""
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.body.raw_source.to_s).not_to eq ""
+        expect(mail.decoded.to_s).not_to eq ""
         expect(mail.message_id).to end_with("@#{site.domain}.mail")
       end
     end
@@ -40,7 +40,7 @@ describe Ezine::Mailer, type: :mailer, dbscope: :example do
       it "mail attributes" do
         expect(mail.from.first).to eq node.sender_email
         expect(mail.to.first).to eq "member@example.jp"
-        expect(mail.subject.to_s).not_to eq ""
+        expect(mail_subject(mail).to_s).not_to eq ""
         expect(mail.body.multipart?).to be_truthy
         expect(mail.body.parts[0].body.to_s).not_to eq ""
         expect(mail.body.parts[1].body.to_s).not_to eq ""

--- a/spec/mailers/ezine/mailer_spec.rb
+++ b/spec/mailers/ezine/mailer_spec.rb
@@ -29,7 +29,7 @@ describe Ezine::Mailer, type: :mailer, dbscope: :example do
         expect(mail.to.first).to eq "member@example.jp"
         expect(mail_subject(mail).to_s).not_to eq ""
         expect(mail.body.multipart?).to be_falsey
-        expect(mail.decoded.to_s).not_to eq ""
+        expect(mail_body(mail)).not_to eq ""
         expect(mail.message_id).to end_with("@#{site.domain}.mail")
       end
     end

--- a/spec/mailers/inquiry/mailer_spec.rb
+++ b/spec/mailers/inquiry/mailer_spec.rb
@@ -11,7 +11,7 @@ describe Inquiry::Mailer, type: :mailer, dbscope: :example do
     it "mail attributes" do
       expect(mail.from.first).to eq "from@example.jp"
       expect(mail.to.first).to eq "notice@example.jp"
-      expect(mail.subject.to_s).not_to eq ""
+      expect(mail_subject(mail).to_s).not_to eq ""
       expect(mail.body.to_s).not_to eq ""
       expect(mail.message_id).to end_with("@#{site.domain}.mail")
     end

--- a/spec/mailers/sys/mailer_spec.rb
+++ b/spec/mailers/sys/mailer_spec.rb
@@ -17,7 +17,7 @@ describe Sys::Mailer, type: :mailer, dbscope: :example do
     it "mail attributes" do
       expect(mail.from.first).to eq user1.email
       expect(mail.to.first).to eq user2.email
-      expect(mail.subject.to_s).not_to eq ""
+      expect(mail_subject(mail).to_s).not_to eq ""
       expect(mail.body.to_s).not_to eq ""
     end
   end

--- a/spec/mailers/workflow/mailer_spec.rb
+++ b/spec/mailers/workflow/mailer_spec.rb
@@ -21,7 +21,7 @@ describe Workflow::Mailer, type: :mailer, dbscope: :example do
     it "mail attributes" do
       expect(mail.from.first).to eq user1.email
       expect(mail.to.first).to eq user2.email
-      expect(mail.subject.to_s).not_to eq ""
+      expect(mail_subject(mail).to_s).not_to eq ""
       expect(mail.body.to_s).not_to eq ""
       expect(mail.message_id).to end_with("@#{site.domain}.mail")
     end
@@ -41,7 +41,7 @@ describe Workflow::Mailer, type: :mailer, dbscope: :example do
     it "mail attributes" do
       expect(mail.from.first).to eq user1.email
       expect(mail.to.first).to eq user2.email
-      expect(mail.subject.to_s).not_to eq ""
+      expect(mail_subject(mail).to_s).not_to eq ""
       expect(mail.body.to_s).not_to eq ""
       expect(mail.message_id).to end_with("@#{site.domain}.mail")
     end
@@ -62,7 +62,7 @@ describe Workflow::Mailer, type: :mailer, dbscope: :example do
     it "mail attributes" do
       expect(mail.from.first).to eq user1.email
       expect(mail.to.first).to eq user2.email
-      expect(mail.subject.to_s).not_to eq ""
+      expect(mail_subject(mail).to_s).not_to eq ""
       expect(mail.body.to_s).not_to eq ""
       expect(mail.message_id).to end_with("@#{site.domain}.mail")
     end

--- a/spec/models/jmaxml/action/send_mail_spec.rb
+++ b/spec/models/jmaxml/action/send_mail_spec.rb
@@ -78,16 +78,16 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first.to_s).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '震度速報'
-            mail_subject ||= mail.subject
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2011年3月11日 14時48分　気象庁発表')
-            expect(mail.body.raw_source).to include('2011年3月11日 14時46分ごろ地震がありました。')
-            expect(mail.body.raw_source).to include('岩手県沿岸南部：震度６弱')
-            expect(mail.body.raw_source).to include('岩手県内陸南部：震度６弱')
-            expect(mail.body.raw_source).to include('岩手県沿岸北部：震度５強')
-            expect(mail.body.raw_source).to include('岩手県内陸北部：震度５強')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            expect(mail_subject(mail)).to eq '震度速報'
+            mail_subject ||= mail_subject(mail)
+            mail_body ||= mail.decoded.to_s
+            expect(mail.decoded.to_s).to include('2011年3月11日 14時48分　気象庁発表')
+            expect(mail.decoded.to_s).to include('2011年3月11日 14時46分ごろ地震がありました。')
+            expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度６弱')
+            expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６弱')
+            expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度５強')
+            expect(mail.decoded.to_s).to include('岩手県内陸北部：震度５強')
+            expect(mail.decoded.to_s).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -121,16 +121,16 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '震源・震度情報'
-            mail_subject ||= mail.subject
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2008年6月14日 08時47分　気象庁発表')
-            expect(mail.body.raw_source).to include('2008年6月14日 08時43分ごろ地震がありました。')
-            expect(mail.body.raw_source).to include('岩手県内陸南部：震度６強')
-            expect(mail.body.raw_source).to include('岩手県沿岸北部：震度４')
-            expect(mail.body.raw_source).to include('岩手県沿岸南部：震度４')
-            expect(mail.body.raw_source).to include('岩手県内陸北部：震度４')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            expect(mail_subject(mail)).to eq '震源・震度情報'
+            mail_subject ||= mail_subject(mail)
+            mail_body ||= mail.decoded.to_s
+            expect(mail.decoded.to_s).to include('2008年6月14日 08時47分　気象庁発表')
+            expect(mail.decoded.to_s).to include('2008年6月14日 08時43分ごろ地震がありました。')
+            expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６強')
+            expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度４')
+            expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度４')
+            expect(mail.decoded.to_s).to include('岩手県内陸北部：震度４')
+            expect(mail.decoded.to_s).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -164,9 +164,9 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '大津波警報・津波警報・津波注意報・津波予報'
-            mail_subject ||= mail.subject
-            mail_body ||= mail.body.raw_source
+            expect(mail_subject(mail)).to eq '大津波警報・津波警報・津波注意報・津波予報'
+            mail_subject ||= mail_subject(mail)
+            mail_body ||= mail.decoded.to_s
             expect(mail.body.raw_source).to include('東日本大震災クラスの津波が来襲します。')
             expect(mail.body.raw_source).to include('岩手県　　　　　　　　　　第１波：津波到達中と推測')
             expect(mail.body.raw_source).to include('北海道太平洋沿岸中部　　　第１波：2011年3月11日 15時30分')
@@ -208,8 +208,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '各地の満潮時刻・津波到達予想時刻に関する情報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '各地の満潮時刻・津波到達予想時刻に関する情報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('各地の満潮時刻と津波到達予想時刻をお知らせします。')
             expect(mail.body.raw_source).to include('青森県太平洋沿岸　　　　　第１波：2010年2月28日 13時30分　高さ：３ｍ')
@@ -251,8 +251,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '奈良県気象警報・注意報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '奈良県気象警報・注意報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2011年9月4日 00時10分　奈良地方気象台発表')
             expect(mail.body.raw_source).to include('【特別警報（大雨）】奈良県では、４日昼過ぎまで土砂災害に、４日朝まで低い土地の浸水や河川の増水に警戒して下さい。')
@@ -298,8 +298,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '揖斐川中流はん濫注意情報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '揖斐川中流はん濫注意情報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2008年9月3日 04時15分　木曽川上流河川事務所・岐阜地方気象台　共同発表')
             expect(mail.body.raw_source).to include(main_sentence)
@@ -355,8 +355,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '福岡県土砂災害警戒情報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '福岡県土砂災害警戒情報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2013年8月31日 11時05分　福岡県・福岡管区気象台　共同発表')
             expect(mail.body.raw_source).to include(headline_text.gsub("\n", "\r\n"))
@@ -394,8 +394,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '火山名　御嶽山　噴火速報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '火山名　御嶽山　噴火速報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2014年9月27日 12時00分　気象庁地震火山部発表')
             expect(mail.body.raw_source).to include('御嶽山で、平成２６年９月２７日１１時５３分頃、噴火が発生しました。')
@@ -433,8 +433,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '火山名　桜島　降灰予報（定時）'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '火山名　桜島　降灰予報（定時）'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2014年6月6日 05時00分　気象庁地震火山部発表')
             expect(mail.body.raw_source).to include("＜降灰＞\r\n鹿児島県鹿児島市、鹿児島県鹿屋市、")
@@ -475,8 +475,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '東京都竜巻注意情報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '東京都竜巻注意情報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2009年8月10日 07時38分　気象庁予報部発表')
             expect(mail.body.raw_source).to include("東京地方では、竜巻発生のおそれがあります。")
@@ -526,8 +526,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '【取消】震度速報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '【取消】震度速報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2011年3月11日 14時46分　気象庁発表')
             expect(mail.body.raw_source).to include('緊急地震速報（警報）を取り消します。')
@@ -565,8 +565,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '【取消】震源・震度情報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '【取消】震源・震度情報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2008年6月14日 09時06分　気象庁発表')
             expect(mail.body.raw_source).to include('震源・震度情報を取り消します。')
@@ -602,8 +602,8 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             expect(mail.from).to eq [ subject.sender_email ]
             expect(mail.to.first).to be_in(emails)
             emails.delete(mail.to.first)
-            expect(mail.subject).to eq '【取消】火山名　御嶽山　噴火速報'
-            mail_subject ||= mail.subject
+            expect(mail_subject(mail)).to eq '【取消】火山名　御嶽山　噴火速報'
+            mail_subject ||= mail_subject(mail)
             mail_body ||= mail.body.raw_source
             expect(mail.body.raw_source).to include('2014年9月27日 11時53分　気象庁地震火山部発表')
             expect(mail.body.raw_source).to include('噴火速報を取り消します。')

--- a/spec/models/jmaxml/action/send_mail_spec.rb
+++ b/spec/models/jmaxml/action/send_mail_spec.rb
@@ -80,14 +80,14 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '震度速報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.decoded.to_s
-            expect(mail.decoded.to_s).to include('2011年3月11日 14時48分　気象庁発表')
-            expect(mail.decoded.to_s).to include('2011年3月11日 14時46分ごろ地震がありました。')
-            expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度６弱')
-            expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６弱')
-            expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度５強')
-            expect(mail.decoded.to_s).to include('岩手県内陸北部：震度５強')
-            expect(mail.decoded.to_s).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2011年3月11日 14時48分　気象庁発表')
+            expect(mail_body).to include('2011年3月11日 14時46分ごろ地震がありました。')
+            expect(mail_body).to include('岩手県沿岸南部：震度６弱')
+            expect(mail_body).to include('岩手県内陸南部：震度６弱')
+            expect(mail_body).to include('岩手県沿岸北部：震度５強')
+            expect(mail_body).to include('岩手県内陸北部：震度５強')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -123,14 +123,14 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '震源・震度情報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.decoded.to_s
-            expect(mail.decoded.to_s).to include('2008年6月14日 08時47分　気象庁発表')
-            expect(mail.decoded.to_s).to include('2008年6月14日 08時43分ごろ地震がありました。')
-            expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６強')
-            expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度４')
-            expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度４')
-            expect(mail.decoded.to_s).to include('岩手県内陸北部：震度４')
-            expect(mail.decoded.to_s).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2008年6月14日 08時47分　気象庁発表')
+            expect(mail_body).to include('2008年6月14日 08時43分ごろ地震がありました。')
+            expect(mail_body).to include('岩手県内陸南部：震度６強')
+            expect(mail_body).to include('岩手県沿岸北部：震度４')
+            expect(mail_body).to include('岩手県沿岸南部：震度４')
+            expect(mail_body).to include('岩手県内陸北部：震度４')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -166,15 +166,15 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '大津波警報・津波警報・津波注意報・津波予報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.decoded.to_s
-            expect(mail.body.raw_source).to include('東日本大震災クラスの津波が来襲します。')
-            expect(mail.body.raw_source).to include('岩手県　　　　　　　　　　第１波：津波到達中と推測')
-            expect(mail.body.raw_source).to include('北海道太平洋沿岸中部　　　第１波：2011年3月11日 15時30分')
-            expect(mail.body.raw_source).to include('北海道太平洋沿岸東部　　　第１波：2011年3月11日 15時30分')
-            expect(mail.body.raw_source).to include('北海道太平洋沿岸西部　　　第１波：2011年3月11日 15時40分')
-            expect(mail.body.raw_source).to include('地震発生時刻：　　2011年3月11日 14時46分ごろ')
-            expect(mail.body.raw_source).to include('震源地：　　　　　三陸沖 牡鹿半島の東南東１３０ｋｍ付近')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('東日本大震災クラスの津波が来襲します。')
+            expect(mail_body).to include('岩手県　　　　　　　　　　第１波：津波到達中と推測')
+            expect(mail_body).to include('北海道太平洋沿岸中部　　　第１波：2011年3月11日 15時30分')
+            expect(mail_body).to include('北海道太平洋沿岸東部　　　第１波：2011年3月11日 15時30分')
+            expect(mail_body).to include('北海道太平洋沿岸西部　　　第１波：2011年3月11日 15時40分')
+            expect(mail_body).to include('地震発生時刻：　　2011年3月11日 14時46分ごろ')
+            expect(mail_body).to include('震源地：　　　　　三陸沖 牡鹿半島の東南東１３０ｋｍ付近')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -210,15 +210,15 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '各地の満潮時刻・津波到達予想時刻に関する情報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('各地の満潮時刻と津波到達予想時刻をお知らせします。')
-            expect(mail.body.raw_source).to include('青森県太平洋沿岸　　　　　第１波：2010年2月28日 13時30分　高さ：３ｍ')
-            expect(mail.body.raw_source).to include('北海道太平洋沿岸東部　　　第１波：2010年2月28日 13時00分　高さ：２ｍ')
-            expect(mail.body.raw_source).to include('北海道太平洋沿岸中部　　　第１波：2010年2月28日 13時30分　高さ：２ｍ')
-            expect(mail.body.raw_source).to include('北海道太平洋沿岸西部　　　第１波：2010年2月28日 14時00分　高さ：１ｍ')
-            expect(mail.body.raw_source).to include('地震発生時刻：　　2010年2月27日 15時34分ごろ')
-            expect(mail.body.raw_source).to include('震源地：　　　　　南米西部')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('各地の満潮時刻と津波到達予想時刻をお知らせします。')
+            expect(mail_body).to include('青森県太平洋沿岸　　　　　第１波：2010年2月28日 13時30分　高さ：３ｍ')
+            expect(mail_body).to include('北海道太平洋沿岸東部　　　第１波：2010年2月28日 13時00分　高さ：２ｍ')
+            expect(mail_body).to include('北海道太平洋沿岸中部　　　第１波：2010年2月28日 13時30分　高さ：２ｍ')
+            expect(mail_body).to include('北海道太平洋沿岸西部　　　第１波：2010年2月28日 14時00分　高さ：１ｍ')
+            expect(mail_body).to include('地震発生時刻：　　2010年2月27日 15時34分ごろ')
+            expect(mail_body).to include('震源地：　　　　　南米西部')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -253,15 +253,15 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '奈良県気象警報・注意報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2011年9月4日 00時10分　奈良地方気象台発表')
-            expect(mail.body.raw_source).to include('【特別警報（大雨）】奈良県では、４日昼過ぎまで土砂災害に、４日朝まで低い土地の浸水や河川の増水に警戒して下さい。')
-            expect(mail.body.raw_source).to include('＜奈良市＞')
-            expect(mail.body.raw_source).to include('大雨特別警報、雷注意報、強風注意報、洪水注意報')
-            expect(mail.body.raw_source).to include('＜大和高田市＞')
-            expect(mail.body.raw_source).to include('＜大和郡山市＞')
-            expect(mail.body.raw_source).to include('＜天理市＞')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2011年9月4日 00時10分　奈良地方気象台発表')
+            expect(mail_body).to include('【特別警報（大雨）】奈良県では、４日昼過ぎまで土砂災害に、４日朝まで低い土地の浸水や河川の増水に警戒して下さい。')
+            expect(mail_body).to include('＜奈良市＞')
+            expect(mail_body).to include('大雨特別警報、雷注意報、強風注意報、洪水注意報')
+            expect(mail_body).to include('＜大和高田市＞')
+            expect(mail_body).to include('＜大和郡山市＞')
+            expect(mail_body).to include('＜天理市＞')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -300,13 +300,13 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '揖斐川中流はん濫注意情報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2008年9月3日 04時15分　木曽川上流河川事務所・岐阜地方気象台　共同発表')
-            expect(mail.body.raw_source).to include(main_sentence)
-            expect(mail.body.raw_source).to include('＜岐阜県△△市＞')
-            expect(mail.body.raw_source).to include('△△地区 △△地区 △△地区')
-            expect(mail.body.raw_source).to include('所により１時間に５０ミリの雨が降っています。')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2008年9月3日 04時15分　木曽川上流河川事務所・岐阜地方気象台　共同発表')
+            expect(mail_body).to include(main_sentence)
+            expect(mail_body).to include('＜岐阜県△△市＞')
+            expect(mail_body).to include('△△地区 △△地区 △△地区')
+            expect(mail_body).to include('所により１時間に５０ミリの雨が降っています。')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -357,13 +357,13 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '福岡県土砂災害警戒情報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2013年8月31日 11時05分　福岡県・福岡管区気象台　共同発表')
-            expect(mail.body.raw_source).to include(headline_text.gsub("\n", "\r\n"))
-            expect(mail.body.raw_source).to include("＜警戒（発表）＞\r\n北九州市、福岡市")
-            expect(mail.body.raw_source).to include("＜警戒（継続）＞\r\n直方市、飯塚市、田川市、行橋市、筑紫野市")
-            expect(mail.body.raw_source).to include("＜解除＞\r\n大牟田市、久留米市、八女市、中間市、小郡市")
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2013年8月31日 11時05分　福岡県・福岡管区気象台　共同発表')
+            expect(mail_body).to include(headline_text.gsub("\n", "\r\n"))
+            expect(mail_body).to include("＜警戒（発表）＞\r\n北九州市、福岡市")
+            expect(mail_body).to include("＜警戒（継続）＞\r\n直方市、飯塚市、田川市、行橋市、筑紫野市")
+            expect(mail_body).to include("＜解除＞\r\n大牟田市、久留米市、八女市、中間市、小郡市")
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -396,11 +396,11 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '火山名　御嶽山　噴火速報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2014年9月27日 12時00分　気象庁地震火山部発表')
-            expect(mail.body.raw_source).to include('御嶽山で、平成２６年９月２７日１１時５３分頃、噴火が発生しました。')
-            expect(mail.body.raw_source).to include("長野県王滝村、長野県木曽町")
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2014年9月27日 12時00分　気象庁地震火山部発表')
+            expect(mail_body).to include('御嶽山で、平成２６年９月２７日１１時５３分頃、噴火が発生しました。')
+            expect(mail_body).to include("長野県王滝村、長野県木曽町")
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -435,14 +435,14 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '火山名　桜島　降灰予報（定時）'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2014年6月6日 05時00分　気象庁地震火山部発表')
-            expect(mail.body.raw_source).to include("＜降灰＞\r\n鹿児島県鹿児島市、鹿児島県鹿屋市、")
-            expect(mail.body.raw_source).to include("＜小さな噴石の落下＞\r\n鹿児島県鹿児島市")
-            expect(mail.body.raw_source).to include('６日０６時から６日２４時までに噴火が発生した場合には、')
-            expect(mail.body.raw_source).to include('６日０６時から０９時まで　南東（垂水・鹿屋方向）')
-            expect(mail.body.raw_source).to include('噴煙が高さ３０００ｍまで上がった場合の')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2014年6月6日 05時00分　気象庁地震火山部発表')
+            expect(mail_body).to include("＜降灰＞\r\n鹿児島県鹿児島市、鹿児島県鹿屋市、")
+            expect(mail_body).to include("＜小さな噴石の落下＞\r\n鹿児島県鹿児島市")
+            expect(mail_body).to include('６日０６時から６日２４時までに噴火が発生した場合には、')
+            expect(mail_body).to include('６日０６時から０９時まで　南東（垂水・鹿屋方向）')
+            expect(mail_body).to include('噴煙が高さ３０００ｍまで上がった場合の')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -477,11 +477,11 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '東京都竜巻注意情報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2009年8月10日 07時38分　気象庁予報部発表')
-            expect(mail.body.raw_source).to include("東京地方では、竜巻発生のおそれがあります。")
-            expect(mail.body.raw_source).to include("千代田区、中央区、港区、新宿区")
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2009年8月10日 07時38分　気象庁予報部発表')
+            expect(mail_body).to include("東京地方では、竜巻発生のおそれがあります。")
+            expect(mail_body).to include("千代田区、中央区、港区、新宿区")
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -528,10 +528,10 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '【取消】震度速報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2011年3月11日 14時46分　気象庁発表')
-            expect(mail.body.raw_source).to include('緊急地震速報（警報）を取り消します。')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2011年3月11日 14時46分　気象庁発表')
+            expect(mail_body).to include('緊急地震速報（警報）を取り消します。')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -567,10 +567,10 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '【取消】震源・震度情報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2008年6月14日 09時06分　気象庁発表')
-            expect(mail.body.raw_source).to include('震源・震度情報を取り消します。')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2008年6月14日 09時06分　気象庁発表')
+            expect(mail_body).to include('震源・震度情報を取り消します。')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end
@@ -604,10 +604,10 @@ describe Jmaxml::Action::SendMail, dbscope: :example do
             emails.delete(mail.to.first)
             expect(mail_subject(mail)).to eq '【取消】火山名　御嶽山　噴火速報'
             mail_subject ||= mail_subject(mail)
-            mail_body ||= mail.body.raw_source
-            expect(mail.body.raw_source).to include('2014年9月27日 11時53分　気象庁地震火山部発表')
-            expect(mail.body.raw_source).to include('噴火速報を取り消します。')
-            expect(mail.body.raw_source).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
+            mail_body ||= mail_body(mail)
+            expect(mail_body).to include('2014年9月27日 11時53分　気象庁地震火山部発表')
+            expect(mail_body).to include('噴火速報を取り消します。')
+            expect(mail_body).to end_with("\r\n#{subject.signature_text.gsub("\n", "\r\n")}\r\n")
           end
           expect(emails).to eq []
         end

--- a/spec/models/jmaxml/filter_spec.rb
+++ b/spec/models/jmaxml/filter_spec.rb
@@ -75,13 +75,15 @@ describe Jmaxml::Filter, dbscope: :example do
       expect(mail.from).to eq [ action2.sender_email ]
       expect(mail.to.first.to_s).to eq user1.email
       expect(mail_subject(mail)).to eq '震度速報'
-      expect(mail.decoded.to_s).to include('2011年3月11日 14時48分　気象庁発表')
-      expect(mail.decoded.to_s).to include('2011年3月11日 14時46分ごろ地震がありました。')
-      expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度６弱')
-      expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６弱')
-      expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度５強')
-      expect(mail.decoded.to_s).to include('岩手県内陸北部：震度５強')
-      expect(mail.decoded.to_s).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
+      mail_body(mail).tap do |body|
+        expect(body).to include('2011年3月11日 14時48分　気象庁発表')
+        expect(body).to include('2011年3月11日 14時46分ごろ地震がありました。')
+        expect(body).to include('岩手県沿岸南部：震度６弱')
+        expect(body).to include('岩手県内陸南部：震度６弱')
+        expect(body).to include('岩手県沿岸北部：震度５強')
+        expect(body).to include('岩手県内陸北部：震度５強')
+        expect(body).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
+      end
     end
   end
 end

--- a/spec/models/jmaxml/filter_spec.rb
+++ b/spec/models/jmaxml/filter_spec.rb
@@ -74,14 +74,14 @@ describe Jmaxml::Filter, dbscope: :example do
       expect(mail).not_to be_nil
       expect(mail.from).to eq [ action2.sender_email ]
       expect(mail.to.first.to_s).to eq user1.email
-      expect(mail.subject).to eq '震度速報'
-      expect(mail.body.raw_source).to include('2011年3月11日 14時48分　気象庁発表')
-      expect(mail.body.raw_source).to include('2011年3月11日 14時46分ごろ地震がありました。')
-      expect(mail.body.raw_source).to include('岩手県沿岸南部：震度６弱')
-      expect(mail.body.raw_source).to include('岩手県内陸南部：震度６弱')
-      expect(mail.body.raw_source).to include('岩手県沿岸北部：震度５強')
-      expect(mail.body.raw_source).to include('岩手県内陸北部：震度５強')
-      expect(mail.body.raw_source).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
+      expect(mail_subject(mail)).to eq '震度速報'
+      expect(mail.decoded.to_s).to include('2011年3月11日 14時48分　気象庁発表')
+      expect(mail.decoded.to_s).to include('2011年3月11日 14時46分ごろ地震がありました。')
+      expect(mail.decoded.to_s).to include('岩手県沿岸南部：震度６弱')
+      expect(mail.decoded.to_s).to include('岩手県内陸南部：震度６弱')
+      expect(mail.decoded.to_s).to include('岩手県沿岸北部：震度５強')
+      expect(mail.decoded.to_s).to include('岩手県内陸北部：震度５強')
+      expect(mail.decoded.to_s).to end_with("\r\n#{action2.signature_text.gsub("\n", "\r\n")}\r\n")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -301,6 +301,17 @@ def wait_for_error(text, wait: nil, selector: nil)
   end
 end
 
+def mail_subject(mail)
+  return if mail.blank?
+
+  subject = mail.subject
+  return subject if subject.blank?
+
+  return subject unless subject.start_with?("=?ISO-2022-JP?")
+
+  NKF.nkf("-w", subject)
+end
+
 # ref.
 #   https://www.relishapp.com/rspec/rspec-expectations/v/2-5/docs/built-in-matchers/be-within-matcher
 #   http://qiita.com/kozy4324/items/9a6530736be7e92954bc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -312,6 +312,18 @@ def mail_subject(mail)
   NKF.nkf("-w", subject)
 end
 
+def mail_body(mail)
+  return if mail.blank?
+
+  body = mail.body
+  return "" if body.blank?
+
+  raw_source = body.raw_source
+  return "" if raw_source.blank?
+
+  NKF.nkf("-w", raw_source)
+end
+
 # ref.
 #   https://www.relishapp.com/rspec/rspec-expectations/v/2-5/docs/built-in-matchers/be-within-matcher
 #   http://qiita.com/kozy4324/items/9a6530736be7e92954bc


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

mail.yml の charset が iso-2022-jp のとき発生する。

## 変更内容

iso-2022-jp のとき nkf で文字を変換するようにした。

## その他

類似コードを検索してみたが、ここ以外は iso-2022-jp へ対応していた（nkf で変換していた）。