### PR TITLE
[fixup^2][feature][cms] loop html settings4

### DIFF
--- a/app/assets/javascripts/cms/lib/loop_snippet.js
+++ b/app/assets/javascripts/cms/lib/loop_snippet.js
@@ -1,0 +1,57 @@
+this.Cms_Loop_Snippet = (function () {
+  function Cms_Loop_Snippet() {
+  }
+
+  // ループHTML設定のスニペットセレクターを初期化する。
+  //
+  // options:
+  //   addon          : アドオンのコンテナセレクター (例: "#addon-...")
+  //   textarea       : スニペットを挿入する CodeMirror の textarea セレクター
+  //   templateSelect : テンプレート選択用の <select> セレクター (任意)
+  Cms_Loop_Snippet.render = function (options) {
+    options = options || {};
+
+    var $snippetSelect = $(options.addon).find('.loop-snippet-selector');
+    if ($snippetSelect.length === 0) {
+      return;
+    }
+
+    var $textarea = options.textarea ? $(options.textarea) : $();
+    var $templateSelect = options.templateSelect ? $(options.templateSelect) : $();
+
+    // スニペットセレクターの初期値を「直接入力」に設定
+    if (!$snippetSelect.val()) {
+      $snippetSelect.val('');
+    }
+
+    // テンプレート選択中はスニペットを挿入しても editor が readOnly のため反映されない。
+    // 操作不能であることを明示するためセレクター自体を disabled にする。
+    var syncDisabled = function () {
+      $snippetSelect.prop('disabled', !!$templateSelect.val());
+    };
+    syncDisabled();
+    $templateSelect.on('change', syncDisabled);
+
+    // スニペットの選択処理: CodeMirror のカーソル位置/選択範囲に挿入
+    $snippetSelect.on('change', function () {
+      var snippet = $snippetSelect.find(':selected').data('snippet');
+      $snippetSelect.val('');
+      if (!snippet) {
+        return;
+      }
+      if ($textarea.length === 0) {
+        return;
+      }
+      var editor = $textarea.data('editor');
+      if (!editor) {
+        return;
+      }
+      editor.getDoc().replaceSelection(snippet);
+      editor.focus();
+      editor.save();
+    });
+  };
+
+  return Cms_Loop_Snippet;
+
+})();

--- a/app/assets/javascripts/ss/script.js
+++ b/app/assets/javascripts/ss/script.js
@@ -69,6 +69,7 @@
 //= require chat/lib/chart
 //= require cms/lib/base
 //= require cms/lib/editor
+//= require cms/lib/loop_snippet
 //= require cms/lib/form
 //= require cms/lib/source_cleaner
 //= require cms/lib/template_form

