### PR TITLE
[fixup][cms] embedded media checker の修正と YoutTube タイトルの自動取得 (#5828)

### DIFF
--- a/public/assets/js/ckeditor/plugins/youtube/plugin.js
+++ b/public/assets/js/ckeditor/plugins/youtube/plugin.js
@@ -6,17 +6,21 @@
 */
 (function () {
 	var fetchTitle = async function(video) {
-		var params = new URLSearchParams();
-		params.append("url", "https://www.youtube.com/watch?v=" + video);
-		params.append("format", "json");
+		try {
+			var params = new URLSearchParams();
+			params.append("url", "https://www.youtube.com/watch?v=" + video);
+			params.append("format", "json");
 
-		var response = await fetch("https://www.youtube.com/oembed" + "?" + params.toString());
-		if (!response.ok) {
-			return;
+			var response = await fetch("https://www.youtube.com/oembed" + "?" + params.toString());
+			if (!response.ok) {
+				return;
+			}
+
+			var data = await response.json();
+			return data["title"];
+		} catch (ex) {
+			return undefined;
 		}
-
-		var data = await response.json();
-		return data["title"];
 	};
 
   CKEDITOR.plugins.add('youtube', {


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

インターネットにつながらない環境下で CKEditor の「Youtube Embed Plugin」でエラーが発生し、
YouTube 動画を埋め込められない。