### PR TITLE
[fix] cms/syntax_checker : #each_html_with_index 500 error

### DIFF
--- a/app/models/cms/syntax_checker/base.rb
+++ b/app/models/cms/syntax_checker/base.rb
@@ -4,7 +4,7 @@ module Cms::SyntaxChecker::Base
   class << self
     def each_html_with_index(content, &block)
       Array(content.content).each_with_index do |value, index|
-        value = value.strip
+        value = value.to_s.strip
         # 'value' must be wrapped with "<div>"
         value = "<div>#{value}</div>" if !value.start_with?("<div>")
 


### PR DESCRIPTION
- [ ] 動作確認をしたか？
- [ ] ドキュメントやコメントを書いたか？

## 概要

本流では発生しないように思われるが、Cms::SyntaxChecker::Base.each_html_with_index にて500エラーが発生するケースがあった。

おそらく value はページ含まれる cms/column/value の field value だが value が string 以外の場合 (例えば数値入力としてintegerとかにすると)、500エラー。