### PR TITLE
[modify] site_search: show groups

### DIFF
--- a/app/controllers/cms/agents/nodes/site_search_controller.rb
+++ b/app/controllers/cms/agents/nodes/site_search_controller.rb
@@ -65,7 +65,7 @@ class Cms::Agents::Nodes::SiteSearchController < ApplicationController
 
     if @cur_site.elasticsearch_sites.present?
       @s.index = @cur_site.elasticsearch_sites.collect { |site| "s#{site.id}" }.join(",")
-      # @aggregation.index = @s.index
+      # @aggregation.index = @s.index # 複数サイトを検索するなら設定する
     end
 
     if params[:target] == 'outside' && @cur_site.elasticsearch_outside_enabled?

--- a/app/models/cms/elasticsearch/page_converter.rb
+++ b/app/models/cms/elasticsearch/page_converter.rb
@@ -18,6 +18,11 @@ class Cms::Elasticsearch::PageConverter
     @html = Fs.exist?(item.path) ? Fs.read(item.path) : item.try(:html)
     @content_html = nil
 
+    categories = item.categories.and_public
+    contact_sub_groups = item.try(:contact_sub_groups) || []
+    groups = contact_sub_groups.pluck(:id).push(item.try(:contact_group_id)).uniq.compact
+    groups.delete_if { |g| g[:elasticsearch_state] == 'disabled' }
+
     doc = {}
     doc[:site_id] = @site.id
     doc[:url] = item.url
@@ -26,11 +31,10 @@ class Cms::Elasticsearch::PageConverter
     doc[:text] = item_text
     doc[:filename] = item.path
     doc[:state] = item.state
-    doc[:category_ids] = item.category_ids
-    doc[:categories] = item.categories.pluck(:name)
-    contact_sub_groups = item.try(:contact_sub_groups) || []
-    doc[:group_ids] = contact_sub_groups.pluck(:id).push(item.try(:contact_group_id)).uniq.compact
-    doc[:groups] = contact_sub_groups.pluck(:name).push(item.try(:contact_group).try(:name)).uniq.compact
+    doc[:categories] = categories.map(&:name)
+    doc[:category_ids] = categories.map(&:id)
+    doc[:groups] = groups.map(&:name).uniq
+    doc[:group_ids] = groups.map(&:id).uniq
     doc[:group_names] = doc[:groups].map { |n| n.split('/') }.flatten.uniq
     doc[:keywords] = item.try(:keywords).try(:join, "\n")
     doc[:description] = item.try(:description)
@@ -118,6 +122,11 @@ class Cms::Elasticsearch::PageConverter
   def convert_file_to_doc(file)
     @file_html = parse_file_html(file)
 
+    categories = item.categories.and_public
+    contact_sub_groups = item.try(:contact_sub_groups) || []
+    groups = contact_sub_groups.pluck(:id).push(item.try(:contact_group_id)).uniq.compact
+    groups.delete_if { |g| g[:elasticsearch_state] == 'disabled' }
+
     doc = {}
     doc[:site_id] = @site.id
     doc[:name] = file_name || file.name
@@ -129,11 +138,10 @@ class Cms::Elasticsearch::PageConverter
     doc[:file][:extname] = file.extname.upcase
     doc[:file][:size] = file.size
     doc[:state] = item.state
-    doc[:category_ids] = item.category_ids
-    doc[:categories] = item.categories.pluck(:name)
-    contact_sub_groups = item.try(:contact_sub_groups) || []
-    doc[:group_ids] = contact_sub_groups.pluck(:id).push(item.try(:contact_group_id)).uniq.compact
-    doc[:groups] = contact_sub_groups.pluck(:name).push(item.try(:contact_group).try(:name)).uniq.compact
+    doc[:categories] = categories.map(&:name)
+    doc[:category_ids] = categories.map(&:id)
+    doc[:groups] = groups.map(&:name).uniq
+    doc[:group_ids] = groups.map(&:id).uniq
     doc[:group_names] = doc[:groups].map { |n| n.split('/') }.flatten.uniq
     doc[:released] = item.released.try(:iso8601)
     doc[:updated] = file.updated.try(:iso8601)

