### PR TITLE
[fix] inquiry/answer : download source_url

### DIFF
--- a/app/models/inquiry/answer.rb
+++ b/app/models/inquiry/answer.rb
@@ -158,10 +158,12 @@ class Inquiry::Answer
   end
 
   def source_full_url
-    if source_url.present?
-      uri = ::Addressable::URI.parse(site.full_url)
-      uri.path = source_url
-      uri.to_s
+    return if source_url.blank?
+
+    if source_url.start_with?("/")
+      ::File.join(site.full_url, source_url)
+    else
+      source_url
     end
   end
 


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

お問い合わせの回答項目にて source_url が full_url になっていることがあり、ダウンロード時に500エラーが発生する