### PR TITLE
[feature][cms] configurable min/max headline level for headline column

### DIFF
--- a/app/models/cms/column/headline.rb
+++ b/app/models/cms/column/headline.rb
@@ -62,10 +62,10 @@ class Cms::Column::Headline < Cms::Column::Base
   end
 
   def validate_headline_range
-    return if min_headline_level.blank? || max_headline_level.blank?
-    min_idx = HEADLINE_LEVELS.index(min_headline_level)
-    max_idx = HEADLINE_LEVELS.index(max_headline_level)
-    return unless min_idx && max_idx
+    return if min_headline_level.blank? && max_headline_level.blank?
+    min_idx = HEADLINE_LEVELS.index(effective_min_headline_level)
+    max_idx = HEADLINE_LEVELS.index(effective_max_headline_level)
+    return if min_idx.nil? || max_idx.nil?
     errors.add(:max_headline_level, :less_than_min_headline_level) if min_idx > max_idx
   end
 end

--- a/app/models/cms/column/headline.rb
+++ b/app/models/cms/column/headline.rb
@@ -1,13 +1,40 @@
 class Cms::Column::Headline < Cms::Column::Base
   include Cms::Addon::Column::TextLike
 
+  HEADLINE_LEVELS = %w(h1 h2 h3 h4 h5 h6).freeze
+  SELECTABLE_BOUNDARY_LEVELS = %w(h2 h3 h4 h5 h6).freeze
+  LEGACY_MIN_HEADLINE_LEVEL = 'h1'.freeze
+  LEGACY_MAX_HEADLINE_LEVEL = 'h4'.freeze
+
+  field :min_headline_level, type: String
+  field :max_headline_level, type: String
+
+  permit_params :min_headline_level, :max_headline_level
+
+  validates :min_headline_level, :max_headline_level,
+            inclusion: { in: SELECTABLE_BOUNDARY_LEVELS, allow_blank: true }
+  validate :validate_headline_range
+
+  after_initialize :apply_new_column_defaults, if: :new_record?
+
   def headline_list
-    {
-      h1: "h1",
-      h2: "h2",
-      h3: "h3",
-      h4: "h4"
-    }
+    min = effective_min_headline_level
+    max = effective_max_headline_level
+    min_idx = HEADLINE_LEVELS.index(min) || 0
+    max_idx = HEADLINE_LEVELS.index(max) || (HEADLINE_LEVELS.size - 1)
+    HEADLINE_LEVELS[min_idx..max_idx].index_by(&:to_sym)
+  end
+
+  def headline_level_options
+    SELECTABLE_BOUNDARY_LEVELS.map { |v| [v, v] }
+  end
+
+  def effective_min_headline_level
+    min_headline_level.presence || LEGACY_MIN_HEADLINE_LEVEL
+  end
+
+  def effective_max_headline_level
+    max_headline_level.presence || LEGACY_MAX_HEADLINE_LEVEL
   end
 
   def form_options(type = nil)
@@ -25,5 +52,20 @@ class Cms::Column::Headline < Cms::Column::Base
 
   def link_check_enabled?
     true
+  end
+
+  private
+
+  def apply_new_column_defaults
+    self.min_headline_level ||= 'h2'
+    self.max_headline_level ||= 'h4'
+  end
+
+  def validate_headline_range
+    return if min_headline_level.blank? || max_headline_level.blank?
+    min_idx = HEADLINE_LEVELS.index(min_headline_level)
+    max_idx = HEADLINE_LEVELS.index(max_headline_level)
+    return unless min_idx && max_idx
+    errors.add(:max_headline_level, :less_than_min_headline_level) if min_idx > max_idx
   end
 end

--- a/app/models/cms/column/headline.rb
+++ b/app/models/cms/column/headline.rb
@@ -2,7 +2,8 @@ class Cms::Column::Headline < Cms::Column::Base
   include Cms::Addon::Column::TextLike
 
   HEADLINE_LEVELS = %w(h1 h2 h3 h4 h5 h6).freeze
-  SELECTABLE_BOUNDARY_LEVELS = %w(h2 h3 h4 h5 h6).freeze
+  MIN_BOUNDARY_LEVELS = %w(h1 h2).freeze
+  MAX_BOUNDARY_LEVELS = %w(h3 h4 h5 h6).freeze
   LEGACY_MIN_HEADLINE_LEVEL = 'h1'.freeze
   LEGACY_MAX_HEADLINE_LEVEL = 'h4'.freeze
 
@@ -11,9 +12,8 @@ class Cms::Column::Headline < Cms::Column::Base
 
   permit_params :min_headline_level, :max_headline_level
 
