### PR TITLE
[fix][cms] labeled "unused" even if the file is used

### DIFF
--- a/app/models/cms.rb
+++ b/app/models/cms.rb
@@ -438,4 +438,13 @@ module Cms
     return SS::EMPTY_ARRAY if values.blank?
     values.filter_map { _1.present? ? I18n.t("cms.options.shortcut.#{_1}") : nil }
   end
+
+  def self.file_used?(containable, file)
+    contains_urls = containable.try(:contains_urls)
+    return false if contains_urls.blank?
+
+    contains_urls.include?(file.url) ||
+      contains_urls.include?(file.url_with_name) ||
+      contains_urls.include?(file.url_with_filename)
+  end
 end

--- a/app/views/cms/agents/addons/file/_show.html.erb
+++ b/app/views/cms/agents/addons/file/_show.html.erb
@@ -12,15 +12,14 @@
     <div id="selected-files">
       <% @item.files.try(:each) do |file| %>
         <%
-          css_class = if @item.respond_to?(:contains_urls)
-                          @item.contains_urls&.include?(file.url) ? "file-view" : "file-view unused"
-                      else
-                        "file-view"
-                      end
+          css_classes = %w(file-view)
+          unless Cms.file_used?(@item, file)
+            css_classes << "unused"
+          end
         %>
-        <div id="file-<%= file.id %>" class="<%= css_class %>" data-file-id="<%= file.id %>">
+        <div id="file-<%= file.id %>" class="<%= css_classes.join(" ") %>" data-file-id="<%= file.id %>">
           <%= sanitizer_status(file) %>
-          <% if css_class.include?("unused") %>
+          <% if css_classes.include?("unused") %>
             <span class="unused-message"><%= t("ss.unused_file") %></span>
           <% end %>
           <%= link_to file.url, class: :thumb, target: "_blank", rel: "noopener" do %>
@@ -56,7 +55,7 @@
               <% else %>
                 <%= link_to t('ss.buttons.replace_file'), params[:cid].blank? ? edit_cms_apis_replace_file_path(owner_item_id: @item, id: file) : edit_cms_apis_node_replace_file_path(owner_item_id: @item, id: file.id), class: "ajax-box" %>
               <% end %>
-              <% if css_class.include?("unused") %>
+              <% if css_classes.include?("unused") %>
                 <%= link_to t('ss.buttons.delete'), delete_cms_apis_delete_unused_file_path(owner_item_id: @item, id: file), class: "ajax-box" %>
               <% end %>
             </div>

--- a/app/views/cms/agents/columns/free/_column_show.html.erb
+++ b/app/views/cms/agents/columns/free/_column_show.html.erb
@@ -7,15 +7,14 @@
     <div id="selected-files">
       <% value.files.each do |file| %>
         <%
-          css_class = if value.respond_to?(:contains_urls)
-                          value.contains_urls&.include?(file.url) ? "file-view" : "file-view unused"
-                      else
-                        "file-view"
-                      end
+          css_classes = %w(file-view)
+          unless Cms.file_used?(value, file)
+            css_classes << "unused"
+          end
         %>
-        <div id="file-<%= file.id %>" class="<%= css_class %>" data-file-id="<%= file.id %>">
+        <div id="file-<%= file.id %>" class="<%= css_classes.join(" ") %>" data-file-id="<%= file.id %>">
           <%= sanitizer_status(file) %>
-          <% if css_class.include?("unused") %>
+          <% if css_classes.include?("unused") %>
             <span class="unused-message"><%= t("ss.unused_file") %></span>
           <% end %>
           <%= link_to file.url, class: :thumb, target: "_blank", rel: "noopener" do %>
@@ -51,7 +50,7 @@
               <% else %>
                 <%= link_to t('ss.buttons.replace_file'), params[:cid].blank? ? edit_cms_apis_replace_file_path(owner_item_id: @item, id: file) : edit_cms_apis_node_replace_file_path(owner_item_id: @item, id: file), class: "ajax-box" %>
               <% end %>
-              <% if css_class.include?("unused") %>
+              <% if css_classes.include?("unused") %>
                 <%= link_to t('ss.buttons.delete'), delete_cms_apis_delete_unused_file_path(owner_item_id: @item, id: file), class: "ajax-box" %>
               <% end %>
             </div>

--- a/spec/features/cms/agents/addons/file/file_view_rendering_spec.rb
+++ b/spec/features/cms/agents/addons/file/file_view_rendering_spec.rb
@@ -166,12 +166,13 @@ end
 
 # 自由入力の詳細画面テスト
 describe 'cms_agents_addons_file', type: :feature, dbscope: :example, js: true do
-  let(:site) { cms_site }
+  let!(:site) { cms_site }
+  let!(:user) { cms_user }
   let!(:node) do
     create :article_node_page, cur_site: site, cur_user: user, filename: "docs", name: "article", group_ids: [cms_group.id],
     st_form_ids: [form.id]
   end
-  let!(:item) { create :article_page, cur_node: node, group_ids: [cms_group.id] }
+  let!(:item) { create :article_page, cur_site: site, cur_user: user, cur_node: node, group_ids: [cms_group.id] }
   let!(:edit_path) { edit_article_page_path site.id, node, item }
   let!(:form) { create(:cms_form, cur_site: site, state: 'public', sub_type: 'entry', group_ids: [cms_group.id]) }
   let!(:column2) { create(:cms_column_free, cur_site: site, cur_form: form, required: "optional", order: 2) }

