### PR TITLE
[fix][gws][memo] メッセージにメニューが非表示でも権限があるとメッセージ通知が見えてしまう問題の修正

### DIFF
--- a/app/views/layouts/ss/_head_user_gws_memo.html.erb
+++ b/app/views/layouts/ss/_head_user_gws_memo.html.erb
@@ -1,69 +1,71 @@
-<% if Gws::Memo::Message.allowed?(:edit, @cur_user, site: @cur_site) %>
-  <%
-    search_condition = SS.config.gws.dig("popup_notice", "search_condition")
-    if search_condition == "unseen"
-      default_label  = t("gws/memo/message.links.seens")
-      switched_label = t("gws/memo/message.links.unseens")
-      default_url    = recent_gws_memo_messages_path(s: { unseen: @cur_user.id })
-      switched_url   = recent_gws_memo_messages_path
-    else
-      default_label  = t("gws/memo/message.links.unseens")
-      switched_label = t("gws/memo/message.links.seens")
-      default_url    = recent_gws_memo_messages_path
-      switched_url   = recent_gws_memo_messages_path(s: { unseen: @cur_user.id })
-    end
-  %>
-  <%= jquery do %>
-    $(".gws-memo-message .unseens").on("click", function() {
-      $(".gws-memo-message.popup-notice-container [data-url]").each(function() {
-        var url = $(this).attr("data-url");
-        var switched = $(this).attr("data-url-switched");
-        $(this).attr("data-url", switched);
-        $(this).attr("data-url-switched", url);
+<%
+  return unless @cur_site.menu_memo_visible?
+  return unless Gws.module_usable?(:memo, @cur_site, @cur_user)
+%>
+<%
+  search_condition = SS.config.gws.dig("popup_notice", "search_condition")
+  if search_condition == "unseen"
+    default_label  = t("gws/memo/message.links.seens")
+    switched_label = t("gws/memo/message.links.unseens")
+    default_url    = recent_gws_memo_messages_path(s: { unseen: @cur_user.id })
+    switched_url   = recent_gws_memo_messages_path
+  else
+    default_label  = t("gws/memo/message.links.unseens")
+    switched_label = t("gws/memo/message.links.seens")
+    default_url    = recent_gws_memo_messages_path
+    switched_url   = recent_gws_memo_messages_path(s: { unseen: @cur_user.id })
+  end
+%>
+<%= jquery do %>
+  $(".gws-memo-message .unseens").on("click", function() {
+    $(".gws-memo-message.popup-notice-container [data-url]").each(function() {
+      var url = $(this).attr("data-url");
+      var switched = $(this).attr("data-url-switched");
+      $(this).attr("data-url", switched);
+      $(this).attr("data-url-switched", url);
+    });
+    var label = $(this).text();
+    var switched = $(this).attr("data-label-switched");
+    $(this).text(switched);
+    $(this).attr("data-label-switched", label);
+  });
+  $(".gws-memo-message .set-seen-all").on("click", function() {
+    var url = $(this).attr("href");
+    var token = $('meta[name="csrf-token"]').attr('content');
+    if (confirm('<%= t("gws/notice.confirm.set_seen") %>')) {
+      $.ajax({
+        url: url,
+        type: 'POST',
+        dataType: 'json',
+        success: function() { location.reload(); },
+        error: function(_xhr, _status, _error) { alert("Error"); }
       });
-      var label = $(this).text();
-      var switched = $(this).attr("data-label-switched");
-      $(this).text(switched);
-      $(this).attr("data-label-switched", label);
-    });
-    $(".gws-memo-message .set-seen-all").on("click", function() {
-      var url = $(this).attr("href");
-      var token = $('meta[name="csrf-token"]').attr('content');
-      if (confirm('<%= t("gws/notice.confirm.set_seen") %>')) {
-        $.ajax({
-          url: url,
-          type: 'POST',
-          dataType: 'json',
-          success: function() { location.reload(); },
-          error: function(_xhr, _status, _error) { alert("Error"); }
-        });
-      }
-      return false;
-    });
-    (new SS_PopupNotice(".gws-memo-message.popup-notice-container")).render();
+    }
+    return false;
+  });
+  (new SS_PopupNotice(".gws-memo-message.popup-notice-container")).render();
+<% end %>
+<div class="gws-memo-message popup-notice-container">
+  <%= link_to gws_memo_messages_path, "class" => "user-message ajax-popup-notice toggle-popup-notice", "data-url" => default_url, "data-url-switched" => switched_url do %>
+    <% count = Gws::Memo::Message.unseens(@cur_user, @cur_site).size %>
+    <% if count > 0 %><span class="unseen"><%= count %></span><% end %>
   <% end %>
-  <div class="gws-memo-message popup-notice-container">
-    <%= link_to gws_memo_messages_path, "class" => "user-message ajax-popup-notice toggle-popup-notice", "data-url" => default_url, "data-url-switched" => switched_url do %>
-      <% count = Gws::Memo::Message.unseens(@cur_user, @cur_site).size %>
-      <% if count > 0 %><span class="unseen"><%= count %></span><% end %>
-    <% end %>
-    <div class="popup-notice" style="display: none;">
-      <header class="popup-notice-header">
-        <h2>
-          <%= t('modules.gws/memo/message') %>
-          <%= link_to default_label, "#",
-                      "class" => "ajax-popup-notice unseens",
-                      "data-url" => default_url,
-                      "data-url-switched" =>  switched_url,
-                      "data-label-switched" => switched_label
-          %>
-        </h2>
-      </header>
-      <div class="popup-notice-items"></div>
-      <div class="popup-notice-actions">
-        <%= link_to t("ss.links.more_all"), gws_memo_messages_path, class: "more-all" %>
-        <%= link_to t("gws/notice.links.set_seen_all"), set_seen_from_popup_gws_memo_messages_path, class: "set-seen-all" %>
-      </div>
+  <div class="popup-notice" style="display: none;">
+    <header class="popup-notice-header">
+      <h2>
+        <%= t('modules.gws/memo/message') %>
+        <%= link_to default_label, "#",
+                    "class" => "ajax-popup-notice unseens",
+                    "data-url" => default_url,
+                    "data-url-switched" =>  switched_url,
+                    "data-label-switched" => switched_label
+        %>
+      </h2>
+    </header>
+    <div class="popup-notice-items"></div>
+    <div class="popup-notice-actions">
+      <%= link_to t("ss.links.more_all"), gws_memo_messages_path, class: "more-all" %>
+      <%= link_to t("gws/notice.links.set_seen_all"), set_seen_from_popup_gws_memo_messages_path, class: "set-seen-all" %>
     </div>
   </div>
-<% end %>
+</div>

--- a/spec/factories/gws/roles.rb
+++ b/spec/factories/gws/roles.rb
@@ -138,6 +138,14 @@ FactoryBot.define do
     end
   end
 
+  trait :gws_role_memo_reader do
+    after(:build) do |item|
+      item.permissions += %w(
+        edit_private_gws_memo_messages
+      )
+    end
+  end
+
   factory :gws_role, class: Gws::Role, traits: [:gws_role]
 
   factory :gws_role_admin, class: Gws::Role, traits: [:gws_role, :gws_role_admin]

--- a/spec/features/gws/memo/menu_setting_and_permission_spec.rb
+++ b/spec/features/gws/memo/menu_setting_and_permission_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'gws_memo_messages', type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:admin) { gws_user }
+
+  context "menu is visible" do
+    context "user has permissions" do
+      let!(:role) { create :gws_role, :gws_role_portal_user_use, :gws_role_memo_reader, cur_site: site }
+      let!(:user) { create :gws_user, group_ids: admin.group_ids, gws_role_ids: [ role.id ] }
+
+      it do
+        login_user user, to: gws_portal_path(site: site)
+
+        link = gws_memo_messages_path(site: site, folder: "INBOX")
+        within ".main-navi" do
+          expect(page).to have_link(site.menu_memo_effective_label, href: link)
+        end
+        within ".gws-memo-message" do
+          expect(page).to have_link(href: link)
+        end
+      end
+    end
+
+    context "user has no permissions" do
+      let!(:role) { create :gws_role, :gws_role_portal_user_use, cur_site: site }
+      let!(:user) { create :gws_user, group_ids: admin.group_ids, gws_role_ids: [ role.id ] }
+
+      it do
+        login_user user, to: gws_portal_path(site: site)
+
+        within ".main-navi" do
+          expect(page).to have_no_link(site.menu_memo_effective_label)
+        end
+        expect(page).to have_no_css(".gws-memo-message")
+      end
+    end
+  end
+
+  context "menu is hidden" do
+    before do
+      site.update!(menu_memo_state: "hide")
+    end
+
+    context "user has permissions" do
+      let!(:role) { create :gws_role, :gws_role_portal_user_use, :gws_role_memo_reader, cur_site: site }
+      let!(:user) { create :gws_user, group_ids: admin.group_ids, gws_role_ids: [ role.id ] }
+
+      it do
+        login_user user, to: gws_portal_path(site: site)
+
+        within ".main-navi" do
+          expect(page).to have_no_link(site.menu_memo_effective_label)
+        end
+        expect(page).to have_no_css(".gws-memo-message")
+      end
+    end
+
+    context "user has no permissions" do
+      let!(:role) { create :gws_role, :gws_role_portal_user_use, cur_site: site }
+      let!(:user) { create :gws_user, group_ids: admin.group_ids, gws_role_ids: [ role.id ] }
+
+      it do
+        login_user user, to: gws_portal_path(site: site)
+
+        within ".main-navi" do
+          expect(page).to have_no_link(site.menu_memo_effective_label)
+        end
+        expect(page).to have_no_css(".gws-memo-message")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

メッセージ通知が非表示ならない問題の修正

## 変更内容

メッセージ通知の表示・非表示の条件を、メッセージメニューの表示・非表示と同じにした。
