### PR TITLE
[fixup][webmail] unable to edit a draft mail with attachments

### DIFF
--- a/app/controllers/webmail/mails_controller.rb
+++ b/app/controllers/webmail/mails_controller.rb
@@ -151,7 +151,10 @@ class Webmail::MailsController < ApplicationController
   def edit
     raise "404" unless @item.draft?
 
-    @item.set_ref_files(@item.attachments)
+    ref_files = @item.attachments.map do |attachment|
+      Webmail::PartFile.new(webmail_mode: @webmail_mode, account: params[:account], mail: @item, part: attachment)
+    end
+    @item.set_ref_files(ref_files)
 
     @dedicated = true
     render layout: "ss/dedicated"
@@ -179,7 +182,10 @@ class Webmail::MailsController < ApplicationController
     if resp
       @item.destroy_files
     else
-      @item.set_ref_files(@item.attachments)
+      ref_files = @item.attachments.map do |attachment|
+        Webmail::PartFile.new(webmail_mode: @webmail_mode, account: params[:account], mail: @item, part: attachment)
+      end
+      @item.set_ref_files(ref_files)
     end
 
     render_create resp, render_opts


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

下書きメールに添付ファイルが付いている場合、編集・送信できない問題の修正。