### PR TITLE
[fix][gws][notice] 500 error if empty string is given to limit

### DIFF
--- a/app/models/concerns/gws/addon/notice/resource_limitation.rb
+++ b/app/models/concerns/gws/addon/notice/resource_limitation.rb
@@ -2,8 +2,10 @@ module Gws::Addon::Notice::ResourceLimitation
   extend ActiveSupport::Concern
   extend SS::Addon
 
+  DEFAULT_NOTICE_INDIVIDUAL_BODY_SIZE_LIMIT = 1_048_576
+
   included do
-    field :notice_individual_body_size_limit, type: Integer, default: 1_048_576
+    field :notice_individual_body_size_limit, type: Integer, default: DEFAULT_NOTICE_INDIVIDUAL_BODY_SIZE_LIMIT
     field :notice_total_body_size_limit, type: Integer, default: 0
     field :notice_individual_file_size_limit, type: Integer, default: 0
     field :notice_total_file_size_limit, type: Integer, default: 0
@@ -17,11 +19,29 @@ module Gws::Addon::Notice::ResourceLimitation
     validates :notice_individual_body_size_limit,
       numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
     validates :notice_total_body_size_limit,
-      numericality: { only_integer: true, greater_than_or_equal_to: 1_024 * 1_024, allow_blank: true }
+      numericality: {
+        only_integer: true, greater_than_or_equal_to: 1_024 * 1_024, allow_blank: true,
+        message: ->(_object, data) do
+          message = I18n.t("errors.messages.greater_than_or_equal_to", count: (1_024 * 1_024).to_fs(:human_size))
+          I18n.t("errors.format", attribute: data[:attribute], message: message)
+        end
+      }
     validates :notice_individual_file_size_limit,
-      numericality: { only_integer: true, greater_than_or_equal_to: 1_024 * 1_024, allow_blank: true }
+      numericality: {
+        only_integer: true, greater_than_or_equal_to: 1_024 * 1_024, allow_blank: true,
+        message: ->(_object, data) do
+          message = I18n.t("errors.messages.greater_than_or_equal_to", count: (1_024 * 1_024).to_fs(:human_size))
+          I18n.t("errors.format", attribute: data[:attribute], message: message)
+        end
+      }
     validates :notice_total_file_size_limit,
-      numericality: { only_integer: true, greater_than_or_equal_to: 1_024 * 1_024, allow_blank: true }
+      numericality: {
+        only_integer: true, greater_than_or_equal_to: 1_024 * 1_024, allow_blank: true,
+        message: ->(_object, data) do
+          message = I18n.t("errors.messages.greater_than_or_equal_to", count: (1_024 * 1_024).to_fs(:human_size))
+          I18n.t("errors.format", attribute: data[:attribute], message: message)
+        end
+      }
   end
 
   def notice_individual_body_size_limit_mb
@@ -30,7 +50,7 @@ module Gws::Addon::Notice::ResourceLimitation
   end
 
   def notice_individual_body_size_limit_mb=(value)
-    self.notice_individual_body_size_limit = value.nil? ? nil : Integer(value) * 1_024 * 1_024
+    self.notice_individual_body_size_limit = value.numeric? ? Integer(value) * 1_024 * 1_024 : 0
   end
 
   def notice_total_body_size_limit_mb
@@ -39,7 +59,7 @@ module Gws::Addon::Notice::ResourceLimitation
   end
 
   def notice_total_body_size_limit_mb=(value)
-    self.notice_total_body_size_limit = value.nil? ? nil : Integer(value) * 1_024 * 1_024
+    self.notice_total_body_size_limit = value.numeric? ? Integer(value) * 1_024 * 1_024 : 0
   end
 
   def notice_individual_file_size_limit_mb
@@ -48,7 +68,7 @@ module Gws::Addon::Notice::ResourceLimitation
   end
 
   def notice_individual_file_size_limit_mb=(value)
-    self.notice_individual_file_size_limit = value.nil? ? nil : Integer(value) * 1_024 * 1_024
+    self.notice_individual_file_size_limit = value.numeric? ? Integer(value) * 1_024 * 1_024 : 0
   end
 
   def notice_total_file_size_limit_mb
@@ -57,7 +77,7 @@ module Gws::Addon::Notice::ResourceLimitation
   end
 
   def notice_total_file_size_limit_mb=(value)
-    self.notice_total_file_size_limit = value.nil? ? nil : Integer(value) * 1_024 * 1_024
+    self.notice_total_file_size_limit = value.numeric? ? Integer(value) * 1_024 * 1_024 : 0
   end
 
   def notice_total_body_size_over?


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

容量制限の項目いずれかを空にして保存ボタンをクリックすると500エラーになる問題の修正
エラーメッセージが、ちょっと意味不明だったので合わせて修正。