### PR TITLE
[fixup][K03012-1872 K03012-1864] ブロック入力の改修について（要望 4: 見出しレベルの初期値設定・拡張）

### DIFF
--- a/app/assets/javascripts/cms/lib/form.js.erb
+++ b/app/assets/javascripts/cms/lib/form.js.erb
@@ -98,43 +98,43 @@ this.Cms_Form = (function () {
       }
     });
 
-    var h = [], ids = [], code, id, errorIdx, ref, i, j;
+    var h = [], ids = [], code, id, ref, i, j;
     $("#addon-cms-agents-addons-form-page .column-value-cms-column-headline").each(function () {
       ids.push($(this).attr("id"));
       h.push($(this).find('[name="item[column_values][][in_wrap][head]"]').val());
     });
 
     // orderOfH
-    errorIdx = [];
+    var errorEntries = [];
     if (h.length) {
       for (i = j = 0, ref = h.length - 1; 0 <= ref ? j <= ref : j >= ref; i = 0 <= ref ? ++j : --j) {
         if (i === 0) {
           if (!/h[12]/i.test(h[i])) {
-            errorIdx.push(i);
+            errorEntries.push({ idx: i, key: "invalidFirstHeadingLevel" });
           }
         } else {
           if (/h3/i.test(h[i])) {
             if (!/h[234]/i.test(h[i - 1])) {
-              errorIdx.push(i);
+              errorEntries.push({ idx: i, key: "invalidHeadingLevelSkip" });
             }
           } else if (/h4/i.test(h[i])) {
             if (!/h[34]/i.test(h[i - 1])) {
-              errorIdx.push(i);
+              errorEntries.push({ idx: i, key: "invalidHeadingLevelSkip" });
             }
           }
         }
       }
     }
 