-  validates :min_headline_level, :max_headline_level,
-            inclusion: { in: SELECTABLE_BOUNDARY_LEVELS, allow_blank: true }
-  validate :validate_headline_range
+  validates :min_headline_level, inclusion: { in: MIN_BOUNDARY_LEVELS, allow_blank: true }
+  validates :max_headline_level, inclusion: { in: MAX_BOUNDARY_LEVELS, allow_blank: true }
 
   after_initialize :apply_new_column_defaults, if: :new_record?
 
@@ -25,8 +25,12 @@ class Cms::Column::Headline < Cms::Column::Base
     HEADLINE_LEVELS[min_idx..max_idx].index_by(&:to_sym)
   end
 
-  def headline_level_options
-    SELECTABLE_BOUNDARY_LEVELS.map { |v| [v, v] }
+  def min_headline_level_options
+    MIN_BOUNDARY_LEVELS.map { |v| [v, v] }
+  end
+
+  def max_headline_level_options
+    MAX_BOUNDARY_LEVELS.map { |v| [v, v] }
   end
 
   def effective_min_headline_level
@@ -59,13 +63,5 @@ class Cms::Column::Headline < Cms::Column::Base
   def apply_new_column_defaults
     self.min_headline_level ||= 'h2'
     self.max_headline_level ||= 'h4'
-  end
-
-  def validate_headline_range
-    return if min_headline_level.blank? && max_headline_level.blank?
-    min_idx = HEADLINE_LEVELS.index(effective_min_headline_level)
-    max_idx = HEADLINE_LEVELS.index(effective_max_headline_level)
-    return if min_idx.nil? || max_idx.nil?
-    errors.add(:max_headline_level, :less_than_min_headline_level) if min_idx > max_idx
   end
 end

--- a/app/models/cms/column/value/headline.rb
+++ b/app/models/cms/column/value/headline.rb
@@ -47,7 +47,7 @@ class Cms::Column::Value::Headline < Cms::Column::Value::Base
 
   def import_csv_cell(value)
     self.text = value.presence
-    self.head ||= 'h1'
+    self.head ||= column&.effective_min_headline_level || 'h1'
   end
 
   def export_csv_cell
@@ -70,6 +70,10 @@ class Cms::Column::Value::Headline < Cms::Column::Value::Base
 
     if column.required? && text.blank?
       self.errors.add(:text, :blank) unless skip_required?
+    end
+
+    if head.present? && column.headline_list.values.exclude?(head)
+      self.errors.add(:head, :inclusion, value: head)
     end
 
     return if text.blank?

--- a/app/views/cms/agents/columns/headline/_form.html.erb
+++ b/app/views/cms/agents/columns/headline/_form.html.erb
@@ -1,0 +1,9 @@
+<dl class="see mod-cms-column-headline">
+  <dt><%= @model.t :min_headline_level %><%= @model.tt :min_headline_level %></dt>
+  <dd><%= f.select :min_headline_level, @item.headline_level_options,
+                   { selected: @item.effective_min_headline_level } %></dd>
+
+  <dt><%= @model.t :max_headline_level %><%= @model.tt :max_headline_level %></dt>
+  <dd><%= f.select :max_headline_level, @item.headline_level_options,
+                   { selected: @item.effective_max_headline_level } %></dd>
+</dl>

--- a/app/views/cms/agents/columns/headline/_form.html.erb
+++ b/app/views/cms/agents/columns/headline/_form.html.erb
@@ -1,9 +1,9 @@
 <dl class="see mod-cms-column-headline">
   <dt><%= @model.t :min_headline_level %><%= @model.tt :min_headline_level %></dt>
-  <dd><%= f.select :min_headline_level, @item.headline_level_options,
+  <dd><%= f.select :min_headline_level, @item.min_headline_level_options,
                    { selected: @item.effective_min_headline_level } %></dd>
 
   <dt><%= @model.t :max_headline_level %><%= @model.tt :max_headline_level %></dt>
-  <dd><%= f.select :max_headline_level, @item.headline_level_options,
+  <dd><%= f.select :max_headline_level, @item.max_headline_level_options,
                    { selected: @item.effective_max_headline_level } %></dd>
 </dl>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -1594,6 +1594,9 @@ ja:
         tooltips: ツールチップ
       cms/column/text_field:
         input_type: 種類
+      cms/column/headline:
+        min_headline_level: 最小見出しレベル
+        max_headline_level: 最大見出しレベル
       cms/column/date_field:
         place_holder: プレースホルダー
         html_tag: HTMLタグ
@@ -2071,6 +2074,7 @@ ja:
       mobile_size_check_failed_to_size: "携帯で表示する場合、本文のデータサイズが%{mobile_size}以下になるようにしてください。(本文サイズ：%{size})"
       mobile_size_check_server_error: 本文データサイズのチェック中にサーバーエラーが発生しました。
       not_a_child_group: はサイトに所属するグループを設定してください。
