### PR TITLE
[modify] cms/line : add setting for template type

### DIFF
--- a/app/controllers/cms/line/settings_controller.rb
+++ b/app/controllers/cms/line/settings_controller.rb
@@ -1,0 +1,18 @@
+class Cms::Line::SettingsController < ApplicationController
+  include Cms::BaseFilter
+  include Cms::CrudFilter
+
+  model Cms::Line::Setting
+
+  navi_view "cms/line/main/navi"
+
+  private
+
+  def set_crumbs
+    @crumbs << [t("cms.line_setting"), cms_line_setting_path]
+  end
+
+  def set_item
+    @item = @model.with_site(@cur_site)
+  end
+end

--- a/app/controllers/cms/line/templates_controller.rb
+++ b/app/controllers/cms/line/templates_controller.rb
@@ -5,6 +5,7 @@ class Cms::Line::TemplatesController < ApplicationController
   navi_view "cms/line/main/navi"
 
   before_action :set_message
+  before_action :set_model
   before_action :set_item, only: [:show, :edit, :update, :delete, :destroy]
   before_action :redirect_to_select_type, only: [:new]
 
@@ -27,10 +28,11 @@ class Cms::Line::TemplatesController < ApplicationController
   end
 
   def set_model
-    @type = %w(text image page json_body -).find do |type|
+    @line_setting = Cms::Line::Setting.with_site(@cur_site)
+    @type = (@line_setting.template_types + %w(-)).find do |type|
       type == params[:type].presence
     end
-    raise "400" if @type.nil?
+    raise "404" if @type.nil?
 
     @type = nil if @type == "-"
     @model = @type ? "#{Cms::Line::Template}::#{@type.classify}".constantize : Cms::Line::Template::Base

--- a/app/models/cms/initializer.rb
+++ b/app/models/cms/initializer.rb
@@ -149,6 +149,7 @@ module Cms
     Cms::Role.permission :use_private_cms_line_mail_handlers, module_name: 'cms/line'
     Cms::Role.permission :use_other_cms_line_statistics, module_name: 'cms/line'
     Cms::Role.permission :use_private_cms_line_statistics, module_name: 'cms/line'
+    Cms::Role.permission :use_cms_line_settings, module_name: 'cms/line'
 
     Cms::Role.permission :use_cms_check_links, module_name: 'cms/check_links'
     Cms::Role.permission :run_cms_check_links, module_name: 'cms/check_links'

--- a/app/models/cms/line/setting.rb
+++ b/app/models/cms/line/setting.rb
@@ -6,6 +6,8 @@ class Cms::Line::Setting
 
   TEMPLATE_TYPES = %w(text image page json_body).freeze
 
+  index({ site_id: 1 }, unique: true)
+
   set_permission_name "cms_line_settings", :use
 
   seqid :id

--- a/app/models/cms/line/setting.rb
+++ b/app/models/cms/line/setting.rb
@@ -1,0 +1,43 @@
+class Cms::Line::Setting
+  include SS::Document
+  include SS::Reference::User
+  include SS::Reference::Site
+  include Cms::SitePermission
+
+  TEMPLATE_TYPES = %w(text image page json_body).freeze
+
+  set_permission_name "cms_line_settings", :use
+
+  seqid :id
+  field :template_types, type: Array, default: []
+
+  permit_params template_types: []
+
+  before_validation :set_default_template_types, if: -> { new_record? && template_types.blank? }
+  validate :validate_template_types
+
+  def template_type_options
+    TEMPLATE_TYPES.map { |type| [I18n.t("cms.options.line_template_type.#{type}"), type] }
+  end
+
+  private
+
+  def set_default_template_types
+    self.template_types = TEMPLATE_TYPES
+  end
+
+  def validate_template_types
+    self.template_types = template_types.select(&:present?)
+    self.template_types << "text" if !template_types.include?("text")
+
+    if (template_types - TEMPLATE_TYPES).present?
+      self.errors.add :template_types, :inclusion
+    end
+  end
+
+  class << self
+    def with_site(site)
+      self.find_or_create_by(site_id: site.id)
+    end
+  end
+end

--- a/app/models/cms/line/setting.rb
+++ b/app/models/cms/line/setting.rb
@@ -1,6 +1,5 @@
 class Cms::Line::Setting
   include SS::Document
-  include SS::Reference::User
   include SS::Reference::Site
   include Cms::SitePermission
 