-    for (i = 0; i < errorIdx.length; i++) {
-      var idx = errorIdx[i];
+    for (i = 0; i < errorEntries.length; i++) {
+      var entry = errorEntries[i];
       Syntax_Checker.errors.push(
         {
-          id: ids[idx],
+          id: ids[entry.idx],
           idx: 0,
-          code: h[idx],
-          msg: Syntax_Checker.message["invalidOrderOfH"],
-          detail: Syntax_Checker.detail["invalidOrderOfH"]
+          code: h[entry.idx],
+          msg: Syntax_Checker.message[entry.key],
+          detail: Syntax_Checker.detail[entry.key]
         }
       );
     }

--- a/app/assets/javascripts/cms/lib/form.js.erb
+++ b/app/assets/javascripts/cms/lib/form.js.erb
@@ -106,21 +106,22 @@ this.Cms_Form = (function () {
 
     // orderOfH
     var errorEntries = [];
+    var levelOf = function (name) {
+      var m = /h([1-6])/i.exec(name);
+      return m ? parseInt(m[1], 10) : 0;
+    };
     if (h.length) {
       for (i = j = 0, ref = h.length - 1; 0 <= ref ? j <= ref : j >= ref; i = 0 <= ref ? ++j : --j) {
+        var currentLevel = levelOf(h[i]);
+        if (currentLevel === 0) continue;
         if (i === 0) {
-          if (!/h[12]/i.test(h[i])) {
+          if (currentLevel > 2) {
             errorEntries.push({ idx: i, key: "invalidFirstHeadingLevel" });
           }
-        } else {
-          if (/h3/i.test(h[i])) {
-            if (!/h[234]/i.test(h[i - 1])) {
-              errorEntries.push({ idx: i, key: "invalidHeadingLevelSkip" });
-            }
-          } else if (/h4/i.test(h[i])) {
-            if (!/h[34]/i.test(h[i - 1])) {
-              errorEntries.push({ idx: i, key: "invalidHeadingLevelSkip" });
-            }
+        } else if (currentLevel > 2) {
+          var prevLevel = levelOf(h[i - 1]);
+          if (prevLevel < currentLevel - 1) {
+            errorEntries.push({ idx: i, key: "invalidHeadingLevelSkip" });
           }
         }
       }

--- a/app/assets/javascripts/cms/lib/syntax_checker.js.erb
+++ b/app/assets/javascripts/cms/lib/syntax_checker.js.erb
@@ -519,11 +519,13 @@ this.Syntax_Checker = (function () {
   // javascript syntax check
 
   Syntax_Checker.message = {
-    invalidOrderOfH: "<%= I18n.t('errors.messages.invalid_order_of_h') %>",
+    invalidFirstHeadingLevel: "<%= I18n.t('errors.messages.invalid_first_heading_level') %>",
+    invalidHeadingLevelSkip: "<%= I18n.t('errors.messages.invalid_heading_level_skip') %>",
     checkLinkText: "<%= I18n.t('errors.messages.check_link_text') %>",
   };
   Syntax_Checker.detail = {
-    invalidOrderOfH: <%= I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h').to_json %>,
+    invalidFirstHeadingLevel: <%= I18n.t('errors.messages.syntax_check_detail.invalid_first_heading_level').to_json %>,
+    invalidHeadingLevelSkip: <%= I18n.t('errors.messages.syntax_check_detail.invalid_heading_level_skip').to_json %>,
     checkLinkText: <%= I18n.t('errors.messages.syntax_check_detail.check_link_text').to_json %>,
   };
 

--- a/app/models/cms/syntax_checker/column/order_of_h_checker.rb
+++ b/app/models/cms/syntax_checker/column/order_of_h_checker.rb
@@ -4,8 +4,10 @@ class Cms::SyntaxChecker::Column::OrderOfHChecker
   attr_accessor :context, :contents
 
   def check
-    code = ''
-    first_error_content = nil
+    code_first = ''
+    code_skip = ''
+    first_content_for_first = nil
+    first_content_for_skip = nil
     h_level_check = context.h_level_check
     header_check = context.header_check
 
@@ -20,9 +22,12 @@ class Cms::SyntaxChecker::Column::OrderOfHChecker
         if current_level <= 2 && !header_check
           h_level_check = current_level
           header_check = true
-        elsif (current_level > 2 && !header_check) || (h_level_check < current_level - 1)
-          code += current_content.column_value.head + " "
-          first_error_content ||= current_content
+        elsif current_level > 2 && !header_check
+          code_first += current_content.column_value.head + " "
+          first_content_for_first ||= current_content
+        elsif h_level_check < current_level - 1
+          code_skip += current_content.column_value.head + " "
+          first_content_for_skip ||= current_content
         else
           h_level_check = current_level
         end
@@ -30,14 +35,21 @@ class Cms::SyntaxChecker::Column::OrderOfHChecker
         # 2 個目以降にある h1, h2 は無チェック
         next
       elsif prev_level < current_level - 1
-        code += current_content.column_value.head + " "
-        first_error_content ||= current_content
+        code_skip += current_content.column_value.head + " "
+        first_content_for_skip ||= current_content
       end
     end
-    return if code.blank?
 
-    context.errors << Cms::SyntaxChecker::CheckerError.new(
-      context: context, content: first_error_content, code: code.strip, checker: self, error: :invalid_order_of_h)
+    if code_first.present?
+      context.errors << Cms::SyntaxChecker::CheckerError.new(
+        context: context, content: first_content_for_first, code: code_first.strip, checker: self,
+        error: :invalid_first_heading_level)
+    end
+    if code_skip.present?
+      context.errors << Cms::SyntaxChecker::CheckerError.new(
+        context: context, content: first_content_for_skip, code: code_skip.strip, checker: self,
+        error: :invalid_heading_level_skip)
+    end
   end
 
   private

--- a/app/models/cms/syntax_checker/order_of_h_checker.rb
+++ b/app/models/cms/syntax_checker/order_of_h_checker.rb
@@ -4,7 +4,8 @@ class Cms::SyntaxChecker::OrderOfHChecker
   H_TAGS = %w(h1 h2 h3 h4 h5 h6).freeze
 
   def check(context, content)
-    code = ''
+    code_first = ''
+    code_skip = ''
     h_level_check = context.h_level_check
     header_check = context.header_check
     h_nodes = context.fragment.css(H_TAGS.join(","))
@@ -19,8 +20,10 @@ class Cms::SyntaxChecker::OrderOfHChecker
         if current_level <= 2 && !header_check
           h_level_check = current_level
           header_check = true
-        elsif (current_level > 2 && !header_check) || (h_level_check < current_level - 1)
-          code += current_node.name + " "
+        elsif current_level > 2 && !header_check
+          code_first += current_node.name + " "
+        elsif h_level_check < current_level - 1
+          code_skip += current_node.name + " "
         else
           h_level_check = current_level
         end
@@ -28,14 +31,20 @@ class Cms::SyntaxChecker::OrderOfHChecker
         # 2 個目以降にある h1, h2 は無チェック
         next
       elsif prev_level < current_level - 1
-        code += current_node.name + " "
+        code_skip += current_node.name + " "
       end
     end
-    return if code.blank?
 
-    context.errors << Cms::SyntaxChecker::CheckerError.new(
-      context: context, content: content, code: code.strip, checker: self, error: :invalid_order_of_h,
-      corrector: self.class.name)
+    if code_first.present?
+      context.errors << Cms::SyntaxChecker::CheckerError.new(
+        context: context, content: content, code: code_first.strip, checker: self,
+        error: :invalid_first_heading_level, corrector: self.class.name)
+    end
+    if code_skip.present?
+      context.errors << Cms::SyntaxChecker::CheckerError.new(
+        context: context, content: content, code: code_skip.strip, checker: self,
+        error: :invalid_heading_level_skip, corrector: self.class.name)
+    end
   end
 
   def correct(context)

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -2096,6 +2096,8 @@ ja:
       not_found_parent_group: 親グループが存在しません。
       plz_check_targets_to_change_state: 公開ステータス変更対象が選択されておりません。対象のチェックボックスにチェックを入れてください。
       invalid_order_of_h: 見出し(H)の順番が不正です。
+      invalid_first_heading_level: 先頭の見出しは h1 または h2 にしてください。
+      invalid_heading_level_skip: 見出しレベルが 1 段を超えて深くなっています。
       invalid_multibyte_character: 英数字は半角文字を入力してください。
       invalid_kana_character: 半角カナ文字が含まれています。
       invalid_date_format: 日付の表記は○年○月○日としてください。
@@ -2140,6 +2142,12 @@ ja:
           - 列方向であればscope="row"を設定してください。
         invalid_order_of_h:
           - 適切な順に配置してください。
+        invalid_first_heading_level:
+          - ページ先頭の見出しは h1 または h2 から開始してください。
+          - 該当の見出しを h1 または h2 に変更してください。
+        invalid_heading_level_skip:
+          - 直前の見出しの次に来る見出しは、同じレベルまたは 1 段深いレベル（例：h2 の次は h3）にしてください。
+          - h2 の直後に h4 を置くなど、レベルを 2 段以上スキップしないでください。
         invalid_multibyte_character:
           - 本文に全角英数が含まれています。
           - 半角英数に置き換えるか削除してください。

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -2095,7 +2095,6 @@ ja:
       not_a_child_group: はサイトに所属するグループを設定してください。
       not_found_parent_group: 親グループが存在しません。
       plz_check_targets_to_change_state: 公開ステータス変更対象が選択されておりません。対象のチェックボックスにチェックを入れてください。
-      invalid_order_of_h: 見出し(H)の順番が不正です。
       invalid_first_heading_level: 先頭の見出しは h1 または h2 にしてください。
       invalid_heading_level_skip: 見出しレベルが 1 段を超えて深くなっています。
       invalid_multibyte_character: 英数字は半角文字を入力してください。
@@ -2140,8 +2139,6 @@ ja:
           - 表のヘッダー(TH)に見出しの方向であるSCOPE属性が設定されていません。
           - 行方向であればscope="colを設定してください。
           - 列方向であればscope="row"を設定してください。
-        invalid_order_of_h:
-          - 適切な順に配置してください。
         invalid_first_heading_level:
           - ページ先頭の見出しは h1 または h2 から開始してください。
           - 該当の見出しを h1 または h2 に変更してください。

--- a/spec/features/article/pages/syntax_checker_spec.rb
+++ b/spec/features/article/pages/syntax_checker_spec.rb
@@ -958,7 +958,7 @@ describe "syntax_checker", type: :feature, dbscope: :example, js: true do
 
               # confirm syntax check header is shown to wait for ajax completion
               expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('cms.syntax_check'))
-              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('errors.messages.invalid_order_of_h'))
+              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('errors.messages.invalid_first_heading_level'))
             end
           end
         end
@@ -1036,7 +1036,7 @@ describe "syntax_checker", type: :feature, dbscope: :example, js: true do
 
               # confirm syntax check header is shown to wait for ajax completion
               expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('cms.syntax_check'))
-              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('errors.messages.invalid_order_of_h'))
+              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('errors.messages.invalid_heading_level_skip'))
             end
           end
         end

--- a/spec/features/article/pages/syntax_checker_spec.rb
+++ b/spec/features/article/pages/syntax_checker_spec.rb
@@ -1084,7 +1084,7 @@ describe "syntax_checker", type: :feature, dbscope: :example, js: true do
           it do
             visit edit_path
 
-            [ "h2", "h3", "h4", "h2" ].each_with_index do |head, i|
+            %w[h2 h3 h4 h2].each_with_index do |head, i|
               within ".column-value-palette" do
                 wait_for_event_fired("ss:columnAdded") do
                   click_on column1.name
@@ -1122,7 +1122,7 @@ describe "syntax_checker", type: :feature, dbscope: :example, js: true do
           it do
             visit edit_path
 
-            [ "h6", "h3", "h2", "h3", "h4", "h6" ].each_with_index do |head, i|
+            %w[h6 h3 h2 h3 h4 h6].each_with_index do |head, i|
               within ".column-value-palette" do
                 wait_for_event_fired("ss:columnAdded") do
                   click_on column1.name

--- a/spec/features/article/pages/syntax_checker_spec.rb
+++ b/spec/features/article/pages/syntax_checker_spec.rb
@@ -1079,6 +1079,75 @@ describe "syntax_checker", type: :feature, dbscope: :example, js: true do
             end
           end
         end
+
+        context "when h4 closes subsection (h2 → h3 → h4 → h2)" do
+          it do
+            visit edit_path
+
+            [ "h2", "h3", "h4", "h2" ].each_with_index do |head, i|
+              within ".column-value-palette" do
+                wait_for_event_fired("ss:columnAdded") do
+                  click_on column1.name
+                end
+              end
+              within all(".column-value-cms-column-headline")[i] do
+                select head, from: "item[column_values][][in_wrap][head]"
+                fill_in "item[column_values][][in_wrap][text]", with: unique_id
+              end
+            end
+
+            within "#addon-cms-agents-addons-form-page" do
+              wait_for_event_fired "ss:check:done" do
+                within ".cms-body-checker" do
+                  check I18n.t("cms.syntax_check")
+                  click_on I18n.t("ss.buttons.run")
+                end
+              end
+
+              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('cms.syntax_check'))
+              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t("errors.template.no_errors"))
+            end
+          end
+        end
+
+        context "when first-heading and skip violations both exist" do
+          # 先頭 h6 (first 違反) と h4→h6 (skip 違反) を同時に含むケース
+          # h6 をプルダウンに含めるため、max_headline_level を h6 に拡張
+          let!(:column1) do
+            create(
+              :cms_column_headline, cur_site: site, cur_form: form,
+              required: "optional", order: 1, max_headline_level: "h6")
+          end
+
+          it do
+            visit edit_path
+
+            [ "h6", "h3", "h2", "h3", "h4", "h6" ].each_with_index do |head, i|
+              within ".column-value-palette" do
+                wait_for_event_fired("ss:columnAdded") do
+                  click_on column1.name
+                end
+              end
+              within all(".column-value-cms-column-headline")[i] do
+                select head, from: "item[column_values][][in_wrap][head]"
+                fill_in "item[column_values][][in_wrap][text]", with: unique_id
+              end
+            end
+
+            within "#addon-cms-agents-addons-form-page" do
+              wait_for_event_fired "ss:check:done" do
+                within ".cms-body-checker" do
+                  check I18n.t("cms.syntax_check")
+                  click_on I18n.t("ss.buttons.run")
+                end
+              end
+
+              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('cms.syntax_check'))
+              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('errors.messages.invalid_first_heading_level'))
+              expect(page).to have_css("#errorSyntaxChecker", text: I18n.t('errors.messages.invalid_heading_level_skip'))
+            end
+          end
+        end
       end
 
       context "with cms/column/table" do

