### PR TITLE
[fix] cms : add parent crumbs under CMS menu

### DIFF
--- a/app/controllers/cms/all_contents_controller.rb
+++ b/app/controllers/cms/all_contents_controller.rb
@@ -19,6 +19,8 @@ class Cms::AllContentsController < ApplicationController
       @crumbs << [t("cms.all_content.download_tab"), cms_all_contents_download_path]
     when 'import'
       @crumbs << [t("cms.all_content.import_tab"), cms_all_contents_import_path]
+    when 'sampling_all'
+      @crumbs << [t("cms.all_content.sampling_tab"), cms_all_contents_sampling_path]
     end
   end
 

--- a/app/controllers/cms/check_links/ignore_urls_controller.rb
+++ b/app/controllers/cms/check_links/ignore_urls_controller.rb
@@ -8,6 +8,11 @@ class Cms::CheckLinks::IgnoreUrlsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("modules.cms/check_links"), cms_check_links_path]
+    @crumbs << [t("cms/check_links.ignore_urls"), action: :index]
+  end
+
   def fix_params
     { cur_user: @cur_user, cur_site: @cur_site }
   end

--- a/app/controllers/cms/check_links/reports_controller.rb
+++ b/app/controllers/cms/check_links/reports_controller.rb
@@ -6,4 +6,11 @@ class Cms::CheckLinks::ReportsController < ApplicationController
 
   navi_view "cms/check_links/main/navi"
   menu_view nil
+
+  private
+
+  def set_crumbs
+    @crumbs << [t("modules.cms/check_links"), cms_check_links_path]
+    @crumbs << [t("cms/check_links.reports"), action: :index]
+  end
 end

--- a/app/controllers/cms/check_links/run_controller.rb
+++ b/app/controllers/cms/check_links/run_controller.rb
@@ -6,6 +6,11 @@ class Cms::CheckLinks::RunController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("modules.cms/check_links"), cms_check_links_path]
+    @crumbs << [t("cms/check_links.run"), action: :index]
+  end
+
   def job_class
     Cms::CheckLinksJob
   end

--- a/app/controllers/cms/check_links/site_settings_controller.rb
+++ b/app/controllers/cms/check_links/site_settings_controller.rb
@@ -6,6 +6,15 @@ class Cms::CheckLinks::SiteSettingsController < ApplicationController
   navi_view "cms/check_links/main/navi"
   menu_view "cms/crud/resource_menu"
 
+  private
+
+  def set_crumbs
+    @crumbs << [t("modules.cms/check_links"), cms_check_links_path]
+    @crumbs << [t("cms/check_links.site_setting"), action: :show]
+  end
+
+  public
+
   def set_item
     @item = @cur_site
 

--- a/app/controllers/cms/form/dbs_controller.rb
+++ b/app/controllers/cms/form/dbs_controller.rb
@@ -8,6 +8,7 @@ class Cms::Form::DbsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [Cms::Form.model_name.human, cms_forms_path]
     @crumbs << [Cms::FormDb.model_name.human, action: :index]
   end
 

--- a/app/controllers/cms/generate_locks_controller.rb
+++ b/app/controllers/cms/generate_locks_controller.rb
@@ -14,7 +14,7 @@ class Cms::GenerateLocksController < ApplicationController
   end
 
   def set_crumbs
-    @crumbs << [t("cms.site_info"), action: :show]
+    @crumbs << [t("modules.addons.ss/generate_lock"), action: :show]
   end
 
   def set_item

--- a/app/controllers/cms/generate_nodes_controller.rb
+++ b/app/controllers/cms/generate_nodes_controller.rb
@@ -7,6 +7,11 @@ class Cms::GenerateNodesController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("cms.etc"), nil]
+    @crumbs << [t("cms.generate_node"), action: :index]
+  end
+
   def job_class
     Cms::Node::GenerateJob
   end

--- a/app/controllers/cms/generate_pages_controller.rb
+++ b/app/controllers/cms/generate_pages_controller.rb
@@ -7,6 +7,11 @@ class Cms::GeneratePagesController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("cms.etc"), nil]
+    @crumbs << [t("cms.generate_page"), action: :index]
+  end
+
   def job_class
     Cms::Page::GenerateJob
   end

--- a/app/controllers/cms/generation_report/titles_controller.rb
+++ b/app/controllers/cms/generation_report/titles_controller.rb
@@ -10,6 +10,12 @@ class Cms::GenerationReport::TitlesController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("mongoid.models.cms/generation_report/title"), cms_generation_report_main_path]
+    leaf = params[:type].to_s == "pages" ? t("cms.generate_page") : t("cms.generate_node")
+    @crumbs << [leaf, action: :index]
+  end
+
   def set_items
     @items ||= begin
       items = @model.site(@cur_site)

--- a/app/controllers/cms/import_controller.rb
+++ b/app/controllers/cms/import_controller.rb
@@ -10,6 +10,7 @@ class Cms::ImportController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.etc"), nil]
     @crumbs << [t("cms.import_node"), action: :import]
   end
 

