### PR TITLE
インストール手順の重複文を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SHIRASAGI is Contents Management System.
 ## Installation (Auto)
 
 - AlmaLinux8 の環境で実行してください。<br />
-- 一般ユーザーで実行する場合はユーザーで実行する場合は、sudo が利用できることを確認してください。<br />
+- 一般ユーザーで実行する場合は、sudo が利用できることを確認してください。<br />
 - パラメーターの"example.jp"には、ブラウザでアクセスする際のドメイン名または、IPアドレスを指定してください。<br />
 
 ```


### PR DESCRIPTION
・インストール手順（Auto）内の「一般ユーザーで実行する場合は…」が重複していたため、重複部分を削除しました。
・ドキュメントのみの変更です。