--- a/spec/models/cms/syntax_checker/article_page_spec.rb
+++ b/spec/models/cms/syntax_checker/article_page_spec.rb
@@ -336,8 +336,8 @@ describe Cms::SyntaxChecker, type: :model, dbscope: :example do
               expect(error.name).to eq column1.name
               expect(error.idx).to be_blank
               expect(error.code).to eq "h3"
-              expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-              expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+              expect(error.full_message).to eq I18n.t('errors.messages.invalid_first_heading_level')
+              expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_first_heading_level')
               expect(error.corrector).to be_blank
               expect(error.corrector_params).to be_blank
             end
@@ -381,8 +381,8 @@ describe Cms::SyntaxChecker, type: :model, dbscope: :example do
               expect(error.name).to eq column1.name
               expect(error.idx).to be_blank
               expect(error.code).to eq "h3"
-              expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-              expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+              expect(error.full_message).to eq I18n.t('errors.messages.invalid_heading_level_skip')
+              expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_heading_level_skip')
               expect(error.corrector).to be_blank
               expect(error.corrector_params).to be_blank
             end

--- a/spec/models/cms/syntax_checker/order_of_h_checker_spec.rb
+++ b/spec/models/cms/syntax_checker/order_of_h_checker_spec.rb
@@ -44,8 +44,8 @@ describe Cms::SyntaxChecker::OrderOfHChecker, type: :model, dbscope: :example do
           expect(error.id).to eq id
           expect(error.idx).to eq idx
           expect(error.code).to eq "h3"