--- a/app/controllers/cms/ldap/imports_controller.rb
+++ b/app/controllers/cms/ldap/imports_controller.rb
@@ -19,6 +19,7 @@ class Cms::Ldap::ImportsController < ApplicationController
   end
 
   def set_crumbs
+    @crumbs << [t("ldap.links.ldap"), cms_ldap_main_path]
     @crumbs << [t("ldap.import"), action: :index]
   end
 

--- a/app/controllers/cms/ldap/result_controller.rb
+++ b/app/controllers/cms/ldap/result_controller.rb
@@ -14,6 +14,7 @@ class Cms::Ldap::ResultController < ApplicationController
   end
 
   def set_crumbs
+    @crumbs << [t("ldap.links.ldap"), cms_ldap_main_path]
     @crumbs << [t("ldap.result"), action: :index]
   end
 

--- a/app/controllers/cms/ldap/servers_controller.rb
+++ b/app/controllers/cms/ldap/servers_controller.rb
@@ -8,6 +8,7 @@ class Cms::Ldap::ServersController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("ldap.links.ldap"), cms_ldap_main_path]
     @crumbs << [t("ldap.server"), action: :main]
   end
 

--- a/app/controllers/cms/ldap/settings_controller.rb
+++ b/app/controllers/cms/ldap/settings_controller.rb
@@ -11,6 +11,7 @@ class Cms::Ldap::SettingsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("ldap.links.ldap"), cms_ldap_main_path]
     @crumbs << [t("ldap.setting"), url_for(action: :show)]
   end
 

--- a/app/controllers/cms/line/deliver_categories_controller.rb
+++ b/app/controllers/cms/line/deliver_categories_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::DeliverCategoriesController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_deliver_category"), cms_line_deliver_categories_path]
   end
 

--- a/app/controllers/cms/line/deliver_conditions_controller.rb
+++ b/app/controllers/cms/line/deliver_conditions_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::DeliverConditionsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_deliver_condition"), cms_line_deliver_conditions_path]
   end
 

--- a/app/controllers/cms/line/deliver_logs_controller.rb
+++ b/app/controllers/cms/line/deliver_logs_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::DeliverLogsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_deliver_log"), cms_line_deliver_logs_path]
   end
 end

--- a/app/controllers/cms/line/event_sessions_controller.rb
+++ b/app/controllers/cms/line/event_sessions_controller.rb
@@ -13,6 +13,7 @@ class Cms::Line::EventSessionsController < ApplicationController
   end
 
   def set_crumbs
-    #@crumbs << [t("cms.sns_post"), cms_sns_post_logs_path]
+    @crumbs << [t("cms.line"), cms_line_messages_path]
+    @crumbs << [t("cms.line_event_session"), cms_line_event_sessions_path]
   end
 end

--- a/app/controllers/cms/line/mail_handlers_controller.rb
+++ b/app/controllers/cms/line/mail_handlers_controller.rb
@@ -13,6 +13,7 @@ class Cms::Line::MailHandlersController < ApplicationController
   end
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_mail_handlers"), cms_line_mail_handlers_path]
   end
 end

--- a/app/controllers/cms/line/messages_controller.rb
+++ b/app/controllers/cms/line/messages_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::MessagesController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_message"), cms_line_messages_path]
   end
 

--- a/app/controllers/cms/line/richmenu/groups_controller.rb
+++ b/app/controllers/cms/line/richmenu/groups_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::Richmenu::GroupsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_richmenu"), cms_line_richmenu_groups_path]
   end
 

--- a/app/controllers/cms/line/service/groups_controller.rb
+++ b/app/controllers/cms/line/service/groups_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::Service::GroupsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_service"), cms_line_service_groups_path]
   end
 

--- a/app/controllers/cms/line/settings_controller.rb
+++ b/app/controllers/cms/line/settings_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::SettingsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_setting"), cms_line_setting_path]
   end
 

--- a/app/controllers/cms/line/statistics_controller.rb
+++ b/app/controllers/cms/line/statistics_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::StatisticsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_statistics"), cms_line_statistics_path]
   end
 

--- a/app/controllers/cms/line/test_members_controller.rb
+++ b/app/controllers/cms/line/test_members_controller.rb
@@ -9,6 +9,7 @@ class Cms::Line::TestMembersController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.line"), cms_line_messages_path]
     @crumbs << [t("cms.line_test_member"), cms_line_test_members_path]
   end
 

--- a/app/controllers/cms/nodes_controller.rb
+++ b/app/controllers/cms/nodes_controller.rb
@@ -10,7 +10,16 @@ class Cms::NodesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("cms.node"), action: :index]
+    case params[:action]
+    when 'download'
+      @crumbs << [t("cms.etc"), nil]
+      @crumbs << [t("cms.csv_export_node"), action: :download]
+    when 'import'
+      @crumbs << [t("cms.etc"), nil]
+      @crumbs << [t("cms.csv_import_node"), action: :import]
+    else
+      @crumbs << [t("cms.node"), action: :index]
+    end
   end
 
   def fix_params

--- a/app/controllers/cms/page_searches_controller.rb
+++ b/app/controllers/cms/page_searches_controller.rb
@@ -7,6 +7,10 @@ class Cms::PageSearchesController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("cms.page_search"), action: :index]
+  end
+
   def fix_params
     { cur_site: @cur_site, cur_user: @cur_user }
   end