--- a/app/models/cms/group.rb
+++ b/app/models/cms/group.rb
@@ -3,6 +3,7 @@ class Cms::Group
   include Cms::SitePermission
   include Contact::Addon::Group
   include Lsorg::Addon::Group
+  include Cms::Addon::Elasticsearch::Group
 
   set_permission_name "cms_groups", :edit
 

--- a/app/models/concerns/cms/addon/elasticsearch/group.rb
+++ b/app/models/concerns/cms/addon/elasticsearch/group.rb
@@ -1,0 +1,26 @@
+module Cms::Addon::Elasticsearch
+  module Group
+    extend ActiveSupport::Concern
+    extend SS::Addon
+
+    included do
+      field :elasticsearch_state, type: String
+      permit_params :elasticsearch_state
+
+      # scope :and_elasticsearch_enabled -> {
+      #   self.and("$or" => [{ elasticsearch_state: nil }, { elasticsearch_state: 'enabled' }])
+      # }
+      # scope :and_elasticsearch_disabled, -> {
+      #   self.and(elasticsearch_state: 'disabled')
+      # }
+    end
+
+    def elasticsearch_state_options
+      %w(enabled disabled).map { |v| [ I18n.t("ss.options.state.#{v}"), v ] }
+    end
+
+    # def elasticsearch_enabled?
+    #   elasticsearch_state != 'disabled'
+    # end
+  end
+end

--- a/app/views/cms/agents/addons/elasticsearch/group/_form.html.erb
+++ b/app/views/cms/agents/addons/elasticsearch/group/_form.html.erb
@@ -1,0 +1,7 @@
+<%
+  return unless @cur_site.elasticsearch_enabled?
+%>
+<dl class="see mod-cms-elasticsearch-group">
+  <dt><%= @model.t :elasticsearch_state %><%= @model.tt :elasticsearch_state %></dt>
+  <dd><%= f.select :elasticsearch_state, @item.elasticsearch_state_options, include_blank: '' %></dd>
+</dl>

--- a/app/views/cms/agents/addons/elasticsearch/group/_show.html.erb
+++ b/app/views/cms/agents/addons/elasticsearch/group/_show.html.erb
@@ -1,0 +1,7 @@
+<%
+  return unless @cur_site.elasticsearch_enabled?
+%>
+<dl class="see mod-cms-elasticsearch-group">
+  <dt><%= @model.t :elasticsearch_state %></dt>
+  <dd><%= @item.label(:elasticsearch_state) || t('ss.options.state.enabled') %></dd>
+</dl>

--- a/app/views/cms/agents/nodes/site_search/_result.html.erb
+++ b/app/views/cms/agents/nodes/site_search/_result.html.erb
@@ -17,18 +17,30 @@ document.addEventListener('DOMContentLoaded', () => {
       const select = form.querySelector('.site-search-categories select[name="s[category_names][]"]');
       const input = form.querySelector('.site-search-categories input[name="s[category_name]"]');
 
-      if (!select.disabled) {
+      if (select && !select.disabled) {
         let option = select.querySelector('option[value="' + name + '"]');
         if (option) {
           option.selected = true;
           form.submit();
         }
-      } else if (!input.disabled) {
+      } else if (input && !input.disabled) {
         let values = input.value.split(/[\s\/　]+/).filter(n => n)
         if (!values.includes(name)) values = values.concat(name)
         input.value = values.join(' ');
         form.submit();
       }
+    });
+  });
+  document.querySelectorAll('.cms-site-search-pages .group-name').forEach(group => {
+    group.addEventListener('click', () => {
+      const name = group.text;
+      const form = document.querySelector('.search-form');
+      const input = form.querySelector('.site-search-organization input[name="s[group_name]"]');
+
+      let values = input.value.split(/[\s\/　]+/).filter(n => n)
+      if (!values.includes(name)) values = values.concat(name)
+      input.value = values.join(' ');
+      form.submit();
     });
   });
 });