+      less_than_min_headline_level: は最小見出しレベル以上の値にしてください。
       not_found_parent_group: 親グループが存在しません。
       plz_check_targets_to_change_state: 公開ステータス変更対象が選択されておりません。対象のチェックボックスにチェックを入れてください。
       invalid_order_of_h: 見出し(H)の順番が不正です。

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -2074,7 +2074,6 @@ ja:
       mobile_size_check_failed_to_size: "携帯で表示する場合、本文のデータサイズが%{mobile_size}以下になるようにしてください。(本文サイズ：%{size})"
       mobile_size_check_server_error: 本文データサイズのチェック中にサーバーエラーが発生しました。
       not_a_child_group: はサイトに所属するグループを設定してください。
-      less_than_min_headline_level: は最小見出しレベル以上の値にしてください。
       not_found_parent_group: 親グループが存在しません。
       plz_check_targets_to_change_state: 公開ステータス変更対象が選択されておりません。対象のチェックボックスにチェックを入れてください。
       invalid_order_of_h: 見出し(H)の順番が不正です。

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -3283,6 +3283,13 @@ ja:
       label_place_holder:
         - リンクテキストのプレースホルダーを入力します。
 
+    cms/column/headline:
+      min_headline_level:
+        - 見出し入力で選択できる最小（最も浅い）見出しレベルを設定します。
+      max_headline_level:
+        - 見出し入力で選択できる最大（最も深い）見出しレベルを設定します。
+        - 設定した深さまでの見出しが選択肢に表示されます。
+
     cms/addon/column/text_like:
       max_length:
         - 入力文字数の最大長を入力します。

--- a/spec/factories/cms/column/healines.rb
+++ b/spec/factories/cms/column/healines.rb
@@ -8,5 +8,10 @@ FactoryBot.define do
     tooltips { "tooltips-#{unique_id}" }
     prefix_label { "pre-#{unique_id}"[0, 10] }
     postfix_label { "pos-#{unique_id}"[0, 10] }
+
+    # Default factory simulates a legacy column (created before min/max_headline_level
+    # was introduced). Tests for new-default behavior should override min/max explicitly.
+    min_headline_level { nil }
+    max_headline_level { nil }
   end
 end

--- a/spec/features/cms/form/columns/headline_spec.rb
+++ b/spec/features/cms/form/columns/headline_spec.rb
@@ -46,4 +46,66 @@ describe Cms::Form::ColumnsController, type: :feature, dbscope: :example, js: tr
       expect(Cms::Column::Base.site(site).where(form_id: form.id).count).to eq 0
     end
   end
+
+  context 'min/max headline level configuration' do
+    it 'creates a new column with h2/h4 defaults and allows updating to h3/h6' do
+      visit cms_form_path(site, form)
+      click_on I18n.t('cms.buttons.manage_columns')
+
+      within '.gws-column-list-toolbar[data-placement="top"]' do
+        wait_for_event_fired("gws:column:added") { click_on I18n.t('cms.columns.cms/headline') }
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      within '.gws-column-form' do
+        fill_in 'item[name]', with: name
+        click_on I18n.t('ss.buttons.save')
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      # new-default (h2/h4) must be persisted for a newly created column
+      created = Cms::Column::Base.site(site).where(form_id: form.id).first
+      expect(created.min_headline_level).to eq 'h2'
+      expect(created.max_headline_level).to eq 'h4'
+
+      wait_for_cbox_opened { find('.btn-gws-column-item-detail').click }
+      within_dialog do
+        expect(page).to have_select('item[min_headline_level]', selected: 'h2')
+        expect(page).to have_select('item[max_headline_level]', selected: 'h4')
+        select 'h3', from: 'item[min_headline_level]'
+        select 'h6', from: 'item[max_headline_level]'
+        click_on I18n.t('ss.buttons.save')
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      updated = Cms::Column::Base.site(site).where(form_id: form.id).first
+      expect(updated.min_headline_level).to eq 'h3'
+      expect(updated.max_headline_level).to eq 'h6'
+      expect(updated.headline_list.values).to eq %w(h3 h4 h5 h6)
+    end
+
+    it 'rejects min/max options that are not h2..h6 (h1 is not offered)' do
+      visit cms_form_path(site, form)
+      click_on I18n.t('cms.buttons.manage_columns')
+
+      within '.gws-column-list-toolbar[data-placement="top"]' do
+        wait_for_event_fired("gws:column:added") { click_on I18n.t('cms.columns.cms/headline') }
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      within '.gws-column-form' do
+        fill_in 'item[name]', with: name
+        click_on I18n.t('ss.buttons.save')
+      end
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      wait_for_cbox_opened { find('.btn-gws-column-item-detail').click }
+      within_dialog do
+        min_options = all('select[name="item[min_headline_level]"] option').map(&:value)
+        max_options = all('select[name="item[max_headline_level]"] option').map(&:value)
+        expect(min_options).to eq %w(h2 h3 h4 h5 h6)
+        expect(max_options).to eq %w(h2 h3 h4 h5 h6)
+      end
+    end
+  end
 end