--- a/app/controllers/cms/sns_post/logs_controller.rb
+++ b/app/controllers/cms/sns_post/logs_controller.rb
@@ -10,5 +10,6 @@ class Cms::SnsPost::LogsController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("cms.sns_post"), cms_sns_post_logs_path]
+    @crumbs << [t("cms.sns_post_log"), action: :index]
   end
 end

--- a/app/controllers/cms/source_cleaner/site_settings_controller.rb
+++ b/app/controllers/cms/source_cleaner/site_settings_controller.rb
@@ -10,7 +10,7 @@ class Cms::SourceCleaner::SiteSettingsController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("cms.source_cleaner"), cms_source_cleaner_main_path]
-    @crumbs << [t("cms.site_setting"), action: :show]
+    @crumbs << [t("translate.site_setting"), action: :show]
   end
 
   public

--- a/app/controllers/cms/source_cleaner/site_settings_controller.rb
+++ b/app/controllers/cms/source_cleaner/site_settings_controller.rb
@@ -6,6 +6,15 @@ class Cms::SourceCleaner::SiteSettingsController < ApplicationController
   navi_view "cms/source_cleaner/main/navi"
   menu_view "cms/crud/resource_menu"
 
+  private
+
+  def set_crumbs
+    @crumbs << [t("cms.source_cleaner"), cms_source_cleaner_main_path]
+    @crumbs << [t("cms.site_setting"), action: :show]
+  end
+
+  public
+
   def set_item
     @item = @cur_site
   end

--- a/app/controllers/cms/translate/access_logs_controller.rb
+++ b/app/controllers/cms/translate/access_logs_controller.rb
@@ -5,6 +5,13 @@ class Cms::Translate::AccessLogsController < ApplicationController
   model Translate::AccessLog
   navi_view "cms/translate/main/navi"
 
+  private
+
+  def set_crumbs
+    @crumbs << [t("translate.main"), cms_translate_main_path]
+    @crumbs << [t("translate.access_log"), action: :index]
+  end
+
   public
 
   def download

--- a/app/controllers/cms/translate/langs_controller.rb
+++ b/app/controllers/cms/translate/langs_controller.rb
@@ -7,6 +7,11 @@ class Cms::Translate::LangsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("translate.main"), cms_translate_main_path]
+    @crumbs << [t("translate.lang"), action: :index]
+  end
+
   def fix_params
     { cur_site: @cur_site }
   end

--- a/app/controllers/cms/translate/site_settings_controller.rb
+++ b/app/controllers/cms/translate/site_settings_controller.rb
@@ -6,6 +6,15 @@ class Cms::Translate::SiteSettingsController < ApplicationController
   navi_view "cms/translate/main/navi"
   menu_view "cms/crud/resource_menu"
 
+  private
+
+  def set_crumbs
+    @crumbs << [t("translate.main"), cms_translate_main_path]
+    @crumbs << [t("translate.site_setting"), action: :show]
+  end
+
+  public
+
   def set_item
     @item = @cur_site
   end

--- a/app/controllers/cms/translate/text_caches_controller.rb
+++ b/app/controllers/cms/translate/text_caches_controller.rb
@@ -7,6 +7,11 @@ class Cms::Translate::TextCachesController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("translate.main"), cms_translate_main_path]
+    @crumbs << [t("translate.text_cache"), action: :index]
+  end
+
   def fix_params
     { cur_site: @cur_site, api: @cur_site.translate_api, update_state: "manually" }
   end

--- a/app/controllers/contact/contacts_controller.rb
+++ b/app/controllers/contact/contacts_controller.rb
@@ -16,6 +16,7 @@ class Contact::ContactsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [ t("cms.group"), cms_groups_path ]
     @crumbs << [ t("modules.contact"), url_for(action: :index) ]
   end
 

--- a/app/controllers/history/cms/history_archives_controller.rb
+++ b/app/controllers/history/cms/history_archives_controller.rb
@@ -9,13 +9,14 @@ class History::Cms::HistoryArchivesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("mongoid.models.gws/history"), action: :index]
+    @crumbs << [t("mongoid.models.gws/history"), history_cms_logs_path]
+    @crumbs << [t("mongoid.models.gws/history_archive_file"), action: :index]
   end
 
   public
 
   def index
-    raise "403" unless SS::User.allowed?(:read, @cur_user)
+    raise "403" unless @model.allowed?(:read, @cur_user, site: @cur_site)
 
     @items = @model.site(@cur_site).
       search(params[:s]).

--- a/app/controllers/history/cms/history_archives_controller.rb
+++ b/app/controllers/history/cms/history_archives_controller.rb
@@ -9,7 +9,7 @@ class History::Cms::HistoryArchivesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("mongoid.models.gws/history"), history_cms_logs_path]
+    @crumbs << [t("history.log"), history_cms_logs_path]
     @crumbs << [t("mongoid.models.gws/history_archive_file"), action: :index]
   end
 

