### PR TITLE
[fix] cms/link checker : get_internal_file subdir site path

### DIFF
--- a/app/controllers/cms/agents/tasks/links_controller.rb
+++ b/app/controllers/cms/agents/tasks/links_controller.rb
@@ -212,7 +212,7 @@ class Cms::Agents::Tasks::LinksController < ApplicationController
 
     url  = url.sub(/\?.*/, "")
     url  = Addressable::URI.unencode(url)
-    file = "#{@site.path}#{url}"
+    file = "#{@site.root_path}#{url}"
     file = File.join(file, "index.html") if Fs.directory?(file)
     Fs.file?(file) ? file : nil
   end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

リンクチェックの修正
サブディレクトリサイトのリンクチェック時に get_internal_file が必ず失敗する
この修正が無くても動作はする