--- a/spec/features/cms/form/columns/headline_spec.rb
+++ b/spec/features/cms/form/columns/headline_spec.rb
@@ -48,7 +48,7 @@ describe Cms::Form::ColumnsController, type: :feature, dbscope: :example, js: tr
   end
 
   context 'min/max headline level configuration' do
-    it 'creates a new column with h2/h4 defaults and allows updating to h3/h6' do
+    it 'creates a new column with h2/h4 defaults and allows updating to h1/h6' do
       visit cms_form_path(site, form)
       click_on I18n.t('cms.buttons.manage_columns')
 
@@ -72,19 +72,19 @@ describe Cms::Form::ColumnsController, type: :feature, dbscope: :example, js: tr
       within_dialog do
         expect(page).to have_select('item[min_headline_level]', selected: 'h2')
         expect(page).to have_select('item[max_headline_level]', selected: 'h4')
-        select 'h3', from: 'item[min_headline_level]'
+        select 'h1', from: 'item[min_headline_level]'
         select 'h6', from: 'item[max_headline_level]'
         click_on I18n.t('ss.buttons.save')
       end
       wait_for_notice I18n.t('ss.notice.saved')
 
       updated = Cms::Column::Base.site(site).where(form_id: form.id).first
-      expect(updated.min_headline_level).to eq 'h3'
+      expect(updated.min_headline_level).to eq 'h1'
       expect(updated.max_headline_level).to eq 'h6'
-      expect(updated.headline_list.values).to eq %w(h3 h4 h5 h6)
+      expect(updated.headline_list.values).to eq %w(h1 h2 h3 h4 h5 h6)
     end
 
-    it 'rejects min/max options that are not h2..h6 (h1 is not offered)' do
+    it 'offers h1, h2 for min and h3..h6 for max' do
       visit cms_form_path(site, form)
       click_on I18n.t('cms.buttons.manage_columns')
 
@@ -103,8 +103,8 @@ describe Cms::Form::ColumnsController, type: :feature, dbscope: :example, js: tr
       within_dialog do
         min_options = all('select[name="item[min_headline_level]"] option').map(&:value)
         max_options = all('select[name="item[max_headline_level]"] option').map(&:value)
-        expect(min_options).to eq %w(h2 h3 h4 h5 h6)
-        expect(max_options).to eq %w(h2 h3 h4 h5 h6)
+        expect(min_options).to eq %w(h1 h2)
+        expect(max_options).to eq %w(h3 h4 h5 h6)
       end
     end
   end

--- a/spec/features/cms/pages/headline_block_spec.rb
+++ b/spec/features/cms/pages/headline_block_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe "headline block pulldown", type: :feature, dbscope: :example, js: true do
+  let(:site) { cms_site }
+  let(:node) do
+    create :article_node_page, cur_site: site, group_ids: [cms_group.id], st_form_ids: [form.id]
+  end
+  let(:form) do
+    create(:cms_form, cur_site: site, state: 'public', sub_type: 'static', group_ids: [cms_group.id])
+  end
+
+  before { login_cms_user }
+
+  context "with a new-default column (min=h3, max=h6)" do
+    let!(:column) do
+      create(
+        :cms_column_headline,
+        cur_site: site, cur_form: form, order: 1, required: "optional",
+        min_headline_level: 'h3', max_headline_level: 'h6'
+      )
+    end
+    let!(:item) do
+      create(
+        :article_page, cur_node: node, form: form,
+        column_values: [
+          column.value_type.new(column: column, head: 'h4', text: 'existing heading')
+        ]
+      )
+    end
+
+    it "offers only h3..h6 in the pulldown with the stored value preselected" do
+      visit edit_article_page_path(site.id, node, item)
+      wait_for_all_ckeditors_ready
+      wait_for_all_turbo_frames
+
+      within ".column-value-cms-column-headline" do
+        options = all('select[name="item[column_values][][in_wrap][head]"] option').map(&:value)
+        expect(options).to eq %w(h3 h4 h5 h6)
+        expect(page).to have_select('item[column_values][][in_wrap][head]', selected: 'h4')
+      end
+    end
+  end
+
+  context "with a legacy column (min/max nil)" do
+    let!(:column) do
+      create(:cms_column_headline, cur_site: site, cur_form: form, order: 1, required: "optional")
+    end
+    let!(:item) do
+      create(
+        :article_page, cur_node: node, form: form,
+        column_values: [
+          column.value_type.new(column: column, head: 'h1', text: 'legacy h1 heading')
+        ]
+      )
+    end
+
+    it "preserves h1 in the pulldown and in public output (backward compatibility)" do
+      visit edit_article_page_path(site.id, node, item)
+      wait_for_all_ckeditors_ready
+      wait_for_all_turbo_frames
+
+      within ".column-value-cms-column-headline" do
+        options = all('select[name="item[column_values][][in_wrap][head]"] option').map(&:value)
+        expect(options).to eq %w(h1 h2 h3 h4)
+        expect(page).to have_select('item[column_values][][in_wrap][head]', selected: 'h1')
+      end
+
+      # verify public-side rendering keeps the original h1
+      rendered = item.column_values.first.send(:to_default_html)
+      expect(rendered).to include('<h1>')
+      expect(rendered).to include('legacy h1 heading')
+    end
+  end
+end