--- a/app/controllers/history/cms/logs_controller.rb
+++ b/app/controllers/history/cms/logs_controller.rb
@@ -11,6 +11,7 @@ class History::Cms::LogsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("history.log"), history_cms_logs_path]
     @crumbs << [t("history.log"), action: :index]
   end
 

--- a/app/controllers/history/cms/trashes_controller.rb
+++ b/app/controllers/history/cms/trashes_controller.rb
@@ -8,6 +8,10 @@ class History::Cms::TrashesController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [History::Trash.model_name.human, action: :index]
+  end
+
   def cms_content_params
     params.require(:item).permit(*%i[name index_name basename parent children]).merge(fix_params)
   end

--- a/app/controllers/job/cms/logs_controller.rb
+++ b/app/controllers/job/cms/logs_controller.rb
@@ -7,6 +7,11 @@ class Job::Cms::LogsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_cms_main_path]
+    @crumbs << [t("job.log"), action: :index]
+  end
+
   def filter_permission
     raise "403" unless Cms::Tool.allowed?(:edit, @cur_user, site: @cur_site)
   end

--- a/app/controllers/job/cms/michecker_results_controller.rb
+++ b/app/controllers/job/cms/michecker_results_controller.rb
@@ -9,6 +9,11 @@ class Job::Cms::MicheckerResultsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_cms_main_path]
+    @crumbs << [Cms::Michecker::Result.model_name.human, action: :index]
+  end
+
   def filter_permission
     raise "404" if SS.config.michecker.blank? || SS.config.michecker['disable']
     raise "403" unless Cms::Tool.allowed?(:edit, @cur_user, site: @cur_site)

--- a/app/controllers/job/cms/reservations_controller.rb
+++ b/app/controllers/job/cms/reservations_controller.rb
@@ -8,6 +8,11 @@ class Job::Cms::ReservationsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_cms_main_path]
+    @crumbs << [t("job.reservation"), action: :index]
+  end
+
   def filter_permission
     raise "403" unless Cms::Tool.allowed?(:edit, @cur_user, site: @cur_site)
   end

--- a/app/controllers/job/cms/tasks_controller.rb
+++ b/app/controllers/job/cms/tasks_controller.rb
@@ -8,6 +8,11 @@ class Job::Cms::TasksController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_cms_main_path]
+    @crumbs << [t("job.task"), action: :index]
+  end
+
   def filter_permission
     raise "403" unless Cms::Tool.allowed?(:edit, @cur_user, site: @cur_site)
   end

--- a/app/controllers/kana/diagnostics_controller.rb
+++ b/app/controllers/kana/diagnostics_controller.rb
@@ -16,6 +16,7 @@ class Kana::DiagnosticsController < ApplicationController
   end
 
   def set_crumbs
+    @crumbs << [t("modules.kana"), nil]
     @crumbs << [t("kana.diagnostic"), url_for(action: :show)]
   end
 

--- a/app/controllers/member/groups_controller.rb
+++ b/app/controllers/member/groups_controller.rb
@@ -10,6 +10,7 @@ class Member::GroupsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("cms.member"), cms_members_path]
     @crumbs << [t("member.group"), action: :index]
   end
 

--- a/app/controllers/recommend/history/logs_controller.rb
+++ b/app/controllers/recommend/history/logs_controller.rb
@@ -7,6 +7,16 @@ class Recommend::History::LogsController < ApplicationController
   navi_view "recommend/main/navi"
   menu_view "recommend/main/menu"
 
+  private
+
+  def set_crumbs
+    @crumbs << [t("recommend.main"), recommend_history_logs_tokens_path]
+    leaf = action_name == "paths" ? t("recommend.paths") : t("recommend.tokens")
+    @crumbs << [leaf, action: action_name]
+  end
+
+  public
+
   def tokens
     raise "403" unless @model.allowed?(:read, @cur_user, site: @cur_site)
 

--- a/app/controllers/recommend/similarity_scores_controller.rb
+++ b/app/controllers/recommend/similarity_scores_controller.rb
@@ -6,6 +6,15 @@ class Recommend::SimilarityScoresController < ApplicationController
 
   navi_view "recommend/main/navi"
 
+  private
+
+  def set_crumbs
+    @crumbs << [t("recommend.main"), recommend_history_logs_tokens_path]
+    @crumbs << [t("recommend.scores"), action: :index]
+  end
+
+  public
+
   def index
     raise "403" unless @model.allowed?(:read, @cur_user, site: @cur_site)
 

--- a/app/controllers/voice/error_files_controller.rb
+++ b/app/controllers/voice/error_files_controller.rb
@@ -6,7 +6,8 @@ class Voice::ErrorFilesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("voice.error_file"), action: :index]
+    @crumbs << [t("voice.file"), voice_files_path]
+    @crumbs << [t("views.voice/error_files.index"), action: :index]
   end
 
   def set_search

--- a/app/controllers/voice/files_controller.rb
+++ b/app/controllers/voice/files_controller.rb
@@ -6,7 +6,8 @@ class Voice::FilesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("voice.file"), action: :index]
+    @crumbs << [t("voice.file"), voice_files_path]
+    @crumbs << [t("views.voice/files.index"), action: :index]
   end
 
   public