--- a/spec/features/cms/agents/addons/file/file_view_rendering_spec.rb
+++ b/spec/features/cms/agents/addons/file/file_view_rendering_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 # 既定フィールドの詳細画面テスト
 describe 'cms_agents_addons_file', type: :feature, dbscope: :example, js: true do
-  let(:site) { cms_site }
-  let!(:node) { create :article_node_page, cur_site: site, cur_user: cms_user }
-  let!(:file) { tmp_ss_file contents: "#{Rails.root}/spec/fixtures/ss/logo.png", user: cms_user, basename: "#{unique_id}.jpg" }
+  let!(:site) { cms_site }
+  let!(:user) { cms_user }
+  let!(:node) { create :article_node_page, cur_site: site, cur_user: user }
+  let!(:file) { tmp_ss_file contents: "#{Rails.root}/spec/fixtures/ss/logo.png", user: user, basename: "#{unique_id}.jpg" }
   let(:logo_path) { "#{Rails.root}/spec/fixtures/ss/logo.png" }
   let(:keyvisual_path) { "#{Rails.root}/spec/fixtures/ss/file/keyvisual.jpg" }
 
@@ -106,7 +107,7 @@ describe 'cms_agents_addons_file', type: :feature, dbscope: :example, js: true d
 
         within "#addon-cms-agents-addons-file" do
           within ".file-view.unused" do
-            expect(page).to have_content(I18n.t("ss.unused_file"))
+            expect(page).to have_css(".unused-message", text: I18n.t("ss.unused_file"))
             expect(page).to have_content(I18n.t("ss.buttons.delete"))
             wait_for_cbox_opened { click_link I18n.t("ss.buttons.delete") }
           end
@@ -125,6 +126,41 @@ describe 'cms_agents_addons_file', type: :feature, dbscope: :example, js: true d
         end
       end
     end
+
+    describe "when file_url_with is `name` but page was created by `filename`" do
+      let!(:item) do
+        create(
+          :article_page, cur_site: site, cur_user: user, cur_node: node, file_ids: [file.id], group_ids: [cms_group.id])
+      end
+
+      before do
+        html = <<~HTML
+          <a class="icon-png" href="#{file.url}">#{file.humanized_name}</a>
+        HTML
+        item.update!(html: html)
+
+        @save_file_url_with = SS.config.replace_value_at(:ss, :file_url_with, "name")
+        file.update!(name: ss_japanese_text)
+      end
+
+      after do
+        SS.config.replace_value_at(:ss, :file_url_with, @save_file_url_with)
+      end
+
+      it do
+        visit article_page_path(site: site, cid: node, id: item)
+        wait_for_all_ckeditors_ready
+        wait_for_all_turbo_frames
+        expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
+
+        within "#addon-cms-agents-addons-file" do
+          expect(page).to have_css(".file-view", count: 1)
+          within ".file-view" do
+            expect(page).to have_no_css(".unused-message")
+          end
+        end
+      end
+    end
   end
 end
 
@@ -132,14 +168,14 @@ end
 describe 'cms_agents_addons_file', type: :feature, dbscope: :example, js: true do
   let(:site) { cms_site }
   let!(:node) do
-    create :article_node_page, cur_site: site, cur_user: cms_user, filename: "docs", name: "article", group_ids: [cms_group.id],
+    create :article_node_page, cur_site: site, cur_user: user, filename: "docs", name: "article", group_ids: [cms_group.id],
     st_form_ids: [form.id]
   end
   let!(:item) { create :article_page, cur_node: node, group_ids: [cms_group.id] }
   let!(:edit_path) { edit_article_page_path site.id, node, item }
   let!(:form) { create(:cms_form, cur_site: site, state: 'public', sub_type: 'entry', group_ids: [cms_group.id]) }
   let!(:column2) { create(:cms_column_free, cur_site: site, cur_form: form, required: "optional", order: 2) }
-  let!(:file) { tmp_ss_file contents: "#{Rails.root}/spec/fixtures/ss/logo.png", user: cms_user, basename: "#{unique_id}.jpg" }
+  let!(:file) { tmp_ss_file contents: "#{Rails.root}/spec/fixtures/ss/logo.png", user: user, basename: "#{unique_id}.jpg" }
   let(:logo_path) { "#{Rails.root}/spec/fixtures/ss/logo.png" }
 
   before do
@@ -211,7 +247,7 @@ describe 'cms_agents_addons_file', type: :feature, dbscope: :example, js: true d
         element = find(".file-view[data-file-id='#{shirasagi_file.id}']")
         expect(element['class']).to include('unused')
         expect(page).to have_css(".file-view.unused", text: shirasagi_file.name)
-        expect(page).to have_content(I18n.t("ss.unused_file"))
+        expect(page).to have_css(".unused-message", text: I18n.t("ss.unused_file"))
 
         within ".file-view.unused" do
           expect(page).to have_link(I18n.t("ss.buttons.delete"))


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

使用中のファイルに「未使用」とラベリングされる問題の修正

## 変更内容

運用の途中で日本語ファイル名を有効化した場合、
英数字ファイル名で作成したリンクに対してマッチングが失敗するので
成功するように修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイル参照検出を強化し、名前付きURLやファイル名を含む参照も考慮して未使用判定の精度を向上しました。

* **リファクター**
  * 各画面の未使用ファイル表示ロジックを統一し、一貫した表示・削除動作にしました。

* **テスト**
  * 検出と表示挙動を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->