### PR TITLE
[modify][gws][ad] 特定状況でのサーバーエラーの修正

### DIFF
--- a/app/models/concerns/gws/addon/portal/portlet/ad_file.rb
+++ b/app/models/concerns/gws/addon/portal/portlet/ad_file.rb
@@ -45,6 +45,7 @@ module Gws::Addon::Portal::Portlet
     private
 
     def normalize_ad_links
+      return if self.frozen?
       return if ad_links.blank?
 
       self.ad_links = ad_links.reject { blank_ad_link?(_1) }


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

削除後に `before_validation :normalize_ad_links` が実行される場合がある。
この場合 self は frozen になっているため、属性の変更が失敗する。
それを防御する。
