### PR TITLE
テスト安定化（ユーザー一括ダウンロードのspecを実行日非依存にする）

### DIFF
--- a/spec/requests/sys/download_all_users_spec.rb
+++ b/spec/requests/sys/download_all_users_spec.rb
@@ -6,6 +6,7 @@ describe Sys::UsersController, type: :request, dbscope: :example, js: true do
   let(:group) { create(:ss_group, name: "Test Group") }
   let(:role) { create(:sys_role, name: "Test Role") }
   let(:organization) { create(:ss_group, name: "Test Organization") }
+  let(:now) { Time.zone.now }
   let(:index_path) { sys_users_path(site.id) }
   let(:new_path) { new_sys_user_path(site.id) }
   let(:download_path) { download_all_sys_users_path(site.id) }
@@ -18,8 +19,10 @@ describe Sys::UsersController, type: :request, dbscope: :example, js: true do
            email: "johndoe@example.com",
            tel: "123-456-7890",
            tel_ext: "1234",
-           account_start_date: "2025-01-01",
-           account_expiration_date: "2025-12-31",
+           # download_all の既定条件(state未指定)は enabled(active) のため、
+           # 固定日付にするとテスト実行日によって期限切れになり CSV から除外される。
+           account_start_date: now - 1.day,
+           account_expiration_date: now + 1.year,
            initial_password_warning: 1,
            session_lifetime: 3600,
            restriction: "api_only",


### PR DESCRIPTION
## 概要
`spec/requests/sys/download_all_users_spec.rb` が失敗しているため、修正。
固定日付だと期限切れ扱いでCSV出力件数が変わるため、アカウント開始/終了日を相対日時に変更してテストを安定化。



