### PR TITLE
[modify] cms : show description setting on page detail and hide manua…

### DIFF
--- a/app/views/cms/agents/addons/meta/_form.html.erb
+++ b/app/views/cms/agents/addons/meta/_form.html.erb
@@ -22,10 +22,9 @@
     <%= f.label :description_setting, t("cms.options.description_setting.description_setting_auto"), value: "auto" %>
   </dd>
 
-  <dt class="depth-2"><%= @model.t :description_body %><%= @model.tt :description_body %></dt>
-  <dd class="depth-2">
+  <dt class="depth-2 js-description-body"<%= " hidden".html_safe if @item.description_setting_auto? %>><%= @model.t :description_body %><%= @model.tt :description_body %></dt>
+  <dd class="depth-2 js-description-body"<%= " hidden".html_safe if @item.description_setting_auto? %>>
     <% opts = @cur_site.auto_description_enabled? ? {} : { class: "presence" } %>
-    <% opts[:readonly] = @item.description_setting_auto? %>
     <%= f.text_area :description, opts %>
   </dd>
 
@@ -35,19 +34,9 @@
 
 <%= javascript_tag do %>
   $(function() {
-  const descriptionField = $('#item_description');
-
-  // 初期状態のクラス設定
-  if (descriptionField.prop('readonly')) {
-    descriptionField.addClass('readonly');
-  }
-
-  $('input[name="item[description_setting]"]').on('change', function() {
-    const currentSetting = $(this).val();
-
-    // 読み取り専用状態とクラスの切り替え
-    descriptionField.prop('readonly', currentSetting === 'auto');
-    descriptionField.toggleClass('readonly', currentSetting === 'auto');
+    $('input[name="item[description_setting]"]').on('change', function() {
+      const isAuto = $(this).val() === 'auto';
+      $('.js-description-body').prop('hidden', isAuto);
+    });
   });
-});
 <% end %>

--- a/app/views/cms/agents/addons/meta/_show.html.erb
+++ b/app/views/cms/agents/addons/meta/_show.html.erb
@@ -10,7 +10,16 @@
   <dd><%= @item.send :keywords %></dd>
 
   <dt><%= @model.t :description %></dt>
-  <dd><%= @item.send :description %></dd>
+  <dd></dd>
+
+  <dt class="depth-2"><%= @model.t :description_setting %></dt>
+  <dd class="depth-2">
+    <% setting_key = @item.description_setting_manual? ? "description_setting_manual" : "description_setting_auto" %>
+    <%= t("cms.options.description_setting.#{setting_key}") %>
+  </dd>
+
+  <dt class="depth-2"><%= @model.t :description_body %></dt>
+  <dd class="depth-2"><%= @item.template_variable_handler_description %></dd>
 
   <dt><%= @model.t :summary_html %></dt>
   <dd><%= @item.send :summary_html %></dd>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -1333,7 +1333,7 @@ ja:
         keywords: キーワード
         description: 概要
         description_setting: 概要の連動設定
-        description_body: 概要の本文(手動)
+        description_body: 概要の本文
         summary_html: サマリー
       cms/addon/html:
         html: HTML

--- a/spec/features/article/pages/default_release_plan_spec.rb
+++ b/spec/features/article/pages/default_release_plan_spec.rb
@@ -30,6 +30,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
             fill_in "item[basename]", with: "sample"
             ensure_addon_opened('#addon-cms-agents-addons-meta')
             fill_in "item[keywords]", with: "sample"
+            choose "item_description_setting_manual"
             fill_in "item[description]", with: "sample"
             click_button I18n.t("ss.buttons.publish_save")
           end
@@ -66,6 +67,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
             fill_in "item[basename]", with: "sample"
             ensure_addon_opened('#addon-cms-agents-addons-meta')
             fill_in "item[keywords]", with: "sample"
+            choose "item_description_setting_manual"
             fill_in "item[description]", with: "sample"
             click_button I18n.t("ss.buttons.draft_save")
           end
