### PR TITLE
[modify]feature/tabular strip annotations

### DIFF
--- a/app/models/gws/tabular.rb
+++ b/app/models/gws/tabular.rb
@@ -124,7 +124,19 @@ module Gws::Tabular
 
   def render_component(component)
     result = ApplicationController.new.render_to_string(component)
-    result.to_s.strip.presence
+    result = strip_action_view_annotations(result.to_s)
+    result.strip.presence
+  end
+
+  def strip_action_view_annotations(str)
+    return str if str.blank?
+
+    # `config.action_view.annotate_rendered_view_with_filenames = true` のときに挿入される
+    # `<!-- BEGIN ... -->` / `<!-- END ... -->` を除去する。
+    #
+    # これが通知件名など「文字列として保存・エスケープ表示」される箇所に混入すると、
+    # そのまま本文として表示されてしまうため、ここで吸収する。
+    str.gsub(/<!--\s*(?:BEGIN|END)\s+[^>]*?(?:app|vendor|lib|gems)\/[^>]*-->\s*/m, '')
   end
 
   def item_title(item, site:)

--- a/spec/models/gws/tabular/render_component_spec.rb
+++ b/spec/models/gws/tabular/render_component_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe Gws::Tabular do
+  describe ".render_component" do
+    it "ActionView のレンダリング注釈（BEGIN/END）を除去する" do
+      annotated = <<~HTML
+        <!-- BEGIN app/components/gws/tabular/column/text_field_component/show_text.html.erb -->
+        20260108テスト
+        <!-- END app/components/gws/tabular/column/text_field_component/show_text.html.erb -->
+      HTML
+
+      allow_any_instance_of(ApplicationController).to receive(:render_to_string).and_return(annotated)
+
+      result = described_class.render_component(Object.new)
+      expect(result).to eq "20260108テスト"
+    end
+  end
+end


### PR DESCRIPTION
- [x] 動作確認をしたか？（RSpec: spec/models/gws/tabular/render_component_spec.rb）

## 概要
通知のTabularコンポーネント描画結果に含まれるBEGIN/END注釈を除去し、表示崩れを防止します。

## 変更内容
- Tabular描画結果からBEGIN/END注釈を除去
- 上記を検証するspecを追加