--- a/spec/features/cms/pages/headline_block_spec.rb
+++ b/spec/features/cms/pages/headline_block_spec.rb
@@ -11,32 +11,32 @@ describe "headline block pulldown", type: :feature, dbscope: :example, js: true 
 
   before { login_cms_user }
 
-  context "with a new-default column (min=h3, max=h6)" do
+  context "with a new-default column (min=h2, max=h6)" do
     let!(:column) do
       create(
         :cms_column_headline,
         cur_site: site, cur_form: form, order: 1, required: "optional",
-        min_headline_level: 'h3', max_headline_level: 'h6'
+        min_headline_level: 'h2', max_headline_level: 'h6'
       )
     end
     let!(:item) do
       create(
         :article_page, cur_node: node, form: form,
         column_values: [
-          column.value_type.new(column: column, head: 'h4', text: 'existing heading')
+          column.value_type.new(column: column, head: 'h3', text: 'existing heading')
         ]
       )
     end
 
-    it "offers only h3..h6 in the pulldown with the stored value preselected" do
+    it "offers only h2..h6 in the pulldown with the stored value preselected" do
       visit edit_article_page_path(site.id, node, item)
       wait_for_all_ckeditors_ready
       wait_for_all_turbo_frames
 
       within ".column-value-cms-column-headline" do
         options = all('select[name="item[column_values][][in_wrap][head]"] option').map(&:value)
-        expect(options).to eq %w(h3 h4 h5 h6)
-        expect(page).to have_select('item[column_values][][in_wrap][head]', selected: 'h4')
+        expect(options).to eq %w(h2 h3 h4 h5 h6)
+        expect(page).to have_select('item[column_values][][in_wrap][head]', selected: 'h3')
       end
     end
   end

--- a/spec/models/cms/column/headline_spec.rb
+++ b/spec/models/cms/column/headline_spec.rb
@@ -29,10 +29,10 @@ describe Cms::Column::Headline, type: :model, dbscope: :example do
     end
 
     context 'when instantiated with explicit values' do
-      subject { described_class.new(min_headline_level: 'h3', max_headline_level: 'h5') }
+      subject { described_class.new(min_headline_level: 'h2', max_headline_level: 'h5') }
 
       it 'preserves explicit values' do
-        expect(subject.min_headline_level).to eq 'h3'
+        expect(subject.min_headline_level).to eq 'h2'
         expect(subject.max_headline_level).to eq 'h5'
       end
     end
@@ -74,24 +74,32 @@ describe Cms::Column::Headline, type: :model, dbscope: :example do
       end
     end
 
-    context 'with extended range h3-h6' do
-      subject { described_class.new(min_headline_level: 'h3', max_headline_level: 'h6').headline_list }
+    context 'with min=h1 max=h6 (full)' do
+      subject { described_class.new(min_headline_level: 'h1', max_headline_level: 'h6').headline_list }
 
-      it { is_expected.to eq(h3: 'h3', h4: 'h4', h5: 'h5', h6: 'h6') }
+      it { is_expected.to eq(h1: 'h1', h2: 'h2', h3: 'h3', h4: 'h4', h5: 'h5', h6: 'h6') }
     end
 
-    context 'with full selectable range h2-h6' do
+    context 'with min=h2 max=h6' do
       subject { described_class.new(min_headline_level: 'h2', max_headline_level: 'h6').headline_list }
 
       it { is_expected.to eq(h2: 'h2', h3: 'h3', h4: 'h4', h5: 'h5', h6: 'h6') }
     end
   end
 
-  describe '#headline_level_options' do
-    subject { described_class.new.headline_level_options.map(&:last) }
+  describe '#min_headline_level_options' do
+    subject { described_class.new.min_headline_level_options.map(&:last) }
 
-    it 'excludes h1 and returns h2 through h6' do
-      is_expected.to eq %w(h2 h3 h4 h5 h6)
+    it 'returns h1 and h2' do
+      is_expected.to eq %w(h1 h2)
+    end
+  end
+
+  describe '#max_headline_level_options' do
+    subject { described_class.new.max_headline_level_options.map(&:last) }
+
+    it 'returns h3 through h6' do
+      is_expected.to eq %w(h3 h4 h5 h6)
     end
   end
 