--- a/spec/features/cms/breadcrumbs_spec.rb
+++ b/spec/features/cms/breadcrumbs_spec.rb
@@ -1,0 +1,158 @@
+require 'spec_helper'
+
+#
+# CMS メイン配下のパンくずリストに、親階層 (LINE / リンクチェック / 全コンテンツ /
+# その他) が表示されることを feature レベルで保証する。
+#
+describe "cms breadcrumbs", type: :feature, dbscope: :example do
+  let!(:site) { cms_site }
+
+  before { login_cms_user }
+
+  shared_examples "linked parent and leaf" do |parent_label, parent_path_method, leaf_label|
+    it "shows '#{parent_label} > #{leaf_label}' under トップ" do
+      visit visit_path
+
+      within "#crumbs" do
+        parent_crumb = find_link(parent_label, match: :first)
+        expect(parent_crumb[:href]).to end_with(send(parent_path_method, site: site.id))
+        expect(page).to have_content(leaf_label)
+      end
+    end
+  end
+
+  shared_examples "non-linked parent and leaf" do |parent_label, leaf_label|
+    it "shows '#{parent_label} > #{leaf_label}' under トップ" do
+      visit visit_path
+
+      within "#crumbs" do
+        expect(page).to have_content(parent_label)
+        expect(page).to have_content(leaf_label)
+      end
+    end
+  end
+
+  context "LINE" do
+    let(:parent_label) { I18n.t("cms.line") }
+
+    context "メッセージ" do
+      let(:visit_path) { cms_line_messages_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_message")
+    end
+
+    context "統計情報" do
+      let(:visit_path) { cms_line_statistics_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_statistics")
+    end
+
+    context "配信ログ" do
+      let(:visit_path) { cms_line_deliver_logs_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_deliver_log")
+    end
+
+    context "配信条件" do
+      let(:visit_path) { cms_line_deliver_conditions_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_deliver_condition")
+    end
+
+    context "配信カテゴリー" do
+      let(:visit_path) { cms_line_deliver_categories_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_deliver_category")
+    end
+
+    context "メール連携" do
+      let(:visit_path) { cms_line_mail_handlers_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_mail_handlers")
+    end
+
+    context "テストメンバー" do
+      let(:visit_path) { cms_line_test_members_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_test_member")
+    end
+
+    context "リッチメニュー" do
+      let(:visit_path) { cms_line_richmenu_groups_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_richmenu")
+    end
+
+    context "サービス" do
+      let(:visit_path) { cms_line_service_groups_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_service")
+    end
+
+    context "セッション" do
+      let(:visit_path) { cms_line_event_sessions_path(site) }
+      include_examples "linked parent and leaf", I18n.t("cms.line"), :cms_line_messages_path, I18n.t("cms.line_event_session")
+    end
+  end
+
+  context "リンクチェック" do
+    context "レポート" do
+      let(:visit_path) { cms_check_links_reports_path(site) }
+      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.reports")
+    end
+
+    context "除外URL" do
+      let(:visit_path) { cms_check_links_ignore_urls_path(site) }
+      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.ignore_urls")
+    end
+
+    context "実行" do
+      let(:visit_path) { cms_check_links_run_path(site) }
+      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.run")
+    end
+
+    context "設定" do
+      let(:visit_path) { cms_check_links_site_setting_path(site) }
+      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.site_setting")
+    end
+  end
+
+  context "全コンテンツ 無作為抽出" do
+    let(:visit_path) { cms_all_contents_sampling_path(site) }
+    include_examples "linked parent and leaf", I18n.t("cms.all_contents"), :cms_all_contents_path, I18n.t("cms.all_content.sampling_tab")
+  end
+
+  context "ゴミ箱" do
+    it "shows 'ゴミ箱' as the leaf crumb" do
+      visit history_cms_trashes_path(site)
+
+      within "#crumbs" do
+        expect(page).to have_content(History::Trash.model_name.human)
+      end
+    end
+  end
+
+  #
+  # その他メニューはドロップダウン上のラベルで、独立したページを持たない。
+  # 親パンくずはクリック不可 (path: nil) として表示する。
+  #
+  context "その他" do
+    let(:parent_label) { I18n.t("cms.etc") }
+
+    context "フォルダー取り込み" do
+      let(:visit_path) { cms_import_path(site) }
+      include_examples "non-linked parent and leaf", I18n.t("cms.etc"), I18n.t("cms.import_node")
+    end
+
+    context "フォルダー書き出し" do
+      let(:visit_path) { cms_generate_nodes_path(site) }
+      include_examples "non-linked parent and leaf", I18n.t("cms.etc"), I18n.t("cms.generate_node")
+    end
+
+    context "ページ書き出し" do
+      let(:visit_path) { cms_generate_pages_path(site) }
+      include_examples "non-linked parent and leaf", I18n.t("cms.etc"), I18n.t("cms.generate_page")
+    end
+
+    context "一括エクスポート" do
+      let(:visit_path) { download_cms_nodes_path(site) }
+      include_examples "non-linked parent and leaf", I18n.t("cms.etc"), I18n.t("cms.csv_export_node")
+    end
+
+    context "一括インポート" do
+      let(:visit_path) { import_cms_nodes_path(site) }
+      include_examples "non-linked parent and leaf", I18n.t("cms.etc"), I18n.t("cms.csv_import_node")
+    end
+  end
+end

--- a/spec/features/cms/breadcrumbs_spec.rb
+++ b/spec/features/cms/breadcrumbs_spec.rb
@@ -27,6 +27,7 @@ describe "cms breadcrumbs", type: :feature, dbscope: :example do
 
       within "#crumbs" do
         expect(page).to have_content(parent_label)
+        expect(page).to have_no_link(parent_label)
         expect(page).to have_content(leaf_label)
       end
     end
@@ -89,28 +90,33 @@ describe "cms breadcrumbs", type: :feature, dbscope: :example do
   context "リンクチェック" do
     context "レポート" do
       let(:visit_path) { cms_check_links_reports_path(site) }
-      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.reports")
+      include_examples "linked parent and leaf",
+        I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.reports")
     end
 
     context "除外URL" do
       let(:visit_path) { cms_check_links_ignore_urls_path(site) }
-      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.ignore_urls")
+      include_examples "linked parent and leaf",
+        I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.ignore_urls")
     end
 
     context "実行" do
       let(:visit_path) { cms_check_links_run_path(site) }
-      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.run")
+      include_examples "linked parent and leaf",
+        I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.run")
     end
 
     context "設定" do
       let(:visit_path) { cms_check_links_site_setting_path(site) }
-      include_examples "linked parent and leaf", I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.site_setting")
+      include_examples "linked parent and leaf",
+        I18n.t("modules.cms/check_links"), :cms_check_links_path, I18n.t("cms/check_links.site_setting")
     end
   end
 
   context "全コンテンツ 無作為抽出" do
     let(:visit_path) { cms_all_contents_sampling_path(site) }
-    include_examples "linked parent and leaf", I18n.t("cms.all_contents"), :cms_all_contents_path, I18n.t("cms.all_content.sampling_tab")
+    include_examples "linked parent and leaf",
+      I18n.t("cms.all_contents"), :cms_all_contents_path, I18n.t("cms.all_content.sampling_tab")
   end
 
   context "ゴミ箱" do

--- a/spec/features/cms/breadcrumbs_spec.rb
+++ b/spec/features/cms/breadcrumbs_spec.rb
@@ -161,4 +161,15 @@ describe "cms breadcrumbs", type: :feature, dbscope: :example do
       include_examples "non-linked parent and leaf", I18n.t("cms.etc"), I18n.t("cms.csv_import_node")
     end
   end
+
+  #
+  # トップ > 操作履歴 > アーカイブ。アーカイブ一覧ページのパンくずに
+  # 親階層「操作履歴」と leaf「アーカイブ」が表示されることを保証する。
+  #
+  context "操作履歴アーカイブ" do
+    let(:visit_path) { history_cms_history_archives_path(site) }
+    include_examples "linked parent and leaf",
+                     I18n.t("mongoid.models.gws/history"), :history_cms_logs_path,
+                     I18n.t("mongoid.models.gws/history_archive_file")
+  end
 end

--- a/spec/features/cms/breadcrumbs_spec.rb
+++ b/spec/features/cms/breadcrumbs_spec.rb
@@ -163,13 +163,224 @@ describe "cms breadcrumbs", type: :feature, dbscope: :example do
   end
 
   #
-  # トップ > 操作履歴 > アーカイブ。アーカイブ一覧ページのパンくずに
-  # 親階層「操作履歴」と leaf「アーカイブ」が表示されることを保証する。
+  # 操作履歴メニュー配下 (操作履歴本体 / アーカイブ) のパンくずに
+  # 親階層「操作履歴」を追加する。
   #
-  context "操作履歴アーカイブ" do
-    let(:visit_path) { history_cms_history_archives_path(site) }
-    include_examples "linked parent and leaf",
-                     I18n.t("mongoid.models.gws/history"), :history_cms_logs_path,
-                     I18n.t("mongoid.models.gws/history_archive_file")
+  context "操作履歴" do
+    let(:parent_label) { I18n.t("history.log") }
+
+    context "操作履歴" do
+      let(:visit_path) { history_cms_logs_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("history.log"), :history_cms_logs_path, I18n.t("history.log")
+    end
+
+    context "アーカイブ" do
+      let(:visit_path) { history_cms_history_archives_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("history.log"), :history_cms_logs_path,
+                       I18n.t("mongoid.models.gws/history_archive_file")
+    end
+  end
+
+  context "LDAP" do
+    let(:parent_label) { I18n.t("ldap.links.ldap") }
+
+    context "設定" do
+      let(:visit_path) { cms_ldap_setting_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("ldap.links.ldap"), :cms_ldap_main_path, I18n.t("ldap.setting")
+    end
+
+    context "サーバー情報" do
+      let(:visit_path) { cms_ldap_server_main_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("ldap.links.ldap"), :cms_ldap_main_path, I18n.t("ldap.server")
+    end
+
+    context "インポート" do
+      let(:visit_path) { cms_ldap_imports_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("ldap.links.ldap"), :cms_ldap_main_path, I18n.t("ldap.import")
+    end
+
+    context "同期結果" do
+      let(:visit_path) { cms_ldap_result_index_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("ldap.links.ldap"), :cms_ldap_main_path, I18n.t("ldap.result")
+    end
+  end
+
+  context "ジョブ" do
+    let(:parent_label) { I18n.t("job.main") }
+
+    context "実行履歴" do
+      let(:visit_path) { job_cms_logs_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("job.main"), :job_cms_main_path, I18n.t("job.log")
+    end
+
+    context "タスク" do
+      let(:visit_path) { job_cms_tasks_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("job.main"), :job_cms_main_path, I18n.t("job.task")
+    end
+
+    context "実行予約" do
+      let(:visit_path) { job_cms_reservations_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("job.main"), :job_cms_main_path, I18n.t("job.reservation")
+    end
+
+    context "miChecker結果" do
+      let(:visit_path) { job_cms_michecker_results_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("job.main"), :job_cms_main_path, Cms::Michecker::Result.model_name.human
+    end
+  end
+
+  context "自動翻訳" do
+    let(:parent_label) { I18n.t("translate.main") }
+
+    context "翻訳テキスト" do
+      let(:visit_path) { cms_translate_text_caches_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("translate.main"), :cms_translate_main_path, I18n.t("translate.text_cache")
+    end
+
+    context "言語" do
+      let(:visit_path) { cms_translate_langs_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("translate.main"), :cms_translate_main_path, I18n.t("translate.lang")
+    end
+
+    context "設定" do
+      let(:visit_path) { cms_translate_site_setting_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("translate.main"), :cms_translate_main_path, I18n.t("translate.site_setting")
+    end
+
+    context "アクセス履歴" do
+      let(:visit_path) { cms_translate_access_logs_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("translate.main"), :cms_translate_main_path, I18n.t("translate.access_log")
+    end
+  end
+
+  context "レコメンド機能" do
+    let(:parent_label) { I18n.t("recommend.main") }
+
+    context "アクセス（トークン）" do
+      let(:visit_path) { recommend_history_logs_tokens_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("recommend.main"), :recommend_history_logs_tokens_path, I18n.t("recommend.tokens")
+    end
+
+    context "アクセス（パス）" do
+      let(:visit_path) { recommend_history_logs_paths_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("recommend.main"), :recommend_history_logs_tokens_path, I18n.t("recommend.paths")
+    end
+
+    context "類似度スコア" do
+      let(:visit_path) { recommend_similarity_scores_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("recommend.main"), :recommend_history_logs_tokens_path, I18n.t("recommend.scores")
+    end
+  end
+
+  context "読み上げ音声" do
+    let(:parent_label) { I18n.t("voice.file") }
+
+    context "ページ一覧" do
+      let(:visit_path) { voice_files_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("voice.file"), :voice_files_path, I18n.t("views.voice/files.index")
+    end
+
+    context "エラー一覧" do
+      let(:visit_path) { voice_error_files_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("voice.file"), :voice_files_path, I18n.t("views.voice/error_files.index")
+    end
+  end
+
+  context "書き出し性能レポート" do
+    let(:parent_label) { I18n.t("mongoid.models.cms/generation_report/title") }
+
+    context "フォルダー書き出し" do
+      let(:visit_path) { cms_generation_report_titles_path(site, type: "nodes") }
+      include_examples "linked parent and leaf",
+                       I18n.t("mongoid.models.cms/generation_report/title"),
+                       :cms_generation_report_main_path, I18n.t("cms.generate_node")
+    end
+
+    context "ページ書き出し" do
+      let(:visit_path) { cms_generation_report_titles_path(site, type: "pages") }
+      include_examples "linked parent and leaf",
+                       I18n.t("mongoid.models.cms/generation_report/title"),
+                       :cms_generation_report_main_path, I18n.t("cms.generate_page")
+    end
+  end
+
+  context "メンバー" do
+    context "グループ" do
+      let(:visit_path) { member_groups_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("cms.member"), :cms_members_path, I18n.t("member.group")
+    end
+  end
+
+  context "定型フォーム" do
+    context "定型フォーム - DB" do
+      let(:visit_path) { cms_form_dbs_path(site) }
+      include_examples "linked parent and leaf",
+                       Cms::Form.model_name.human, :cms_forms_path, Cms::FormDb.model_name.human
+    end
+  end
+
+  context "ソースクリーニング" do
+    context "設定" do
+      let(:visit_path) { cms_source_cleaner_site_setting_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("cms.source_cleaner"), :cms_source_cleaner_main_path,
+                       I18n.t("cms.site_setting")
+    end
+  end
+
+  context "かな" do
+    context "診断" do
+      let(:visit_path) { kana_diagnostic_path(site) }
+      include_examples "non-linked parent and leaf",
+                       I18n.t("modules.kana"), I18n.t("kana.diagnostic")
+    end
+  end
+
+  context "SNS投稿連携" do
+    context "投稿履歴" do
+      let(:visit_path) { cms_sns_post_logs_path(site) }
+      include_examples "linked parent and leaf",
+                       I18n.t("cms.sns_post"), :cms_sns_post_logs_path, I18n.t("cms.sns_post_log")
+    end
+  end
+
+  context "ページ検索" do
+    it "shows 'ページ検索' as the leaf crumb" do
+      visit cms_page_searches_path(site)
+
+      within "#crumbs" do
+        expect(page).to have_content(I18n.t("cms.page_search"))
+      end
+    end
+  end
+
+  context "書き出し停止" do
+    it "shows '書き出し停止' as the leaf crumb" do
+      visit cms_generate_lock_path(site)
+
+      within "#crumbs" do
+        expect(page).to have_content(I18n.t("modules.addons.ss/generate_lock"))
+      end
+    end
   end
 end

--- a/spec/features/cms/form/dbs/dbs_spec.rb
+++ b/spec/features/cms/form/dbs/dbs_spec.rb
@@ -43,4 +43,22 @@ describe Cms::Form::DbsController, type: :feature, dbscope: :example, js: true d
       expect(Cms::FormDb.count).to eq 0
     end
   end
+
+  #
+  # 定型フォーム-DB のパンくずリストには、定型フォーム-DB の直上に「定型フォーム」が
+  # 表示される (set_crumbs で親階層を追加する挙動: dbs_controller.rb)。
+  #
+  context 'breadcrumb' do
+    before { login_cms_user }
+
+    it "includes Cms::Form as a parent crumb with link to cms_forms_path" do
+      visit cms_form_dbs_path(site)
+
+      within '#crumbs' do
+        form_crumb = find_link(Cms::Form.model_name.human)
+        expect(form_crumb[:href]).to end_with(cms_forms_path(site: site.id))
+        expect(page).to have_content(Cms::FormDb.model_name.human)
+      end
+    end
+  end
 end

--- a/spec/features/cms/line/settings_spec.rb
+++ b/spec/features/cms/line/settings_spec.rb
@@ -17,6 +17,10 @@ describe "cms/line/settings", type: :feature, dbscope: :example, js: true do
 
     it "#show" do
       visit show_path
+      within "#crumbs" do
+        expect(page).to have_link(I18n.t("cms.line"), href: cms_line_messages_path(site))
+        expect(page).to have_text(I18n.t("cms.line_setting"))
+      end
       within "#addon-basic" do
         expect(page).to have_text(types_label(default_template_types))
       end

--- a/spec/features/cms/source_cleaner/site_setting_spec.rb
+++ b/spec/features/cms/source_cleaner/site_setting_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe "cms/source_cleaner/site_setting", type: :feature, dbscope: :example, js: true do
+  let!(:site) { cms_site }
+  let(:show_path) { cms_source_cleaner_site_setting_path site.id }
+
+  context "with auth" do
+    before { login_cms_user }
+
+    it "#show" do
+      visit show_path
+
+      within "#crumbs" do
+        expect(page).to have_link(I18n.t("cms.source_cleaner"), href: cms_source_cleaner_main_path(site: site))
+        expect(page).to have_text(I18n.t("translate.site_setting"))
+      end
+    end
+  end
+end

--- a/spec/features/contact/contacts/basic_spec.rb
+++ b/spec/features/contact/contacts/basic_spec.rb
@@ -63,6 +63,10 @@ describe Contact::ContactsController, type: :feature, dbscope: :example, js: tru
   context "confirm page usage" do
     it do
       visit contact_contacts_path(site: site)
+      within "#crumbs" do
+        expect(page).to have_link(I18n.t("cms.group"), href: cms_groups_path(site: site))
+        expect(page).to have_text(I18n.t("modules.contact"))
+      end
       within "[data-id='#{main_contact.id}']" do
         expect(page).to have_css(".name", text: main_contact.name)
         expect(page).to have_css(".pages-used", text: "2")


### PR DESCRIPTION
## Summary
- CMS メニュー配下の各機能（リンクチェック、LINE 連携、ノード、エクスポート/インポート、ゴミ箱、全コンテンツ、ページ書き出し等）のページ上部に表示されるパンくずに、親階層（CMS／フォルダー／LINE 配信／LINE メッセージなど）を補完
- 影響箇所をカバーする feature spec を追加
- **#6023（定型フォーム-DB のパンくず修正）の内容を本 PR に統合**
  - コントローラー側の親階層追加（`cms/form/dbs_controller.rb`）は本 PR で既に反映済み
  - #6023 のパンくず検証 spec を `spec/features/cms/form/dbs/dbs_spec.rb` に取り込み

## Test plan
- [x] `bundle exec rspec spec/features/cms/breadcrumbs_spec.rb`
- [x] `bundle exec rspec spec/features/cms/form/dbs/dbs_spec.rb`
- [x] CMS メニュー配下の各管理画面で、パンくずに親階層が含まれることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * CMS の多数画面でパンくずナビゲーションを追加・拡張しました（LINE／リンクチェック／全コンテンツ抽出、生成・インポート/エクスポート、LDAP／翻訳／ジョブ／履歴／音声等）。画面間移動と文脈把握が向上します。

* **テスト**
  * CMS のパンくず表示を網羅する機能テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->