### PR TITLE
[fix](ss): confirmキャンセル時にボタンdisabledが解除されない問題を修正 (#551)

### DIFF
--- a/app/assets/javascripts/ss/lib/base.js.erb
+++ b/app/assets/javascripts/ss/lib/base.js.erb
@@ -789,6 +789,13 @@ this.SS = (function () {
   SS.onDoubleClickGuardClick = function(ev) {
     var $element = $(ev.target);
     var timeout = $element.data("ss-timeout") || SS.defaultTimeoutMillis;
+    // NOTE:
+    // - `ss_button_to` uses JS to build and submit a form and calls `ev.preventDefault()` even on "OK".
+    // - So, `defaultPrevented` alone can't distinguish "canceled" vs "will submit".
+    // - `SS_ButtonTo` marks submit path with `ev.ssButtonToSubmit = true`.
+    if (ev.isDefaultPrevented() && !ev.ssButtonToSubmit) {
+      return;
+    }
 
     $.rails.disableFormElement($element);
     if (timeout > -1) {

--- a/app/assets/javascripts/ss/lib/button_to.js
+++ b/app/assets/javascripts/ss/lib/button_to.js
@@ -53,10 +53,16 @@ SS_ButtonTo.invokeAction = function(ev) {
   var confirmation = $button.data('ss-confirmation');
   if (confirmation) {
     if (!confirm(confirmation)) {
+      // mark canceled for other handlers in this same click event
       ev.preventDefault();
       return;
     }
   }
+
+  // mark this click event as "will submit" for other handlers (e.g. double click guard)
+  // NOTE: we intentionally set this before ev.preventDefault() because some handlers
+  //       treat defaultPrevented as "canceled".
+  ev.ssButtonToSubmit = true;
 
   ev.preventDefault();
 

--- a/spec/features/gws/memo/notices/set_seen_all_spec.rb
+++ b/spec/features/gws/memo/notices/set_seen_all_spec.rb
@@ -86,6 +86,58 @@ describe 'gws/memo/notices', type: :feature, dbscope: :example, js: true do
         end
       end
     end
+
+    it do
+      visit index_path
+
+      within ".gws-memo-notices" do
+        within ".list-items" do
+          find("input[name='ids[]'][value='#{item1.id}']", visible: false).set(true)
+        end
+        expect(page).to have_checked_field("ids[]", with: item1.id, visible: false)
+
+        within ".list-head" do
+          page.dismiss_confirm(I18n.t("gws/notice.confirm.set_seen")) do
+            click_on I18n.t("gws/notice.links.set_seen")
+          end
+
+          expect(page).to have_button(I18n.t("gws/notice.links.set_seen"), disabled: false)
+          expect(page).to have_button(I18n.t("ss.links.delete"), disabled: false)
+
+          page.accept_confirm(I18n.t("gws/notice.confirm.set_seen")) do
+            click_on I18n.t("gws/notice.links.set_seen")
+          end
+        end
+      end
+
+      wait_for_notice I18n.t("ss.notice.set_seen")
+    end
+
+    it do
+      visit index_path
+
+      within ".gws-memo-notices" do
+        within ".list-items" do
+          find("input[name='ids[]'][value='#{item1.id}']", visible: false).set(true)
+        end
+        expect(page).to have_checked_field("ids[]", with: item1.id, visible: false)
+
+        within ".list-head" do
+          page.dismiss_confirm(I18n.t("ss.confirm.delete")) do
+            click_on I18n.t("ss.links.delete")
+          end
+
+          expect(page).to have_button(I18n.t("gws/notice.links.set_seen"), disabled: false)
+          expect(page).to have_button(I18n.t("ss.links.delete"), disabled: false)
+
+          page.accept_confirm(I18n.t("ss.confirm.delete")) do
+            click_on I18n.t("ss.links.delete")
+          end
+        end
+      end
+
+      wait_for_notice I18n.t("ss.notice.deleted")
+    end
   end
 
   context "popup" do
@@ -94,8 +146,9 @@ describe 'gws/memo/notices', type: :feature, dbscope: :example, js: true do
     it do
       visit portal_path
 
-      first(".gws-memo-notice.popup-notice-container").click
       within ".gws-memo-notice.popup-notice-container" do
+        wait_for_event_fired("ss:dropdownOpened") { first("a.ajax-popup-notice").click }
+
         within ".popup-notice-items" do
           expect(page).to have_css(".list-item", text: item1.subject)
           expect(page).to have_css(".list-item", text: item2.subject)
@@ -117,8 +170,9 @@ describe 'gws/memo/notices', type: :feature, dbscope: :example, js: true do
     it do
       visit portal_path
 
-      first(".gws-memo-notice.popup-notice-container").click
       within ".gws-memo-notice.popup-notice-container" do
+        wait_for_event_fired("ss:dropdownOpened") { first("a.ajax-popup-notice").click }
+
         within ".popup-notice-items" do
           expect(page).to have_css(".list-item", text: item1.subject)
           expect(page).to have_css(".list-item", text: item2.subject)
@@ -130,9 +184,9 @@ describe 'gws/memo/notices', type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t("ss.notice.set_seen")
 
-      first(".gws-memo-notice.popup-notice-container").click
-      wait_for_js_ready
       within ".gws-memo-notice.popup-notice-container" do
+        wait_for_event_fired("ss:dropdownOpened") { first("a.ajax-popup-notice").click }
+
         within ".popup-notice-items" do
           expect(page).to have_css(".list-item.empty", text: I18n.t("gws/memo/message.notice.no_recents"))
         end


### PR DESCRIPTION


* [fix](ss): confirmキャンセル時にボタンdisabledが解除されない問題を修正

* fix: prevent double submit guard conflict for ss_button_to

---------

- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
通知一覧で、「既読にする」ボタンを押した後に「キャンセル」ボタンを押すと「既読にする」ボタンがDisableのままになる不具合の修正

<img width="1901" height="424" alt="スクリーンショット 2026-01-07 10 29 17（2）" src="https://github.com/user-attachments/assets/86f68ad3-e12c-4e74-828e-b7fb1cd220e6" />


## 変更内容
`ss_button_to` と二重クリック防止（double click guard）のイベント処理が競合し、意図した「クリック無効化」が効かないケースがあったため、**「キャンセル」と「送信する」経路をイベント上で識別できるようにして二重送信リスクを下げる**。

- **`ss_button_to` の submit 経路をイベントに明示**
  - `app/assets/javascripts/ss/lib/button_to.js`
  - confirm OK の場合でも `ev.preventDefault()` を呼ぶ実装のため、他ハンドラが `defaultPrevented` を「キャンセル」と誤認しないよう、`ev.ssButtonToSubmit = true` を先に付与
  - confirm Cancel の場合は従来通り `preventDefault` して終了（送信しない）

- **二重クリック防止側で「キャンセル」と「送信」を判別**
  - `app/assets/javascripts/ss/lib/base.js.erb`
  - これまで `ev.isDefaultPrevented()` のみで早期 return していたため、`ss_button_to` の submit 経路でも guard が効かない問題がありました
  - `ev.isDefaultPrevented() && !ev.ssButtonToSubmit` のときだけ早期 return するよう変更し、`ss_button_to` 送信時は guard（`$.rails.disableFormElement`）を継続

### 動作確認
- `ss_button_to`で **Cancel**: 送信されないこと／ボタンが無効化されないこと
- `ss_button_to`で **OK**: 1回目クリックで送信され、ボタンが無効化されること