@@ -114,9 +122,9 @@ describe Cms::Column::Headline, type: :model, dbscope: :example do
     end
 
     context 'when set' do
-      let(:column) { described_class.new(min_headline_level: 'h3', max_headline_level: 'h5') }
+      let(:column) { described_class.new(min_headline_level: 'h2', max_headline_level: 'h5') }
 
-      it { expect(column.effective_min_headline_level).to eq 'h3' }
+      it { expect(column.effective_min_headline_level).to eq 'h2' }
       it { expect(column.effective_max_headline_level).to eq 'h5' }
     end
   end
@@ -129,19 +137,21 @@ describe Cms::Column::Headline, type: :model, dbscope: :example do
       )
     end
 
-    describe 'inclusion of min_headline_level / max_headline_level' do
-      it 'rejects h1 because h1 is not a selectable boundary' do
-        column.min_headline_level = 'h1'
-        column.max_headline_level = 'h4'
-        expect(column).not_to be_valid
-        expect(column.errors[:min_headline_level]).not_to be_empty
+    describe 'inclusion of min_headline_level' do
+      it 'accepts h1 and h2' do
+        %w(h1 h2).each do |level|
+          column.min_headline_level = level
+          column.max_headline_level = 'h4'
+          expect(column).to be_valid, "expected min=#{level} to be valid but got: #{column.errors.full_messages}"
+        end
       end
 
-      it 'accepts h2 through h6 for min' do
-        %w(h2 h3 h4 h5 h6).each do |level|
+      it 'rejects h3..h6 (only h1, h2 are selectable for min)' do
+        %w(h3 h4 h5 h6).each do |level|
           column.min_headline_level = level
-          column.max_headline_level = 'h6'
-          expect(column).to be_valid, "expected min=#{level} to be valid but got: #{column.errors.full_messages}"
+          column.max_headline_level = 'h4'
+          expect(column).not_to be_valid
+          expect(column.errors[:min_headline_level]).not_to be_empty
         end
       end
 
@@ -157,37 +167,26 @@ describe Cms::Column::Headline, type: :model, dbscope: :example do
       end
     end
 
-    describe 'range validation (min <= max)' do
-      it 'rejects min > max' do
-        column.min_headline_level = 'h5'
-        column.max_headline_level = 'h3'
-        expect(column).not_to be_valid
-        expect(column.errors[:max_headline_level]).not_to be_empty
+    describe 'inclusion of max_headline_level' do
+      it 'accepts h3 through h6' do
+        %w(h3 h4 h5 h6).each do |level|
+          column.min_headline_level = 'h2'
+          column.max_headline_level = level
+          expect(column).to be_valid, "expected max=#{level} to be valid but got: #{column.errors.full_messages}"
+        end
       end
 
-      it 'accepts min == max' do
-        column.min_headline_level = 'h3'
-        column.max_headline_level = 'h3'
-        expect(column).to be_valid
+      it 'rejects h1, h2 (only h3..h6 are selectable for max)' do
+        %w(h1 h2).each do |level|
+          column.min_headline_level = 'h2'
+          column.max_headline_level = level
+          expect(column).not_to be_valid
+          expect(column.errors[:max_headline_level]).not_to be_empty
+        end
       end
 
-      it 'accepts min < max' do
-        column.min_headline_level = 'h2'
-        column.max_headline_level = 'h6'
-        expect(column).to be_valid
-      end
-
-      # min が legacy フォールバック (h1) より大きい値で、max だけ blank だと、
-      # effective_max が h4 にフォールバックして実効レンジが反転する。
-      it 'rejects when only max is blank and min is greater than legacy max (h4)' do
-        column.min_headline_level = 'h5'
-        column.max_headline_level = nil
-        expect(column).not_to be_valid
-        expect(column.errors[:max_headline_level]).not_to be_empty
-      end
-
-      it 'accepts when only max is blank and min is within legacy range' do
-        column.min_headline_level = 'h2'
+      it 'accepts nil for legacy columns' do
+        column.min_headline_level = nil
         column.max_headline_level = nil
         expect(column).to be_valid
       end