--- a/app/views/cms/agents/addons/column/layout/_form.html.erb
+++ b/app/views/cms/agents/addons/column/layout/_form.html.erb
@@ -38,9 +38,10 @@
   var $addon = $("<%= "##{addon[:id]}" %>");
   var $snippetSelect = $addon.find('.loop-snippet-selector');
   var $layoutTextarea = $addon.find('textarea[name*="[layout]"]');
+  var $templateSelect = $addon.find('#<%= loop_setting_select_id %>');
 
   // テンプレート選択時に textarea を readonly にする (内容は保持)
-  if ($addon.find('#<%= loop_setting_select_id %>').length) {
+  if ($templateSelect.length) {
     Cms_Editor_CodeMirror.lock(
       '#<%= loop_setting_select_id %>',
       '#<%= addon[:id] %> textarea[name*="[layout]"]'
@@ -51,6 +52,17 @@
   if ($snippetSelect.length && !$snippetSelect.val()) {
     $snippetSelect.val('');
   }
+
+  // テンプレート選択中はスニペットを挿入しても editor が readOnly のため反映されない。
+  // 操作不能であることを明示するためセレクター自体を disabled にする。
+  var syncSnippetSelectorDisabled = function() {
+    if (!$snippetSelect.length) {
+      return;
+    }
+    $snippetSelect.prop('disabled', !!$templateSelect.val());
+  };
+  syncSnippetSelectorDisabled();
+  $templateSelect.on('change', syncSnippetSelectorDisabled);
 
   // スニペットの選択処理: CodeMirror のカーソル位置/選択範囲に挿入
   $snippetSelect.on('change', function() {

--- a/app/views/cms/agents/addons/column/layout/_form.html.erb
+++ b/app/views/cms/agents/addons/column/layout/_form.html.erb
@@ -35,10 +35,7 @@
 </dl>
 
 <%= jquery do %>
-  var $addon = $("<%= "##{addon[:id]}" %>");
-  var $snippetSelect = $addon.find('.loop-snippet-selector');
-  var $layoutTextarea = $addon.find('textarea[name*="[layout]"]');
-  var $templateSelect = $addon.find('#<%= loop_setting_select_id %>');
+  var $templateSelect = $("<%= "##{addon[:id]}" %>").find('#<%= loop_setting_select_id %>');
 
   // テンプレート選択時に textarea を readonly にする (内容は保持)
   if ($templateSelect.length) {
@@ -48,39 +45,9 @@
     );
   }
 
-  // スニペットセレクターの初期値を「直接入力」に設定
-  if ($snippetSelect.length && !$snippetSelect.val()) {
-    $snippetSelect.val('');
-  }
-
-  // テンプレート選択中はスニペットを挿入しても editor が readOnly のため反映されない。
-  // 操作不能であることを明示するためセレクター自体を disabled にする。
-  var syncSnippetSelectorDisabled = function() {
-    if (!$snippetSelect.length) {
-      return;
-    }
-    $snippetSelect.prop('disabled', !!$templateSelect.val());
-  };
-  syncSnippetSelectorDisabled();
-  $templateSelect.on('change', syncSnippetSelectorDisabled);
-
-  // スニペットの選択処理: CodeMirror のカーソル位置/選択範囲に挿入
-  $snippetSelect.on('change', function() {
-    var $option = $snippetSelect.find(':selected');
-    var snippet = $option.data('snippet');
-    $snippetSelect.val('');
-    if (!snippet) {
-      return;
-    }
-    if ($layoutTextarea.length === 0) {
-      return;
-    }
-    var editor = $layoutTextarea.data('editor');
-    if (!editor) {
-      return;
-    }
-    editor.getDoc().replaceSelection(snippet);
-    editor.focus();
-    editor.save();
+  Cms_Loop_Snippet.render({
+    addon: '#<%= addon[:id] %>',
+    textarea: '#<%= addon[:id] %> textarea[name*="[layout]"]',
+    templateSelect: '#<%= loop_setting_select_id %>'
   });
 <% end %>

--- a/app/views/cms/agents/addons/column/layout/_form.html.erb
+++ b/app/views/cms/agents/addons/column/layout/_form.html.erb
@@ -79,7 +79,7 @@
     if (!editor) {
       return;
     }
-    editor.getDoc().replaceSelection(snippet + "\n");
+    editor.getDoc().replaceSelection(snippet);
     editor.focus();
     editor.save();
   });

--- a/app/views/cms/agents/addons/layout_html/_form.html.erb
+++ b/app/views/cms/agents/addons/layout_html/_form.html.erb
@@ -73,9 +73,10 @@
   var $addon = $("<%= "##{addon[:id]}" %>");
   var $snippetSelect = $addon.find('.loop-snippet-selector');
   var $htmlTextarea = $addon.find('textarea[name*="[html]"]');
+  var $templateSelect = $addon.find('#<%= loop_setting_select_id %>');
 
   // テンプレート選択時に textarea を readonly にする (内容は保持)
-  if ($addon.find('#<%= loop_setting_select_id %>').length) {
+  if ($templateSelect.length) {
     Cms_Editor_CodeMirror.lock(
       '#<%= loop_setting_select_id %>',
       '#<%= addon[:id] %> textarea[name*="[html]"]'
@@ -86,6 +87,17 @@
   if ($snippetSelect.length && !$snippetSelect.val()) {
     $snippetSelect.val('');
   }
+
+  // テンプレート選択中はスニペットを挿入しても editor が readOnly のため反映されない。
+  // 操作不能であることを明示するためセレクター自体を disabled にする。
+  var syncSnippetSelectorDisabled = function() {
+    if (!$snippetSelect.length) {
+      return;
+    }
+    $snippetSelect.prop('disabled', !!$templateSelect.val());
+  };
+  syncSnippetSelectorDisabled();
+  $templateSelect.on('change', syncSnippetSelectorDisabled);
 
   // スニペットの選択処理: CodeMirror のカーソル位置/選択範囲に挿入
   $snippetSelect.on('change', function() {

--- a/app/views/cms/agents/addons/layout_html/_form.html.erb
+++ b/app/views/cms/agents/addons/layout_html/_form.html.erb
@@ -114,7 +114,7 @@
     if (!editor) {
       return;
     }
-    editor.getDoc().replaceSelection(snippet + "\n");
+    editor.getDoc().replaceSelection(snippet);
     editor.focus();
     editor.save();
   });

--- a/app/views/cms/agents/addons/layout_html/_form.html.erb
+++ b/app/views/cms/agents/addons/layout_html/_form.html.erb
@@ -70,10 +70,7 @@
 </dl>
 
 <%= jquery do %>
-  var $addon = $("<%= "##{addon[:id]}" %>");
-  var $snippetSelect = $addon.find('.loop-snippet-selector');
-  var $htmlTextarea = $addon.find('textarea[name*="[html]"]');
-  var $templateSelect = $addon.find('#<%= loop_setting_select_id %>');
+  var $templateSelect = $("<%= "##{addon[:id]}" %>").find('#<%= loop_setting_select_id %>');
 
   // テンプレート選択時に textarea を readonly にする (内容は保持)
   if ($templateSelect.length) {
@@ -83,40 +80,10 @@
     );
   }
 
-  // スニペットセレクターの初期値を「直接入力」に設定
-  if ($snippetSelect.length && !$snippetSelect.val()) {
-    $snippetSelect.val('');
-  }
-
-  // テンプレート選択中はスニペットを挿入しても editor が readOnly のため反映されない。
-  // 操作不能であることを明示するためセレクター自体を disabled にする。
-  var syncSnippetSelectorDisabled = function() {
-    if (!$snippetSelect.length) {
-      return;
-    }
-    $snippetSelect.prop('disabled', !!$templateSelect.val());
-  };
-  syncSnippetSelectorDisabled();
-  $templateSelect.on('change', syncSnippetSelectorDisabled);
-
-  // スニペットの選択処理: CodeMirror のカーソル位置/選択範囲に挿入
-  $snippetSelect.on('change', function() {
-    var $option = $snippetSelect.find(':selected');
-    var snippet = $option.data('snippet');
-    $snippetSelect.val('');
-    if (!snippet) {
-      return;
-    }
-    if ($htmlTextarea.length === 0) {
-      return;
-    }
-    var editor = $htmlTextarea.data('editor');
-    if (!editor) {
-      return;
-    }
-    editor.getDoc().replaceSelection(snippet);
-    editor.focus();
-    editor.save();
+  Cms_Loop_Snippet.render({
+    addon: '#<%= addon[:id] %>',
+    textarea: '#<%= addon[:id] %> textarea[name*="[html]"]',
+    templateSelect: '#<%= loop_setting_select_id %>'
   });
 <% end %>
 

--- a/app/views/cms/agents/addons/page_list/_form.html.erb
+++ b/app/views/cms/agents/addons/page_list/_form.html.erb
@@ -193,7 +193,7 @@
       if (!editor) {
         return;
       }
-      editor.getDoc().replaceSelection(snippet + "\n");
+      editor.getDoc().replaceSelection(snippet);
       editor.focus();
       editor.save();
     });

--- a/app/views/cms/agents/addons/page_list/_form.html.erb
+++ b/app/views/cms/agents/addons/page_list/_form.html.erb
@@ -160,11 +160,23 @@
     var $addon = $("<%= "##{addon[:id]}" %>");
     var $snippetSelect = $addon.find('.loop-snippet-selector');
     var $liquidTextarea = $addon.find('#item_loop_liquid');
+    var $liquidTemplateSelect = $('#item_loop_setting_id_liquid');
 
     // スニペットセレクターの初期値を「直接入力」に設定
     if ($snippetSelect.length && !$snippetSelect.val()) {
       $snippetSelect.val('');
     }
+
+    // テンプレート選択中はスニペットを挿入しても editor が readOnly のため反映されない。
+    // 操作不能であることを明示するためセレクター自体を disabled にする。
+    var syncSnippetSelectorDisabled = function() {
+      if (!$snippetSelect.length) {
+        return;
+      }
+      $snippetSelect.prop('disabled', !!$liquidTemplateSelect.val());
+    };
+    syncSnippetSelectorDisabled();
+    $liquidTemplateSelect.on('change', syncSnippetSelectorDisabled);
 
     // スニペットの選択処理: CodeMirror のカーソル位置/選択範囲に挿入
     $snippetSelect.on('change', function() {

--- a/app/views/cms/agents/addons/page_list/_form.html.erb
+++ b/app/views/cms/agents/addons/page_list/_form.html.erb
@@ -157,45 +157,10 @@
   </dl>
 
   <%= jquery do %>
-    var $addon = $("<%= "##{addon[:id]}" %>");
-    var $snippetSelect = $addon.find('.loop-snippet-selector');
-    var $liquidTextarea = $addon.find('#item_loop_liquid');
-    var $liquidTemplateSelect = $('#item_loop_setting_id_liquid');
-
-    // スニペットセレクターの初期値を「直接入力」に設定
-    if ($snippetSelect.length && !$snippetSelect.val()) {
-      $snippetSelect.val('');
-    }
-
-    // テンプレート選択中はスニペットを挿入しても editor が readOnly のため反映されない。
-    // 操作不能であることを明示するためセレクター自体を disabled にする。
-    var syncSnippetSelectorDisabled = function() {
-      if (!$snippetSelect.length) {
-        return;
-      }
-      $snippetSelect.prop('disabled', !!$liquidTemplateSelect.val());
-    };
-    syncSnippetSelectorDisabled();
-    $liquidTemplateSelect.on('change', syncSnippetSelectorDisabled);
-
-    // スニペットの選択処理: CodeMirror のカーソル位置/選択範囲に挿入
-    $snippetSelect.on('change', function() {
-      var $option = $snippetSelect.find(':selected');
-      var snippet = $option.data('snippet');
-      $snippetSelect.val('');
-      if (!snippet) {
-        return;
-      }
-      if ($liquidTextarea.length === 0) {
-        return;
-      }
-      var editor = $liquidTextarea.data('editor');
-      if (!editor) {
-        return;
-      }
-      editor.getDoc().replaceSelection(snippet);
-      editor.focus();
-      editor.save();
+    Cms_Loop_Snippet.render({
+      addon: '#<%= addon[:id] %>',
+      textarea: '#item_loop_liquid',
+      templateSelect: '#item_loop_setting_id_liquid'
     });
   <% end %>
 <% end %>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -2177,6 +2177,8 @@ ja:
         snippets:
           - 良く使うHTML片が一覧に表示されます。
           - HTML片を選択すると、現在のカーソル位置にHTML片が挿入されます。
+          - その他、liquidに使用するタグは下記よりご確認ください。
+          - <a href="https://shirasagi.github.io/features/liquid/index.html" target="_blank" rel="noopener">https://shirasagi.github.io/features/liquid/index.html</a>
         loop_html:
           - 事前に登録したテンプレートが一覧表示されます。
           - 一覧からテンプレートを選択するか、「直接入力する」を選択し任意のHTMLを設定してください。

--- a/db/seeds/cms/contents/loop_settings.rb
+++ b/db/seeds/cms/contents/loop_settings.rb
@@ -271,17 +271,6 @@ save_loop_setting(
   html: "{{ page.categories | map: \"basename\" | ss_prepend: \"item-\" | join: \" \" }}"
 )
 
-# ページ変数 - タグ
-save_loop_setting(
-  name: "ページ/タグ",
-  loop_html_setting_type: "snippet",
-  description: "ページのタグをスペース区切りで表示",
-  html_format: "liquid",
-  state: "public",
-  order: 250,
-  html: "{{ page.tags | join: \" \" }}"
-)
-
 # ページ変数 - グループ
 save_loop_setting(
   name: "ページ/管理グループ",

--- a/spec/features/cms/node/liquid_snippet_spec.rb
+++ b/spec/features/cms/node/liquid_snippet_spec.rb
@@ -107,6 +107,9 @@ describe "cms node liquid snippets", type: :feature, dbscope: :example, js: true
       textarea_value = find('#item_loop_liquid', visible: false).value
       expect(textarea_value).to include("existing-liquid-content")
       expect(textarea_value).to include(snippet_html_high)
+      # スニペットはカーソル位置 (fill_in_code_mirror 後は先頭) にそのまま挿入され、
+      # 前後に余分な改行が付かないこと (回帰防止)
+      expect(textarea_value).to eq(snippet_html_high + "existing-liquid-content")
     end
   end
 

--- a/spec/features/cms/node/liquid_snippet_spec.rb
+++ b/spec/features/cms/node/liquid_snippet_spec.rb
@@ -217,6 +217,32 @@ describe "cms node liquid snippets", type: :feature, dbscope: :example, js: true
   end
 
   #
+  # テンプレート選択時、textarea は readOnly になるが editor.replaceSelection で
+  # スニペットが挿入できてしまっていた (利用者には反映されないテンプレート内容に
+  # 上書きされ、混乱を招いた)。回帰防止のため、テンプレート選択中はスニペット
+  # セレクターが disabled になることを検証する。
+  #
+  it "disables the snippet selector while a liquid template is selected" do
+    visit edit_node_conf_path(site.id, node)
+    ensure_addon_opened('#addon-event-agents-addons-page_list')
+
+    within '#addon-event-agents-addons-page_list' do
+      select('Liquid', from: 'item[loop_format]') if page.has_select?('item[loop_format]')
+      wait_for_js_ready
+
+      expect(loop_snippet_select).not_to be_disabled
+
+      select_loop_setting('item_loop_setting_id_liquid', liquid_template_low.name)
+      Selenium::WebDriver::Wait.new(timeout: Capybara.default_max_wait_time).until { loop_snippet_select.disabled? }
+      expect(loop_snippet_select).to be_disabled
+
+      select_loop_setting('item_loop_setting_id_liquid', I18n.t('cms.input_directly'))
+      Selenium::WebDriver::Wait.new(timeout: Capybara.default_max_wait_time).until { !loop_snippet_select.disabled? }
+      expect(loop_snippet_select).not_to be_disabled
+    end
+  end
+
+  #
   # 管理画面で編集したループHTML設定が、記事フォルダの公開ページに反映されることを
   # SHIRASAGI / Liquid 両形式で End-to-End で検証する。
   #


### PR DESCRIPTION

## 概要
スニペットセレクターはテンプレート選択中も操作可能で、CodeMirror が readOnly のまま editor.replaceSelection でスニペット内容を上書きできてしまっていた。テンプレート内容に 反映されない挿入が発生し利用者の混乱を招くため、テンプレート選択中はセレクター自体をdisabled にする。column/layout・layout_html・page_list の 3 アドオンで横展開し、 page_list 側に回帰防止用のフィーチャースペックを追加。あわせて snippets ヘルプに Liquid タグ一覧へのリンクを補足。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ループ用スニペットの初期化・挿入処理を共通モジュールに移行しました。

* **バグ修正**
  * テンプレート選択中はスニペット選択を自動無効化し、解除で復帰する同期動作を改善しました。
  * スニペット挿入時の不要な末尾改行や挿入タイミングの不整合を解消しました。

* **テスト**
  * テンプレート選択状態とスニペット選択の有効/無効遷移を検証する回帰テストを追加・調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->