### PR TITLE
[fix][gws][notice] unable to restore posts which have start_on and/or end_on

### DIFF
--- a/app/controllers/gws/notice/trashes_controller.rb
+++ b/app/controllers/gws/notice/trashes_controller.rb
@@ -2,6 +2,8 @@ class Gws::Notice::TrashesController < ApplicationController
   include Gws::BaseFilter
   include Gws::CrudFilter
 
+  helper Gws::Notice::PlanHelper
+
   before_action :set_items
   before_action :set_item, only: [:show, :delete, :destroy, :undo_delete]
   before_action :set_selected_items, only: [:destroy_all, :soft_delete_all]

--- a/app/helpers/gws/notice/plan_helper.rb
+++ b/app/helpers/gws/notice/plan_helper.rb
@@ -35,12 +35,13 @@ module Gws::Notice::PlanHelper
     return unless @cur_site.notice_calendar_menu_visible?
     return unless item.term_enabled?
 
-    unless item.class.public_states.include?(item.state)
+    if !item.class.public_states.include?(item.state) || item.deleted?
+      # item は非公開または削除されている
       return only_icon ? nil : text.presence
     end
 
     if item.closed? && !@cur_site.notice_back_number_menu_visible?
-      # @item はバックナンバー。しかし、バックナンバーが非表示に設定されている
+      # item はバックナンバー。しかし、バックナンバーが非表示に設定されている
       return only_icon ? nil : text.presence
     end
 

--- a/spec/features/gws/notices/trash_spec.rb
+++ b/spec/features/gws/notices/trash_spec.rb
@@ -1,9 +1,14 @@
 require 'spec_helper'
 
 describe "gws_notices", type: :feature, dbscope: :example, js: true do
+  let(:now) { Time.zone.now.change(usec: 0) }
   let(:site) { gws_site }
   let(:folder) { create(:gws_notice_folder) }
-  let!(:item) { create :gws_notice_post, folder: folder, comment_state: "enabled", deleted: Time.zone.now }
+  let!(:item) do
+    create(
+      :gws_notice_post, folder: folder, comment_state: "enabled",
+      start_on: now - 1.day, end_on: now + 1.day, deleted: now)
+  end
 
   before { login_gws_user }
 


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

カレンダーが設定された投稿を復元できない。
復元しようとしてゴミ箱で内で開いたら 500 エラーが発生する。
この問題の修正。