--- a/app/views/cms/agents/addons/line/message/body/_show.html.erb
+++ b/app/views/cms/agents/addons/line/message/body/_show.html.erb
@@ -46,7 +46,7 @@ $(".message-type.page .img-warp img").load(function (){
         <% end %>
       </div>
     <% else %>
-      <div>テンプレートが設定されていません。</div>
+      <div><%= t("cms.line_empty_template") %></div>
     <% end %>
 
     <% if @item.templates.size >= @model.max_templates %>

--- a/app/views/cms/agents/addons/line/template/page/_form.html.erb
+++ b/app/views/cms/agents/addons/line/template/page/_form.html.erb
@@ -35,7 +35,7 @@ $('.mod-cms-line-template a.ajax-box').data('on-select', function($item) {
   </dd>
 
   <dt><%= @model.t :title %><%= @model.tt :title %></dt>
-  <dd><%= f.text_field :title, class: "js-emoji js-inline" %></dd>
+  <dd><%= f.text_field :title, class: "js-emoji js-inline", style: "width: 80%;" %></dd>
 
   <dt><%= @model.t :summary %><%= @model.tt :summary %></dt>
   <dd><%= f.text_area :summary, class: "js-emoji" %></dd>

--- a/app/views/cms/line/main/_navi.html.erb
+++ b/app/views/cms/line/main/_navi.html.erb
@@ -28,6 +28,9 @@
     <h3><%= link_to t("cms.line_service"), cms_line_service_groups_path %></h3>
     <h3><%= link_to t("cms.line_event_session"), cms_line_event_sessions_path %></h3>
   <% end %>
+  <% if Cms::Line::Setting.allowed?(:read, @cur_user, site: @cur_site) %>
+    <h3><%= link_to t("cms.line_setting"), cms_line_setting_path %></h3>
+  <% end %>
 </nav>
 
 <%= render partial: "cms/main/navi" %>

--- a/app/views/cms/line/settings/_form.html.erb
+++ b/app/views/cms/line/settings/_form.html.erb
@@ -1,0 +1,17 @@
+<dl class="see">
+  <dt><%= @model.t :template_types %><%= @model.tt :template_types %></dt>
+  <dd>
+    <%= hidden_field_tag "#{f.object_name}[template_types][]", '', id: nil %>
+    <% @item.template_type_options.each do |v, k| %>
+      <label>
+        <% if k.to_s == "text" %>
+          <%= check_box_tag "#{f.object_name}[template_types][]", k, true, disabled: true %>
+          <%= hidden_field_tag "#{f.object_name}[template_types][]", "text", id: "item_template_types_#{k}" %>
+        <% else %>
+          <%= check_box_tag "#{f.object_name}[template_types][]", k, @item.template_types.include?(k.to_s), id: "item_template_types_#{k}" %>
+        <% end %>
+        <%= v %>
+      </label>
+    <% end %>
+  </dd>
+</dl>

--- a/app/views/cms/line/settings/_menu.html.erb
+++ b/app/views/cms/line/settings/_menu.html.erb
@@ -1,0 +1,9 @@
+<nav class="nav-menu">
+  <% if params[:action] =~ /show/ %>
+    <% if @item.allowed?(:edit, @cur_user, site: @cur_site, node: @cur_node) %>
+      <%= link_to t('ss.links.edit'), { action: :edit }, class: :edit %>
+    <% end %>
+  <% else %>
+    <%= link_to t('ss.links.back_to_show'), { action: :show }, class: "back-to-show" %>
+  <% end %>
+</nav>

--- a/app/views/cms/line/settings/_show.html.erb
+++ b/app/views/cms/line/settings/_show.html.erb
@@ -1,0 +1,4 @@
+<dl class="see">
+  <dt><%= @model.t :template_types %></dt>
+  <dd><%= @item.template_types.map { |k| t("cms.options.line_template_type.#{k}") }.join(", ") %></dd>
+</dl>

--- a/app/views/cms/line/templates/_select_type.html.erb
+++ b/app/views/cms/line/templates/_select_type.html.erb
@@ -1,44 +1,16 @@
 <div class="line-select-message-type">
-  <div>作成するテンプレートを選択してください。</div>
+  <div><%= t("cms.line_select_template") %></div>
   <div class="message-types">
-    <div class="message-type-wrap">
-      <%= link_to({ action: :new, type: "text" }, { class: "message-type text #{(@type == "text") ? "current" : ""}" }) do %>
-        <%= image_tag("/assets/img/line/templates/text.jpg", alt: "text") %>
-        <div class="description">
-          <h2 class="title">テキスト</h2>
-          <div class="summary">通常のテキストメッセージです。</div>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="message-type-wrap">
-      <%= link_to({ action: :new, type: "image" }, { class: "message-type image #{(@type == "image") ? "current" : ""}" }) do %>
-        <%= image_tag("/assets/img/line/templates/image.jpg", alt: "image") %>
-        <div class="description">
-          <h2 class="title">画像</h2>
-          <div class="summary">画像を送信します。</div>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="message-type-wrap">
-      <%= link_to({ action: :new, type: "page" }, { class: "message-type page #{(@type == "page") ? "current" : ""}" }) do %>
-        <%= image_tag("/assets/img/line/templates/page.jpg", alt: "page") %>
-        <div class="description">
-          <h2 class="title">記事ページ</h2>
-          <div class="summary">記事ページへのリンクとサマリーを送信します。</div>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="message-type-wrap">
-      <%= link_to({ action: :new, type: "json_body" }, { class: "message-type json_body #{(@type == "json_body") ? "current" : ""}" }) do %>
-        <%= image_tag("/assets/img/line/templates/json_body.jpg", alt: "json_body") %>
-        <div class="description">
-          <h2 class="title">JSON</h2>
-          <div class="summary">JSONテンプレートを直接入力します。</div>
-        </div>
-      <% end %>
-    </div>
+    <% @line_setting.template_types.each do |type| %>
+      <div class="message-type-wrap">
+        <%= link_to({ action: :new, type: type }, { class: "message-type #{type} #{(@type == type) ? "current" : ""}" }) do %>
+          <%= image_tag("/assets/img/line/templates/#{type}.jpg", alt: "text") %>
+          <div class="description">
+            <h2 class="title"><%= t("cms.line_template_type.#{type}.title") %></h2>
+            <div class="summary"><%= t("cms.line_template_type.#{type}.summary") %></div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/cms/line/templates/_select_type.html.erb
+++ b/app/views/cms/line/templates/_select_type.html.erb
@@ -4,7 +4,7 @@
     <% @line_setting.template_types.each do |type| %>
       <div class="message-type-wrap">
         <%= link_to({ action: :new, type: type }, { class: "message-type #{type} #{(@type == type) ? "current" : ""}" }) do %>
-          <%= image_tag("/assets/img/line/templates/#{type}.jpg", alt: "text") %>
+          <%= image_tag("/assets/img/line/templates/#{type}.jpg", alt: t("cms.line_template_type.#{type}.title")) %>
           <div class="description">
             <h2 class="title"><%= t("cms.line_template_type.#{type}.title") %></h2>
             <div class="summary"><%= t("cms.line_template_type.#{type}.summary") %></div>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -40,6 +40,21 @@ ja:
     line_facility_search_category: 施設カテゴリー
     line_message: メッセージ
     line_template: テンプレート
+    line_template_type:
+      text:
+        title: テキスト
+        summary: 通常のテキストメッセージです。
+      image:
+        title: 画像
+        summary: 画像を送信します。
+      page:
+        title: 記事ページ
+        summary: 記事ページへのリンクとサマリーを送信します。
+      json_body:
+        title: JSON
+        summary: JSONテンプレートを直接入力します。
+    line_select_template: 作成するテンプレートを選択してください。
+    line_empty_template: テンプレートが設定されていません。
     line_statistics: 統計情報
     line_mail_handlers: メール連携
     line_deliver_log: 配信ログ
@@ -49,6 +64,7 @@ ja:
     line_deliver_age_setting: 年齢設定
     line_test_member: テストメンバー
     line_event_session: セッション
+    line_setting: 設定
     form_check: 制約チェック
     list_view: リスト表示
     row_error: 'error %{row_num}行目'
@@ -409,9 +425,9 @@ ja:
           - LINEの友達登録者全員に配信されます。
           - 「LINEメッセージを受信する/しない」に関わらず送信されます。
       line_statistics:
-         - 統計情報は日毎に自動更新され、メッセージの送信時刻（統計情報の作成日時）から14日間のみ更新されます。
-         - 統計情報の数値は、APIの仕様上、多少の誤差を含むことがあります。
-         - 統計情報の人数はおよそ20人未満の場合、プライバシー保護の為、非表示（情報なし）となります。
+        - 統計情報は日毎に自動更新され、メッセージの送信時刻（統計情報の作成日時）から14日間のみ更新されます。
+        - 統計情報の数値は、APIの仕様上、多少の誤差を含むことがあります。
+        - 統計情報の人数はおよそ20人未満の場合、プライバシー保護の為、非表示（情報なし）となります。
       line_statistics_exceeded_units_by_month: 月内に発行したユニット名が1000を超えている為、統計情報を取得できませんでした。
       page_expiration_header: ページの公開期限が切れています。
       page_expiration_body:
@@ -662,6 +678,7 @@ ja:
         text: テキスト
         image: 画像
         page: 記事ページ
+        json_body: JSON
       line_template_thumb_state:
         none: 表示しない
         thumb_carousel: 記事のサムネイル画像
@@ -1007,6 +1024,7 @@ ja:
     use_private_cms_line_mail_handlers: LINEメール連携の管理（所有）
     use_other_cms_line_statistics: LINE統計情報の利用（全て）
     use_private_cms_line_statistics: LINE統計情報の利用（所有）
+    use_cms_line_settings: LINE設定の管理
     edit_cms_ignore_syntax_check: アクセシビリティチェックを無視して保存する
     edit_cms_user_profile: プロフィールの編集
     edit_password_cms_user_profile: プロフィールのパスワード変更
@@ -1906,6 +1924,8 @@ ja:
         overview_unique_click: URLをタップした人数
         update_statistics: 統計情報の更新
         null_label: 情報なし
+      cms/line/setting:
+        template_types: 使用するテンプレート
       cms/addon/clipboard_copy:
         clipboard_copy_target: コピー対象
         clipboard_copy_selector: CSSセレクター
@@ -2490,6 +2510,10 @@ ja:
         - メールのシグネチャを削除する為に利用できます。
       auto_link_state:
         - メール本文をHTMLに変換する際にリンクとメールアドレスをaタグに置換するか設定します。
+
+    cms/line/setting:
+      template_types:
+        - メッセージを作成する際に表示するテンプレートを選択します。
 
     cms/site:
       name:
@@ -3303,9 +3327,9 @@ ja:
         - 種類を選択します。
 
     cms/column/select_page:
-       node_ids:
-         - 記事フォルダーを設定します。
-         - 設定した記事フォルダー配下のページを選択可能です。
+      node_ids:
+        - 記事フォルダーを設定します。
+        - 設定した記事フォルダー配下のページを選択可能です。
 
     cms/addon/form_db/import:
       import_url: |-
@@ -3512,9 +3536,9 @@ ja:
 
     cms/line/message:
       name:
-       - タイトルを入力します。
+        - タイトルを入力します。
       title:
-       - タイトルを入力します。
+        - タイトルを入力します。
       statistic_state:
         - 有効にするとメッセージ送信時に統計情報を保存します。
 

--- a/config/routes/cms/routes_end.rb
+++ b/config/routes/cms/routes_end.rb
@@ -302,6 +302,7 @@ Rails.application.routes.draw do
         end
       end
       resources :event_sessions, only: [:index, :show, :destroy], concerns: :deletion
+      resource :setting, only: %i[show edit update]
     end
 
     get "generate_nodes" => "generate_nodes#index"

--- a/lib/migrations/cms/20260427000000_cms_line_settings_permissions.rb
+++ b/lib/migrations/cms/20260427000000_cms_line_settings_permissions.rb
@@ -1,0 +1,12 @@
+class SS::Migration20260427000000
+  include SS::Migration::Base
+
+  def change
+    message_permission = "use_other_cms_line_messages"
+    setting_permission = "use_cms_line_settings"
+
+    Cms::Role.in(permissions: message_permission).each do |item|
+      item.add_to_set(permissions: setting_permission)
+    end
+  end
+end

--- a/spec/factories/cms/line/setting.rb
+++ b/spec/factories/cms/line/setting.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cms_line_setting, class: Cms::Line::Setting do
+    site { cms_site }
+  end
+end

--- a/spec/features/cms/line/settings_spec.rb
+++ b/spec/features/cms/line/settings_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe "cms/line/test_members", type: :feature, dbscope: :example, js: true do
+  let(:site) { cms_site }
+  let(:item) { create :cms_line_setting }
+  let(:default_template_types) { %w(text image page json_body) }
+
+  let(:show_path) { cms_line_setting_path site }
+  let(:edit_path) { edit_cms_line_setting_path site }
+
+  def types_label(types)
+    types.map { |k| I18n.t("cms.options.line_template_type.#{k}") }.join(", ")
+  end
+
+  describe "basic crud" do
+    before { login_cms_user }
+
+    it "#show" do
+      visit show_path
+      within "#addon-basic" do
+        expect(page).to have_text(types_label(default_template_types))
+      end
+      expect(Cms::Line::Setting.site(site).count).to eq 1
+    end
+
+    it "#edit" do
+      visit edit_path
+      within "form#item-form" do
+        uncheck "item_template_types_page"
+        click_on I18n.t("ss.buttons.save")
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+      expect(Cms::Line::Setting.site(site).count).to eq 1
+
+      within "#addon-basic" do
+        expect(page).to have_text(types_label(default_template_types - %w(page)))
+      end
+    end
+  end
+end

--- a/spec/features/cms/line/settings_spec.rb
+++ b/spec/features/cms/line/settings_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "cms/line/test_members", type: :feature, dbscope: :example, js: true do
+describe "cms/line/settings", type: :feature, dbscope: :example, js: true do
   let(:site) { cms_site }
   let(:item) { create :cms_line_setting }
   let(:default_template_types) { %w(text image page json_body) }

--- a/spec/features/cms/line/templates/image_spec.rb
+++ b/spec/features/cms/line/templates/image_spec.rb
@@ -22,7 +22,7 @@ describe "cms/line/templates image", type: :feature, dbscope: :example, js: true
       # add template
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
         click_on I18n.t("cms.buttons.add_template")
       end
       within ".line-select-message-type" do
@@ -44,7 +44,7 @@ describe "cms/line/templates image", type: :feature, dbscope: :example, js: true
       # check talk-balloon
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_no_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_no_css("div", text: I18n.t("cms.line_empty_template"))
         within ".line-talk-view" do
           expect(page.find('img')[:src]).to start_with file1.full_url
           first(".actions .edit-template").click
@@ -77,7 +77,7 @@ describe "cms/line/templates image", type: :feature, dbscope: :example, js: true
 
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
       end
     end
   end

--- a/spec/features/cms/line/templates/json_body_spec.rb
+++ b/spec/features/cms/line/templates/json_body_spec.rb
@@ -16,7 +16,7 @@ describe "cms/line/templates json_body", type: :feature, dbscope: :example, js: 
       # add template
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
         click_on I18n.t("cms.buttons.add_template")
       end
       within ".line-select-message-type" do
@@ -46,7 +46,7 @@ describe "cms/line/templates json_body", type: :feature, dbscope: :example, js: 
       # check talk-balloon
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_no_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_no_css("div", text: I18n.t("cms.line_empty_template"))
         within ".line-talk-view" do
           expect(page).to have_css(".talk-balloon", text: "{JSONテンプレート;}")
           first(".actions .edit-template").click
@@ -79,7 +79,7 @@ describe "cms/line/templates json_body", type: :feature, dbscope: :example, js: 
 
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
       end
     end
   end

--- a/spec/features/cms/line/templates/page_spec.rb
+++ b/spec/features/cms/line/templates/page_spec.rb
@@ -38,7 +38,7 @@ describe "cms/line/templates text", type: :feature, dbscope: :example, js: true 
       # add template
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
         click_on I18n.t("cms.buttons.add_template")
       end
       wait_for_js_ready
@@ -69,7 +69,7 @@ describe "cms/line/templates text", type: :feature, dbscope: :example, js: true 
       # check talk-balloon
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_no_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_no_css("div", text: I18n.t("cms.line_empty_template"))
         within ".line-talk-view" do
           expect(page).to have_css(".talk-balloon .title", text: page1.name)
           expect(page).to have_css(".talk-balloon .summary", text: summary1)
@@ -103,7 +103,7 @@ describe "cms/line/templates text", type: :feature, dbscope: :example, js: true 
       # delete talk-balloon
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_no_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_no_css("div", text: I18n.t("cms.line_empty_template"))
         within ".line-talk-view" do
           expect(page).to have_css(".talk-balloon .title", text: page2.name)
           expect(page).to have_css(".talk-balloon .summary", text: summary2)
@@ -119,7 +119,7 @@ describe "cms/line/templates text", type: :feature, dbscope: :example, js: true 
 
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
       end
     end
   end

--- a/spec/features/cms/line/templates/select_type_spec.rb
+++ b/spec/features/cms/line/templates/select_type_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe "cms/line/templates", type: :feature, dbscope: :example, js: true do
+  let(:site) { cms_site }
+  let(:item) { create :cms_line_message }
+  let(:show_path) { cms_line_message_path site, item }
+
+  before { login_cms_user }
+
+  context "default case" do
+    it "#show" do
+      visit show_path
+
+      # add template
+      within "#addon-cms-agents-addons-line-message-body" do
+        expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
+        click_on I18n.t("cms.buttons.add_template")
+      end
+      wait_for_js_ready
+
+      within ".message-types" do
+        expect(page).to have_selector(".message-type", count: 4)
+        expect(page).to have_css(".message-type.text")
+        expect(page).to have_css(".message-type.image")
+        expect(page).to have_css(".message-type.page")
+        expect(page).to have_css(".message-type.json_body")
+      end
+    end
+  end
+
+  context "without page template" do
+    let!(:setting) { create(:cms_line_setting, template_types: %w(text image json_body)) }
+
+    it "#show" do
+      visit show_path
+
+      # add template
+      within "#addon-cms-agents-addons-line-message-body" do
+        expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
+        click_on I18n.t("cms.buttons.add_template")
+      end
+      wait_for_js_ready
+
+      within ".message-types" do
+        expect(page).to have_selector(".message-type", count: 3)
+        expect(page).to have_css(".message-type.text")
+        expect(page).to have_css(".message-type.image")
+        expect(page).to have_css(".message-type.json_body")
+      end
+    end
+  end
+end

--- a/spec/features/cms/line/templates/text_spec.rb
+++ b/spec/features/cms/line/templates/text_spec.rb
@@ -16,7 +16,7 @@ describe "cms/line/templates text", type: :feature, dbscope: :example, js: true 
       # add template
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
         click_on I18n.t("cms.buttons.add_template")
       end
       within ".line-select-message-type" do
@@ -37,7 +37,7 @@ describe "cms/line/templates text", type: :feature, dbscope: :example, js: true 
       # check talk-balloon
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_no_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_no_css("div", text: I18n.t("cms.line_empty_template"))
         within ".line-talk-view" do
           expect(page).to have_css(".talk-balloon", text: text1)
           first(".actions .edit-template").click
@@ -69,7 +69,7 @@ describe "cms/line/templates text", type: :feature, dbscope: :example, js: true 
 
       within "#addon-cms-agents-addons-line-message-body" do
         expect(page).to have_css("h2", text: I18n.t("modules.addons.cms/line/message/body"))
-        expect(page).to have_css("div", text: "テンプレートが設定されていません。")
+        expect(page).to have_css("div", text: I18n.t("cms.line_empty_template"))
       end
     end
   end

--- a/spec/lib/migrations/cms/20260427000000_cms_line_settings_permissions_spec.rb
+++ b/spec/lib/migrations/cms/20260427000000_cms_line_settings_permissions_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require Rails.root.join("lib/migrations/cms/20260427000000_cms_line_settings_permissions.rb")
+
+RSpec.describe SS::Migration20260427000000, dbscope: :example do
+  let!(:site) { cms_site }
+  let!(:role1) { create :cms_role, cur_site: site, name: unique_id, permissions: %w(use_private_cms_line_messages) }
+  let!(:role2) { create :cms_role, cur_site: site, name: unique_id, permissions: %w(use_other_cms_line_messages) }
+  let!(:role3) { create :cms_role, cur_site: site, name: unique_id, permissions: (Cms::Role.permission_names - [name]) }
+  let!(:role4) { create :cms_role, cur_site: site, name: unique_id, permissions: Cms::Role.permission_names }
+  let!(:name) { "use_cms_line_settings" }
+
+  it do
+    expect(role1.permissions).not_to include(name)
+    expect(role2.permissions).not_to include(name)
+    expect(role3.permissions).not_to include(name)
+    expect(role4.permissions).to include(name)
+
+    described_class.new.change
+
+    role1.reload
+    role2.reload
+    role3.reload
+    role4.reload
+
+    expect(role1.permissions).to match_array(%w(use_private_cms_line_messages))
+    expect(role2.permissions).to match_array(%w(use_other_cms_line_messages) + [name])
+    expect(role3.permissions).to match_array(Cms::Role.permission_names)
+    expect(role4.permissions).to match_array(Cms::Role.permission_names)
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * LINE設定管理画面を追加し、テンプレートタイプの有効/無効を管理可能に
  * 設定に基づくテンプレート選択画面の動的表示と専用ルートを追加
  * 権限（LINE設定利用）の宣言を追加

* **スタイル**
  * フォーム入力フィールドの幅指定を改善

* **テスト**
  * LINE設定管理・テンプレート選択の機能テストを追加

* **その他**
  * 表示文言を多言語化、権限移行用マイグレーションを追加
  * テンプレート種別不正時に404応答へ変更
<!-- end of auto-generated comment: release notes by coderabbit.ai -->