@@ -104,6 +106,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
             fill_in "item[basename]", with: "sample"
             ensure_addon_opened('#addon-cms-agents-addons-meta')
             fill_in "item[keywords]", with: "sample"
+            choose "item_description_setting_manual"
             fill_in "item[description]", with: "sample"
             click_button I18n.t("ss.buttons.publish_save")
           end
@@ -147,6 +150,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
             fill_in "item[basename]", with: "sample"
             ensure_addon_opened('#addon-cms-agents-addons-meta')
             fill_in "item[keywords]", with: "sample"
+            choose "item_description_setting_manual"
             fill_in "item[description]", with: "sample"
             click_button I18n.t("ss.buttons.publish_save")
           end

--- a/spec/features/cms/pages/meta_spec.rb
+++ b/spec/features/cms/pages/meta_spec.rb
@@ -116,6 +116,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to match(auto_generated_description)
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(auto_generated_description)
+        end
       end
 
       it "keeps manual description in manual mode" do
@@ -144,6 +151,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq manual_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(manual_description)
+        end
       end
     end
 
@@ -191,6 +205,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq updated_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(updated_description)
+        end
       end
     end
 
@@ -252,6 +273,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq updated_description
 
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, duplicated_item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(updated_description)
+        end
+
         # オリジナルページを確認
         original_item.reload
 
@@ -265,6 +293,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq original_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, original_item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(original_description)
+        end
       end
     end
 
@@ -324,6 +359,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq updated_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, published_item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(updated_description)
+        end
       end
     end
 
@@ -362,6 +404,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq auto_generated_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(auto_generated_description)
+        end
       end
 
       it "updates description when body is updated after save" do
@@ -402,6 +451,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq updated_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(updated_description)
+        end
       end
 
       it "manual mode: description is set and reflected in meta tag" do
@@ -425,6 +481,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq "Manual description"
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content("Manual description")
+        end
       end
 
       it "auto mode: description is blank but meta tag is from body" do
@@ -447,6 +510,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq "Auto mode test"
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content("Auto mode test")
+        end
       end
 
       it "switch manual→auto: description remains, meta tag from body" do
@@ -480,6 +550,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq "Switch test"
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content("Switch test")
+        end
       end
 
       it "auto mode: empty body results in empty meta tag" do
@@ -534,6 +611,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         doc = Nokogiri::HTML.parse(html)
         description_elements = doc.css("meta[name='description']")
         expect(description_elements[0]['content']).to eq "Second body"
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content("Second body")
+        end
       end
 
       it "updates description when html is changed in duplicated page with auto mode" do
@@ -591,6 +675,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq duplicated_description
 
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, duplicated_item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(duplicated_description)
+        end
+
         # オリジナルページを確認
         original_item.reload
 
@@ -604,6 +695,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq original_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, original_item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(original_description)
+        end
       end
 
       it "updates description in the replacement page with auto mode" do
@@ -666,6 +764,13 @@ describe "cms/pages", type: :feature, dbscope: :example, js: true do
         description_elements = doc.css("meta[name='description']")
         expect(description_elements).not_to be_empty
         expect(description_elements[0]['content']).to eq updated_description
+
+        # 詳細画面でも同じ概要が表示されていることを確認
+        visit cms_page_path(site.id, published_item.id)
+        ensure_addon_opened('#addon-cms-agents-addons-meta')
+        within '#addon-cms-agents-addons-meta' do
+          expect(page).to have_content(updated_description)
+        end
       end
     end
   end


### PR DESCRIPTION
## 概要
メタアドオンの概要を本文と連動に設定していた場合に、管理画面の詳細画面で概要の内容が表示されるよう修正



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * CMS詳細ページでメタ説明の設定（自動/手動）と本文を別々に表示するように変更しました
  * メタ説明編集フォームで本文の表示切替をシンプルにし、操作性を向上しました

* **テスト**
  * メタ説明が詳細ページに表示されることを確認するテストを拡充しました
  * 記事作成のテストで手動設定を選択するケースを追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shirasagi/shirasagi/pull/6042)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->