--- a/spec/models/cms/column/headline_spec.rb
+++ b/spec/models/cms/column/headline_spec.rb
@@ -1,0 +1,181 @@
+require 'spec_helper'
+
+describe Cms::Column::Headline, type: :model, dbscope: :example do
+  let(:site) { cms_site }
+  let(:form) { create(:cms_form, cur_site: site, sub_type: 'entry') }
+
+  describe 'after_initialize defaults' do
+    context 'when instantiated without arguments' do
+      subject { described_class.new }
+
+      it 'applies new-column defaults (h2/h4)' do
+        expect(subject.min_headline_level).to eq 'h2'
+        expect(subject.max_headline_level).to eq 'h4'
+      end
+    end
+
+    context 'when instantiated with explicit nil (legacy simulation)' do
+      subject do
+        c = described_class.new
+        c.min_headline_level = nil
+        c.max_headline_level = nil
+        c
+      end
+
+      it 'preserves nil (legacy behavior)' do
+        expect(subject.min_headline_level).to be_nil
+        expect(subject.max_headline_level).to be_nil
+      end
+    end
+
+    context 'when instantiated with explicit values' do
+      subject { described_class.new(min_headline_level: 'h3', max_headline_level: 'h5') }
+
+      it 'preserves explicit values' do
+        expect(subject.min_headline_level).to eq 'h3'
+        expect(subject.max_headline_level).to eq 'h5'
+      end
+    end
+
+    context 'when loaded from DB' do
+      let!(:saved) do
+        column = described_class.new(cur_site: site, cur_form: form, name: "legacy-#{unique_id}", order: 1)
+        column.min_headline_level = nil
+        column.max_headline_level = nil
+        column.save!
+        column
+      end
+
+      it 'does not re-apply defaults to existing records' do
+        reloaded = described_class.find(saved.id)
+        expect(reloaded.min_headline_level).to be_nil
+        expect(reloaded.max_headline_level).to be_nil
+      end
+    end
+  end
+
+  describe '#headline_list' do
+    context 'with new defaults' do
+      subject { described_class.new(min_headline_level: 'h2', max_headline_level: 'h4').headline_list }
+
+      it { is_expected.to eq(h2: 'h2', h3: 'h3', h4: 'h4') }
+    end
+
+    context 'with legacy nil values' do
+      subject do
+        c = described_class.new
+        c.min_headline_level = nil
+        c.max_headline_level = nil
+        c.headline_list
+      end
+
+      it 'falls back to legacy h1-h4 range' do
+        is_expected.to eq(h1: 'h1', h2: 'h2', h3: 'h3', h4: 'h4')
+      end
+    end
+
+    context 'with extended range h3-h6' do
+      subject { described_class.new(min_headline_level: 'h3', max_headline_level: 'h6').headline_list }
+
+      it { is_expected.to eq(h3: 'h3', h4: 'h4', h5: 'h5', h6: 'h6') }
+    end
+
+    context 'with full selectable range h2-h6' do
+      subject { described_class.new(min_headline_level: 'h2', max_headline_level: 'h6').headline_list }
+
+      it { is_expected.to eq(h2: 'h2', h3: 'h3', h4: 'h4', h5: 'h5', h6: 'h6') }
+    end
+  end
+
+  describe '#headline_level_options' do
+    subject { described_class.new.headline_level_options.map(&:last) }
+
+    it 'excludes h1 and returns h2 through h6' do
+      is_expected.to eq %w(h2 h3 h4 h5 h6)
+    end
+  end
+
+  describe '#effective_min_headline_level / #effective_max_headline_level' do
+    context 'when nil (legacy)' do
+      let(:column) do
+        c = described_class.new
+        c.min_headline_level = nil
+        c.max_headline_level = nil
+        c
+      end
+
+      it 'returns legacy h1 for min' do
+        expect(column.effective_min_headline_level).to eq 'h1'
+      end
+
+      it 'returns legacy h4 for max' do
+        expect(column.effective_max_headline_level).to eq 'h4'
+      end
+    end
+
+    context 'when set' do
+      let(:column) { described_class.new(min_headline_level: 'h3', max_headline_level: 'h5') }
+
+      it { expect(column.effective_min_headline_level).to eq 'h3' }
+      it { expect(column.effective_max_headline_level).to eq 'h5' }
+    end
+  end
+
+  describe 'validations' do
+    let(:column) do
+      described_class.new(
+        cur_site: site, cur_form: form,
+        name: "spec-#{unique_id}", order: 1
+      )
+    end
+
+    describe 'inclusion of min_headline_level / max_headline_level' do
+      it 'rejects h1 because h1 is not a selectable boundary' do
+        column.min_headline_level = 'h1'
+        column.max_headline_level = 'h4'
+        expect(column).not_to be_valid
+        expect(column.errors[:min_headline_level]).not_to be_empty
+      end
+
+      it 'accepts h2 through h6 for min' do
+        %w(h2 h3 h4 h5 h6).each do |level|
+          column.min_headline_level = level
+          column.max_headline_level = 'h6'
+          expect(column).to be_valid, "expected min=#{level} to be valid but got: #{column.errors.full_messages}"
+        end
+      end
+
+      it 'accepts nil for legacy columns' do
+        column.min_headline_level = nil
+        column.max_headline_level = nil
+        expect(column).to be_valid
+      end
+
+      it 'rejects unknown value' do
+        column.min_headline_level = 'h9'
+        expect(column).not_to be_valid
+      end
+    end
+
+    describe 'range validation (min <= max)' do
+      it 'rejects min > max' do
+        column.min_headline_level = 'h5'
+        column.max_headline_level = 'h3'
+        expect(column).not_to be_valid
+        expect(column.errors[:max_headline_level]).not_to be_empty
+      end
+
+      it 'accepts min == max' do
+        column.min_headline_level = 'h3'
+        column.max_headline_level = 'h3'
+        expect(column).to be_valid
+      end
+
+      it 'accepts min < max' do
+        column.min_headline_level = 'h2'
+        column.max_headline_level = 'h6'
+        expect(column).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/cms/column/headline_spec.rb
+++ b/spec/models/cms/column/headline_spec.rb
@@ -176,6 +176,21 @@ describe Cms::Column::Headline, type: :model, dbscope: :example do
         column.max_headline_level = 'h6'
         expect(column).to be_valid
       end