-          expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+          expect(error.full_message).to eq I18n.t('errors.messages.invalid_heading_level_skip')
+          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_heading_level_skip')
           expect(error.corrector).to eq described_class.name
           expect(error.corrector_params).to be_blank
         end
@@ -66,8 +66,8 @@ describe Cms::SyntaxChecker::OrderOfHChecker, type: :model, dbscope: :example do
           expect(error.id).to eq id
           expect(error.idx).to eq idx
           expect(error.code).to eq "h4"
-          expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+          expect(error.full_message).to eq I18n.t('errors.messages.invalid_heading_level_skip')
+          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_heading_level_skip')
           expect(error.corrector).to eq described_class.name
           expect(error.corrector_params).to be_blank
         end
@@ -88,8 +88,8 @@ describe Cms::SyntaxChecker::OrderOfHChecker, type: :model, dbscope: :example do
           expect(error.id).to eq id
           expect(error.idx).to eq idx
           expect(error.code).to eq "h5"
-          expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+          expect(error.full_message).to eq I18n.t('errors.messages.invalid_heading_level_skip')
+          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_heading_level_skip')
           expect(error.corrector).to eq described_class.name
           expect(error.corrector_params).to be_blank
         end
@@ -120,8 +120,8 @@ describe Cms::SyntaxChecker::OrderOfHChecker, type: :model, dbscope: :example do
             expect(error.id).to eq id
             expect(error.idx).to eq idx
             expect(error.code).to eq "h#{level}"
