### PR TITLE
[modify] cms user: show other site

### DIFF
--- a/app/views/cms/users/_show.html.erb
+++ b/app/views/cms/users/_show.html.erb
@@ -63,5 +63,9 @@
 
   <% group_ids = Cms::Group.unscoped.site(@cur_site).pluck(:id) %>
   <dt><%= @model.t :group_ids %></dt>
-  <dd><%= br @item.groups.order_by(name: 1).select{ |c| group_ids.include?(c.id) }.map{|c| c.name} %></dd>
+  <dd>
+    <% @item.groups.order_by(name: 1).to_a.sort_by { |c| group_ids.include?(c.id) ? 0 : 1 }.map do |c| %>
+      <%= "(#{t('cms.other_site')}) " unless group_ids.include?(c.id) %><%= c.name %><br>
+    <% end %>
+  </dd>
 </dl>

--- a/app/views/cms/users/_show.html.erb
+++ b/app/views/cms/users/_show.html.erb
@@ -64,7 +64,7 @@
   <% group_ids = Cms::Group.unscoped.site(@cur_site).pluck(:id) %>
   <dt><%= @model.t :group_ids %></dt>
   <dd>
-    <% @item.groups.order_by(name: 1).to_a.sort_by { |c| group_ids.include?(c.id) ? 0 : 1 }.map do |c| %>
+    <% @item.groups.order_by(name: 1).to_a.sort_by { |c| group_ids.include?(c.id) ? 0 : 1 }.each do |c| %>
       <%= "(#{t('cms.other_site')}) " unless group_ids.include?(c.id) %><%= c.name %><br>
     <% end %>
   </dd>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -74,6 +74,7 @@ ja:
     node: フォルダー
     node_config: フォルダー設定
     notice: お知らせ
+    other_site: 他サイト
     page: 固定ページ
     page_search: ページ検索
     part: パーツ


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [ ] ドキュメントやコメントを書いたか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * CMS管理画面でユーザーのグループ表示を改善しました。所属グループは先に表示され、所属していないグループには「(他サイト)」ラベルが付くようになり、全グループが一覧で確認できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->