### PR TITLE
[modify]iOS Safari で Material Icons が表示されない問題の修正

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -722,9 +722,11 @@ _:future,
       text-align: center;
     }
     &.opened::before {
+      // Material Icons Outlined: arrow_back
       content: "\e5c4";
     }
     &.closed::before {
+      // Material Icons Outlined: arrow_forward
       content: "\e5c8";
     }
   }
@@ -1526,19 +1528,24 @@ _:future,
     font-size: 20px;
   }
   .icon-material-display::before {
-    content: "display_settings" !important;
+    // Material Icons Outlined: settings_display (was display_settings)
+    content: "\e8bd" !important;
   }
   .icon-material-import-node::before {
-    content: "drive_folder_upload" !important;
+    // Material Icons Outlined: drive_folder_upload
+    content: "\e9a3" !important;
   }
   .icon-material-more-horiz::before {
-    content: "more_horiz" !important;
+    // Material Icons Outlined: more_horiz
+    content: "\e5d3" !important;
   }
   .icon-material-settings::before {
-    content: "settings" !important;
+    // Material Icons Outlined: settings
+    content: "\e8b8" !important;
   }
   .icon-material-shortcut::before {
-    content: "shortcut" !important;
+    // Material Icons Outlined: shortcut
+    content: "\f060" !important;
   }
 }
 
@@ -2063,7 +2070,8 @@ footer.send {
     }
 
     &::before {
-      content: "pageview";
+      // Material Icons Outlined: pageview
+      content: "\e8a0";
       position: absolute;
       top: 5px;
       left: 10px;


### PR DESCRIPTION
## 概要
iOS Safari など一部環境で Material Icons のリガチャ表示が崩れてアイコンが表示されない問題に対し、CMSで使うアイコンも含めて コードポイント指定に統一して表示させる修正

## 変更内容
app/assets/stylesheets/ss/_pc_mb.scss の一部アイコン指定を、リガチャ文字列（例: "arrow_back"）から Material Icons Outlined のコードポイント（例: "\e5c4"） に変更
対象アイコン（例）: サイドメニュー開閉（arrow_back / arrow_forward）、表示系（settings_display）、アップロード（drive_folder_upload）、その他UI（more_horiz / settings / shortcut）、CMS内で使う pageview
各指定に「どのアイコンのコードポイントか」が分かるコメントを付与（レビュー・保守用）

## 参考
https://fonts.google.com/icons?icon.size=24&icon.color=%231f1f1f
