### PR TITLE
[modify] .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -158,6 +158,9 @@ Rails:
 Rails/Output:
   Enabled: false
 
+Rails/StrongParametersExpect:
+  Enabled: false
+
 Style/ArgumentsForwarding:
   Enabled: false
 


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

- "plugsin" を使用（"require" の代わりに）
- cop "Rails/StrongParametersExpect" を除外。`params.permit` の代わりに `params.expect` を使えという指示だが、両者に互換性はなくシラサギの場合はほぼ全てのケースにおいて `params.permit` を利用するのが適切。