+
+      # min が legacy フォールバック (h1) より大きい値で、max だけ blank だと、
+      # effective_max が h4 にフォールバックして実効レンジが反転する。
+      it 'rejects when only max is blank and min is greater than legacy max (h4)' do
+        column.min_headline_level = 'h5'
+        column.max_headline_level = nil
+        expect(column).not_to be_valid
+        expect(column.errors[:max_headline_level]).not_to be_empty
+      end
+
+      it 'accepts when only max is blank and min is within legacy range' do
+        column.min_headline_level = 'h2'
+        column.max_headline_level = nil
+        expect(column).to be_valid
+      end
     end
   end
 end

--- a/spec/models/cms/column/value/headline_spec.rb
+++ b/spec/models/cms/column/value/headline_spec.rb
@@ -31,4 +31,81 @@ describe Cms::Column::Value::Headline, type: :model, dbscope: :example do
       expect(subject.text).to eq value.text
     end
   end
+
+  describe 'head inclusion validation' do
+    let!(:node) { create :article_node_page }
+    let!(:form) { create(:cms_form, cur_site: cms_site, state: 'public', sub_type: 'entry') }
+
+    context 'with a new-default column (h2-h4)' do
+      let!(:column) do
+        create(:cms_column_headline,
+               cur_form: form, order: 1,
+               min_headline_level: 'h2', max_headline_level: 'h4')
+      end
+
+      it 'rejects head outside the range (h1)' do
+        value = column.value_type.new(column: column, head: 'h1', text: 'sample')
+        expect(value).not_to be_valid
+        expect(value.errors[:head]).not_to be_empty
+      end
+
+      it 'rejects head outside the range (h5)' do
+        value = column.value_type.new(column: column, head: 'h5', text: 'sample')
+        expect(value).not_to be_valid
+      end
+
+      it 'accepts head within the range (h3)' do
+        value = column.value_type.new(column: column, head: 'h3', text: 'sample')
+        expect(value).to be_valid
+      end
+    end
+
+    context 'with a legacy column (min/max nil)' do
+      let!(:column) { create(:cms_column_headline, cur_form: form, order: 1) }
+
+      it 'accepts head h1 (backward compatibility)' do
+        value = column.value_type.new(column: column, head: 'h1', text: 'sample')
+        expect(value).to be_valid
+      end
+
+      it 'accepts head h4' do
+        value = column.value_type.new(column: column, head: 'h4', text: 'sample')
+        expect(value).to be_valid
+      end
+
+      it 'rejects head h5 (outside legacy range)' do
+        value = column.value_type.new(column: column, head: 'h5', text: 'sample')
+        expect(value).not_to be_valid
+      end
+    end
+  end
+
+  describe '#import_csv_cell' do
+    let!(:form) { create(:cms_form, cur_site: cms_site, state: 'public', sub_type: 'entry') }
+
+    context 'with a new-default column' do
+      let!(:column) do
+        create(:cms_column_headline,
+               cur_form: form, order: 1,
+               min_headline_level: 'h2', max_headline_level: 'h4')
+      end
+
+      it 'defaults head to the column min (h2)' do
+        value = column.value_type.new(column: column)
+        value.import_csv_cell('sample text')
+        expect(value.head).to eq 'h2'
+        expect(value.text).to eq 'sample text'
+      end
+    end
+
+    context 'with a legacy column' do
+      let!(:column) { create(:cms_column_headline, cur_form: form, order: 1) }
+
+      it 'defaults head to h1 (legacy)' do
+        value = column.value_type.new(column: column)
+        value.import_csv_cell('sample text')
+        expect(value.head).to eq 'h1'
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ヘッドライン列で最小・最大レベルを設定できるUI（選択式）が追加され、デフォルトは h2 / h4。
  * 設定に応じて有効なヘッドラインレベル範囲が動的に計算され、ページ編集時のレベル選択に反映される。

* **バグ修正**
  * CSVインポートの既定見出しが列の最小レベルに合わせられるよう改善。
  * 許可外のヘッドラインレベルを拒否する検証を強化。

* **テスト**
  * 各種仕様（既定、境界、互換性）を検証する機能／モデルテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->