@@ -86,8 +98,6 @@ document.addEventListener('DOMContentLoaded', () => {
           if hit.dig('highlight', 'text_index')
             text = hit.dig('highlight', 'text_index')[0].gsub(/[\s\n]+/, ' ').strip
           end
-
-          categories = source['categories'].presence || []
         %>
         <h2><%= link_to title, url, class: 'title', target: link_target %></h2>
         <div class="summary">
@@ -112,11 +122,19 @@ document.addEventListener('DOMContentLoaded', () => {
               </time>
             </div>
           <% end %>
-          <% if @cur_node.category_state != 'hide' && categories.present? %>
+          <% if @cur_node.category_state != 'hide' && source['categories'].present? %>
             <div class="category-list">
               <%= Cms::Page.t(:category_ids) %>:
-              <% categories.each_with_index do |name, idx| %>
+              <% source['categories'].each_with_index do |name, idx| %>
                 <%= ' | ' if idx > 0 %><a class="category-name"><%= name %></a>
+              <% end %>
+            </div>
+          <% end %>
+          <% if @cur_site.elasticsearch_site_ids.present? && @cur_node.organization_state != 'hide' && source['group_names'].present? %>
+            <div class="group-list">
+              <%= t("ss.organization") %>:
+              <% source['group_names'].each_with_index do |name, idx| %>
+                <%= ' | ' if idx > 0 %><a class="group-name"><%= name %></a>
               <% end %>
             </div>
           <% end %>

--- a/app/views/cms/agents/nodes/site_search/index.html.erb
+++ b/app/views/cms/agents/nodes/site_search/index.html.erb
@@ -101,6 +101,8 @@ Cms_Site_Search_History.render(".cms-site-search .search-form", "<%= @cur_node.f
         options = []
         if @cur_node.st_categories.present?
           options = @cur_node.st_categories.map { |c| [c.name, c.name] }
+        elsif @cur_site.elasticsearch_site_ids.present?
+          options = []
         elsif categories = (@aggregation.search_categories || {}).dig('aggregations', 'categories', 'buckets')
           options = categories.map { |c| [c['key'], c['key']] }
         end

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -821,6 +821,7 @@ ja:
       cms/print: 印刷
       cms/clipboard_copy: クリップボードへコピー
       cms/form_search: 定型フォーム絞込検索
+      cms/elasticsearch/group: サイト内検索設定
     columns:
       cms/text_field: 一行入力
       cms/date_field: 日付入力
@@ -1974,6 +1975,8 @@ ja:
         search_node_id: 検索フォルダー
         column_name: 検索項目名
         column_kind: 検索パターン
+      cms/addon/elasticsearch/group:
+        elasticsearch_state: 検索インデックス
 
   activemodel:
     attributes:
@@ -3627,6 +3630,11 @@ ja:
         検索項目名を入力します。
       column_kind: |-
         検索パターンを設定します。
+
+    cms/addon/elasticsearch/group:
+      elasticsearch_state:
+        - グループ名を検索結果として表示するかを設定します。
+        - デフォルトは有効です。
 
   all_content:
     page_id: ページID

--- a/spec/features/cms/agents/nodes/site_search2_spec.rb
+++ b/spec/features/cms/agents/nodes/site_search2_spec.rb
@@ -8,17 +8,17 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
   let!(:node) { create :article_node_page, layout_id: layout.id, filename: "node" }
   let!(:site_search_node) { create :cms_node_site_search, cur_site: site, cur_node: node }
 
-  let!(:group1) { create :cms_group, name: "#{cms_group.name}/#{unique_id}" }
-  let!(:group2) { create :cms_group, name: "#{cms_group.name}/#{unique_id}" }
-  let!(:cate1) { create :category_node_page }
-  let!(:cate2) { create :category_node_page }
+  let!(:group1) { create :cms_group, name: "#{cms_group.name}/政策" } # Choices.js: 1 character hit
+  let!(:group2) { create :cms_group, name: "#{cms_group.name}/企画" }
+  let!(:cate1) { create :category_node_page, name: "生活" }
+  let!(:cate2) { create :category_node_page, name: "くらし" }
   let!(:file1) { create :ss_file, site_id: site.id, user_id: user.id }
   let!(:file2) { create :ss_file, site_id: site.id, user_id: user.id }
 
   let!(:item1) { create :cms_page, cur_node: node, layout: layout, name: 'page1' }
   let!(:item2) do
     create :article_page, cur_node: node, layout: layout, name: 'page2',
-      file_ids: [file1.id], category_ids: [cate1.id], contact_sub_group_ids: [group1.id],
+      file_ids: [file1.id], category_ids: [cate1.id], group_ids: [group1.id], contact_sub_group_ids: [group1.id],
       html: '<img src="' + file1.url + '" alt="alt" title="title">'
   end
 
@@ -32,22 +32,22 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
   end
   let!(:item3) do
     create :article_page, cur_node: node, layout: layout, form: form, name: 'page3',
-      file_ids: [file2.id], category_ids: [cate2.id], contact_sub_group_ids: [group2.id],
+      file_ids: [file2.id], category_ids: [cate2.id], group_ids: [group2.id], contact_sub_group_ids: [group2.id],
       column_values: [
         column.value_type.new(column: column, file_id: file2.id, image_html_type: 'image')
       ]
   end
 
   before do
-    ::Cms::Elasticsearch.init_ingest(site: site)
-    ::Cms::Elasticsearch.drop_index(site: site) rescue nil
-    ::Cms::Elasticsearch.create_index(site: site)
+    Cms::Elasticsearch.init_ingest(site: site)
+    Cms::Elasticsearch.drop_index(site: site) rescue nil
+    Cms::Elasticsearch.create_index(site: site)
 
     Cms::PageIndexQueue.site(site).each do |item|
-      job = ::Cms::Elasticsearch::Indexer::PageReleaseJob.bind(site_id: site.id)
+      job = Cms::Elasticsearch::Indexer::PageReleaseJob.bind(site_id: site.id)
       ss_perform_now(job, action: item.job_action, id: item.page_id.to_s, queue_id: item.id.to_s)
     end
-    ::Cms::Elasticsearch.refresh_index(site: site)
+    Cms::Elasticsearch.refresh_index(site: site)
     expect(Cms::PageRelease.all.size).to eq 3
     expect(Cms::PageIndexQueue.all.size).to eq 0
   end
@@ -62,11 +62,11 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
       visit site_search_node.url
 
       within '.search-form' do
-        expect(page).to have_no_css(".site-search-type")
-        expect(page).to have_no_css(".site-search-target")
-        expect(page).to have_no_css(".site-search-article-node")
-        expect(page).to have_no_css(".site-search-categories")
-        expect(page).to have_no_css(".site-search-organization")
+        expect(page).not_to have_css(".site-search-type")
+        expect(page).not_to have_css(".site-search-target")
+        expect(page).not_to have_css(".site-search-article-node")
+        expect(page).not_to have_css(".site-search-categories")
+        expect(page).not_to have_css(".site-search-organization")
       end
     end
   end
@@ -78,14 +78,15 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
 
     it do
       visit site_search_node.url
+
       within '.search-form' do
         expect(page.all("select[name='s[article_node_ids][]'] option").count).to eq 2
         expect(page.all("select[name='s[category_names][]'] option").count).to eq 2
-        select I18n.t("cms.options.site_search_type.page"), from: "s[type]"
+        find("select[name='s[type]'] option[value='page']").select_option
         click_button I18n.t('ss.buttons.search')
       end
       within '.pages .item:nth-child(1)' do
-        expect(page).to have_no_selector('img')
+        expect(page).not_to have_selector('img')
       end
       within '.pages .item:nth-child(2)' do
         expect(page).to have_css('.title')
@@ -94,6 +95,7 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
         expect(page).to have_css('.meta .url')
         expect(page).to have_css('.meta .date')
         expect(page).to have_css('.meta .category-list')
+        expect(page).to have_no_css('.meta .group-list')
       end
       within '.pages .item:nth-child(3)' do
         expect(page).to have_css('.title')
@@ -102,6 +104,7 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
         expect(page).to have_css('.meta .url')
         expect(page).to have_css('.meta .date')
         expect(page).to have_css('.meta .category-list')
+        expect(page).to have_no_css('.meta .group-list')
       end
 
       ## article_node
@@ -135,7 +138,6 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
       within '.pages .item:nth-child(2)' do
         find('.category-name:nth-child(1)').click
       end
-      expect(page.all('.item').count).to eq 1
       expect(find('.site-search-categories select').value).to eq [cate1.name]
     end
   end
@@ -149,7 +151,7 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
         click_button I18n.t('ss.buttons.search')
       end
       within '.pages .item:nth-child(1)' do
-        expect(page).to have_no_selector('img')
+        expect(page).not_to have_selector('img')
       end
       within '.pages .item:nth-child(2)' do
         expect(page).to have_css('.title')
@@ -248,13 +250,13 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
           expect(page).to have_css('.site-search-article-nodes.style-select', visible: true)
           expect(page).to have_css('.site-search-categories.style-select', visible: true)
           expect(page).to have_css('.site-search-organization.style-select', visible: true)
-          expect(page).to have_no_css('.site-search-categories.style-input', visible: true)
-          expect(page).to have_no_css('.site-search-organization.style-input', visible: true)
+          expect(page).not_to have_css('.site-search-categories.style-input', visible: true)
+          expect(page).not_to have_css('.site-search-organization.style-input', visible: true)
 
           find("select[name='target'] option[value='outside']").select_option
-          expect(page).to have_no_css('.site-search-article-nodes.style-select', visible: true)
-          expect(page).to have_no_css('.site-search-categories.style-select', visible: true)
-          expect(page).to have_no_css('.site-search-organization.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-article-nodes.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-categories.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-organization.style-select', visible: true)
           expect(page).to have_css('.site-search-categories.style-input', visible: true)
           expect(page).to have_css('.site-search-organization.style-input', visible: true)
         end
@@ -267,15 +269,15 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
       site.update elasticsearch_site_ids: [site.id, site2.id], elasticsearch_outside: 'enabled'
       site2.update elasticsearch_hosts: es_url
 
-      ::Cms::Elasticsearch.init_ingest(site: site2)
-      ::Cms::Elasticsearch.drop_index(site: site2) rescue nil
-      ::Cms::Elasticsearch.create_index(site: site2)
+      Cms::Elasticsearch.init_ingest(site: site2)
+      Cms::Elasticsearch.drop_index(site: site2) rescue nil
+      Cms::Elasticsearch.create_index(site: site2)
 
       Cms::PageIndexQueue.site(site2).each do |item|
-        job = ::Cms::Elasticsearch::Indexer::PageReleaseJob.bind(site_id: site2.id)
+        job = Cms::Elasticsearch::Indexer::PageReleaseJob.bind(site_id: site2.id)
         ss_perform_now(job, action: item.job_action, id: item.page_id.to_s, queue_id: item.id.to_s)
       end
-      ::Cms::Elasticsearch.refresh_index(site: site2)
+      Cms::Elasticsearch.refresh_index(site: site2)
     end
 
     context 'search for target' do
@@ -283,16 +285,16 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
         visit site_search_node.url
 
         within '.search-form' do
-          expect(page).to have_no_css('.site-search-article-nodes.style-select', visible: true)
-          expect(page).to have_no_css('.site-search-categories.style-select', visible: true)
-          expect(page).to have_no_css('.site-search-organization.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-article-nodes.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-categories.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-organization.style-select', visible: true)
           expect(page).to have_css('.site-search-categories.style-input', visible: true)
           expect(page).to have_css('.site-search-organization.style-input', visible: true)
 
           find("select[name='target'] option[value='outside']").select_option
-          expect(page).to have_no_css('.site-search-article-nodes.style-select', visible: true)
-          expect(page).to have_no_css('.site-search-categories.style-select', visible: true)
-          expect(page).to have_no_css('.site-search-organization.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-article-nodes.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-categories.style-select', visible: true)
+          expect(page).not_to have_css('.site-search-organization.style-select', visible: true)
           expect(page).to have_css('.site-search-categories.style-input', visible: true)
           expect(page).to have_css('.site-search-organization.style-input', visible: true)
         end
@@ -307,7 +309,7 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
           click_button I18n.t('ss.buttons.search')
         end
         within '.pages .item:nth-child(1)' do
-          expect(page).to have_no_selector('img')
+          expect(page).not_to have_selector('img')
         end
         within '.pages .item:nth-child(2)' do
           expect(page).to have_css('.title')
@@ -316,6 +318,7 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
           expect(page).to have_css('.meta .url')
           expect(page).to have_css('.meta .date')
           expect(page).to have_css('.meta .category-list')
+          expect(page).to have_css('.meta .group-list')
         end
         within '.pages .item:nth-child(3)' do
           expect(page).to have_css('.title')
@@ -324,14 +327,16 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
           expect(page).to have_css('.meta .url')
           expect(page).to have_css('.meta .date')
           expect(page).to have_css('.meta .category-list')
+          expect(page).to have_css('.meta .group-list')
         end
 
         ## category
         within '.search-form' do
-          fill_in 's[category_name]', with: "#{cate1.name} etc"
+          fill_in 's[category_name]', with: cate2.name
           fill_in 's[group_name]', with: ''
           click_button I18n.t('ss.buttons.search')
         end
+
         within '.pages' do
           expect(page.all('.item').count).to eq 1
         end
@@ -339,7 +344,7 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
         ## group
         within '.search-form' do
           fill_in 's[category_name]', with: ''
-          fill_in 's[group_name]', with: "#{group1.name.split('/').last} etc"
+          fill_in 's[group_name]', with: group2.name.split('/').last
           click_button I18n.t('ss.buttons.search')
         end
         within '.pages' do
@@ -347,11 +352,26 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
         end
 
         ## click on cateogry in the results
-        within '.pages .item:nth-child(1)' do
+        within '.search-form' do
+          fill_in 's[category_name]', with: ''
+          fill_in 's[group_name]', with: ''
+          click_button I18n.t('ss.buttons.search')
+        end
+        within '.pages .item:nth-child(2)' do
           find('.category-name:nth-child(1)').click
         end
-        expect(page.all('.item').count).to eq 1
         expect(find('.site-search-categories.style-input input').value).to eq cate1.name
+
+        ## click on group in the results
+        within '.search-form' do
+          fill_in 's[category_name]', with: ''
+          fill_in 's[group_name]', with: ''
+          click_button I18n.t('ss.buttons.search')
+        end
+        within '.pages .item:nth-child(2)' do
+          find('.group-name:nth-child(2)').click
+        end
+        expect(find('.site-search-organization.style-input input').value).to eq group1.name.split('/').last
       end
     end
   end

--- a/vendor/elasticsearch/mappings.json
+++ b/vendor/elasticsearch/mappings.json
@@ -7,7 +7,7 @@
     "text": { "type": "text", "analyzer": "my_ja_analyzer", "copy_to": "text_index" },
     "keywords": { "type": "text", "copy_to": "text_index" },
     "description": { "type": "text", "copy_to": "text_index" },
-    "categories": { "type": "keyword" },
+    "categories": { "type": "keyword", "copy_to": "categories_index" },
     "release_date": { "type": "date", "format": "strict_date_optional_time||epoch_millis" },
     "close_date": { "type": "date", "format": "strict_date_optional_time||epoch_millis" },
     "released": { "type": "date", "format": "strict_date_optional_time||epoch_millis" },
@@ -16,7 +16,7 @@
     "user_ids": { "type": "integer" },
     "group_ids": { "type": "integer" },
     "groups": { "type": "keyword" },
-    "group_names": { "type": "keyword" },
+    "group_names": { "type": "keyword", "copy_to": "groups_index" },
     "custom_group_ids": { "type": "integer" },
     "member_ids": { "type": "integer" },
     "member_group_ids": { "type": "integer" },
@@ -27,6 +27,8 @@
     "updated": { "type": "date", "format": "strict_date_optional_time||epoch_millis" },
     "created": { "type": "date", "format": "strict_date_optional_time||epoch_millis" },
     "text_index" : { "type": "text", "analyzer": "my_ja_analyzer", "store": "true" },
+    "categories_index" : { "type": "text", "analyzer": "my_ja_analyzer", "store": "true" },
+    "groups_index" : { "type": "text", "analyzer": "my_ja_analyzer", "store": "true" },
     "data" : { "type": "text", "index" : "false", "store" : "false" },
     "file" : {
       "properties" : {


### PR DESCRIPTION
- [ ] 動作確認をしたか？
- [ ] ドキュメントやコメントを書いたか？

## 概要

## 変更内容

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * サイト検索結果にグループリストを追加
  * 検索結果のグループ名をクリックして検索をフィルタリング可能に
  * グループ管理画面でElasticsearch設定オプションを追加

* **改善**
  * 無効化されたグループを検索インデックスから除外
  * カテゴリ・グループの処理ロジックを最適化
  * 複数サイト検索対応の注釈を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->