-            expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-            expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+            expect(error.full_message).to eq I18n.t('errors.messages.invalid_first_heading_level')
+            expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_first_heading_level')
             expect(error.corrector).to eq described_class.name
             expect(error.corrector_params).to be_blank
           end
@@ -144,8 +144,8 @@ describe Cms::SyntaxChecker::OrderOfHChecker, type: :model, dbscope: :example do
           expect(error.id).to eq id
           expect(error.idx).to eq idx
           expect(error.code).to eq "h4 h5"
-          expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+          expect(error.full_message).to eq I18n.t('errors.messages.invalid_heading_level_skip')
+          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_heading_level_skip')
           expect(error.corrector).to eq described_class.name
           expect(error.corrector_params).to be_blank
         end
@@ -188,8 +188,8 @@ describe Cms::SyntaxChecker::OrderOfHChecker, type: :model, dbscope: :example do
           expect(error.id).to eq id
           expect(error.idx).to eq idx
           expect(error.code).to eq "h#{level}"
-          expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+          expect(error.full_message).to eq I18n.t('errors.messages.invalid_first_heading_level')
+          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_first_heading_level')
           expect(error.corrector).to eq described_class.name
           expect(error.corrector_params).to be_blank
         end
@@ -231,8 +231,8 @@ describe Cms::SyntaxChecker::OrderOfHChecker, type: :model, dbscope: :example do
         context.errors.first.tap do |error|
           expect(error.id).to eq id
           expect(error.idx).to eq idx
-          expect(error.full_message).to eq I18n.t('errors.messages.invalid_order_of_h')
-          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_order_of_h')
+          expect(error.full_message).to eq I18n.t('errors.messages.invalid_heading_level_skip')
+          expect(error.detail).to eq I18n.t('errors.messages.syntax_check_detail.invalid_heading_level_skip')
           expect(error.corrector).to eq described_class.name
           expect(error.corrector_params).to be_blank
         end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

関連： #6030 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 記事編集時の見出しレベル検証で、先頭見出し不正と見出しレベルの飛びを区別し、各ケースに応じたより具体的なエラーメッセージと詳細が表示されるよう改善しました。
* **Tests**
  * 見出し検証に関するテストを拡充し、各エラーケース（先頭不正／スキップ／同時発生）を検証するシナリオを追加・更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shirasagi/shirasagi/pull/6052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->