### PR TITLE
[fix] sys : add parent crumbs under システム設定

### DIFF
--- a/app/controllers/history/cms/history_archives_controller.rb
+++ b/app/controllers/history/cms/history_archives_controller.rb
@@ -9,8 +9,7 @@ class History::Cms::HistoryArchivesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("mongoid.models.gws/history"), history_cms_logs_path]
-    @crumbs << [t("mongoid.models.gws/history_archive_file"), action: :index]
+    @crumbs << [t("mongoid.models.gws/history"), action: :index]
   end
 
   public

--- a/app/controllers/history/cms/history_archives_controller.rb
+++ b/app/controllers/history/cms/history_archives_controller.rb
@@ -9,7 +9,8 @@ class History::Cms::HistoryArchivesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("mongoid.models.gws/history"), action: :index]
+    @crumbs << [t("mongoid.models.gws/history"), history_cms_logs_path]
+    @crumbs << [t("mongoid.models.gws/history_archive_file"), action: :index]
   end
 
   public

--- a/app/controllers/history/sys/logs_controller.rb
+++ b/app/controllers/history/sys/logs_controller.rb
@@ -9,6 +9,7 @@ class History::Sys::LogsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("mongoid.models.gws/history"), history_sys_logs_path]
     @crumbs << [t("history.log"), action: :index]
   end
 

--- a/app/controllers/job/sys/logs_controller.rb
+++ b/app/controllers/job/sys/logs_controller.rb
@@ -7,6 +7,11 @@ class Job::Sys::LogsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_sys_main_path]
+    @crumbs << [t("job.log"), action: :index]
+  end
+
   def filter_permission
     raise "403" unless SS::User.allowed?(:edit, @cur_user)
   end

--- a/app/controllers/job/sys/michecker_results_controller.rb
+++ b/app/controllers/job/sys/michecker_results_controller.rb
@@ -9,6 +9,11 @@ class Job::Sys::MicheckerResultsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_sys_main_path]
+    @crumbs << [Cms::Michecker::Result.model_name.human, action: :index]
+  end
+
   def filter_permission
     raise "404" if SS.config.michecker.blank? || SS.config.michecker['disable']
     raise "403" unless SS::User.allowed?(:edit, @cur_user)

--- a/app/controllers/job/sys/reservations_controller.rb
+++ b/app/controllers/job/sys/reservations_controller.rb
@@ -8,6 +8,11 @@ class Job::Sys::ReservationsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_sys_main_path]
+    @crumbs << [t("job.reservation"), action: :index]
+  end
+
   def filter_permission
     raise "403" unless SS::User.allowed?(:edit, @cur_user)
   end

--- a/app/controllers/job/sys/statuses_controller.rb
+++ b/app/controllers/job/sys/statuses_controller.rb
@@ -13,6 +13,7 @@ class Job::Sys::StatusesController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("job.main"), job_sys_main_path]
     @crumbs << [t("job.status"), action: :show]
   end
 

--- a/app/controllers/job/sys/tasks_controller.rb
+++ b/app/controllers/job/sys/tasks_controller.rb
@@ -8,6 +8,11 @@ class Job::Sys::TasksController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("job.main"), job_sys_main_path]
+    @crumbs << [t("job.task"), action: :index]
+  end
+
   def filter_permission
     raise "403" unless SS::User.allowed?(:edit, @cur_user)
   end

--- a/app/controllers/sys/auth/environments_controller.rb
+++ b/app/controllers/sys/auth/environments_controller.rb
@@ -9,6 +9,11 @@ class Sys::Auth::EnvironmentsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("sys.auth"), sys_auth_path]
+    @crumbs << [t("sys.auth/environment"), action: :index]
+  end
+
   def append_view_paths
     append_view_path "app/views/sys/auth/main/"
     super

--- a/app/controllers/sys/auth/oauth2_applications_controller.rb
+++ b/app/controllers/sys/auth/oauth2_applications_controller.rb
@@ -11,6 +11,11 @@ class Sys::Auth::OAuth2ApplicationsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("sys.auth"), sys_auth_path]
+    @crumbs << [SS::OAuth2::Application::Base.model_name.human, action: :index]
+  end
+
   def preload_constants
     SS::OAuth2::Application::Confidential
     SS::OAuth2::Application::Service

--- a/app/controllers/sys/auth/open_id_connects_controller.rb
+++ b/app/controllers/sys/auth/open_id_connects_controller.rb
@@ -9,6 +9,11 @@ class Sys::Auth::OpenIdConnectsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("sys.auth"), sys_auth_path]
+    @crumbs << [t("sys.auth/open_id_connect"), action: :index]
+  end
+
   def append_view_paths
     append_view_path "app/views/sys/auth/main/"
     super

--- a/app/controllers/sys/auth/samls_controller.rb
+++ b/app/controllers/sys/auth/samls_controller.rb
@@ -9,6 +9,11 @@ class Sys::Auth::SamlsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("sys.auth"), sys_auth_path]
+    @crumbs << [t("sys.auth/saml"), action: :index]
+  end
+
   def append_view_paths
     append_view_path "app/views/sys/auth/main/"
     super

--- a/app/controllers/sys/auth/settings_controller.rb
+++ b/app/controllers/sys/auth/settings_controller.rb
@@ -9,6 +9,11 @@ class Sys::Auth::SettingsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("sys.auth"), sys_auth_path]
+    @crumbs << [t("sys.auth/setting"), action: :show]
+  end
+
   def set_item
     @item = @model.first_or_create
   end

--- a/app/controllers/sys/diag/app_logs_controller.rb
+++ b/app/controllers/sys/diag/app_logs_controller.rb
@@ -26,6 +26,7 @@ class Sys::Diag::AppLogsController < ApplicationController
   end
 
   def set_crumbs
+    @crumbs << [t("sys.diag"), sys_diag_main_path]
     @crumbs << [ relative_log_file_path, url_for(action: :show) ]
   end
 

--- a/app/controllers/sys/diag/mails_controller.rb
+++ b/app/controllers/sys/diag/mails_controller.rb
@@ -54,6 +54,7 @@ class Sys::Diag::MailsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("sys.diag"), sys_diag_main_path]
     @crumbs << ["MAIL Test", action: :index]
   end
 

--- a/app/controllers/sys/diag/servers_controller.rb
+++ b/app/controllers/sys/diag/servers_controller.rb
@@ -15,6 +15,7 @@ class Sys::Diag::ServersController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("sys.diag"), sys_diag_main_path]
     @crumbs << ["Server Info", action: :show]
   end
 

--- a/app/controllers/sys/history_archives_controller.rb
+++ b/app/controllers/sys/history_archives_controller.rb
@@ -9,6 +9,7 @@ class Sys::HistoryArchivesController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("mongoid.models.gws/history"), history_sys_logs_path]
     @crumbs << [t("mongoid.models.gws/history_archive_file"), action: :index]
   end
 

--- a/app/controllers/sys/history_archives_controller.rb
+++ b/app/controllers/sys/history_archives_controller.rb
@@ -9,7 +9,7 @@ class Sys::HistoryArchivesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("mongoid.models.gws/history"), action: :index]
+    @crumbs << [t("mongoid.models.gws/history_archive_file"), action: :index]
   end
 
   public

--- a/spec/features/sys/breadcrumbs_spec.rb
+++ b/spec/features/sys/breadcrumbs_spec.rb
@@ -99,17 +99,13 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
   end
 
   #
-  # システム設定 > 操作履歴 > アーカイブ。現状は leaf が「操作履歴」になっていたが、
-  # 本ページは履歴のアーカイブ一覧であるため leaf を「アーカイブ」へ修正する。
+  # システム設定 > 操作履歴 > アーカイブ。アーカイブ一覧ページのパンくずに
+  # 親階層「操作履歴」と leaf「アーカイブ」が表示されることを保証する。
   #
   context "操作履歴アーカイブ" do
-    it "shows 'アーカイブ' as the leaf crumb" do
-      visit sys_history_archives_path
-
-      within "#crumbs" do
-        archive_label = I18n.t("mongoid.models.gws/history_archive_file")
-        expect(page).to have_content(archive_label)
-      end
-    end
+    let(:visit_path) { sys_history_archives_path }
+    include_examples "has parent and leaf crumbs",
+                     I18n.t("mongoid.models.gws/history"), :history_sys_logs_path,
+                     I18n.t("mongoid.models.gws/history_archive_file")
   end
 end

--- a/spec/features/sys/breadcrumbs_spec.rb
+++ b/spec/features/sys/breadcrumbs_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+#
+# システム設定配下のパンくずリストに、親階層 (認証 / 診断 / ジョブ) が
+# 表示されることを feature レベルで保証する。
+#
+describe "sys breadcrumbs", type: :feature, dbscope: :example do
+  before { login_sys_user }
+
+  shared_examples "has parent and leaf crumbs" do |parent_label, parent_path_name, leaf_label|
+    it "shows '#{parent_label} > #{leaf_label}' under システム設定" do
+      visit visit_path
+
+      within "#crumbs" do
+        parent_crumb = find_link(parent_label)
+        expect(parent_crumb[:href]).to end_with(send(parent_path_name))
+        expect(page).to have_content(leaf_label)
+      end
+    end
+  end
+
+  context "認証" do
+    context "SAML" do
+      let(:visit_path) { sys_auth_samls_path }
+      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/saml")
+    end
+
+    context "OpenID Connect" do
+      let(:visit_path) { sys_auth_open_id_connects_path }
+      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/open_id_connect")
+    end
+
+    context "環境変数" do
+      let(:visit_path) { sys_auth_environments_path }
+      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/environment")
+    end
+
+    context "OAuthアプリ" do
+      let(:visit_path) { sys_auth_oauth2_applications_path }
+      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, SS::OAuth2::Application::Base.model_name.human
+    end
+
+    context "設定" do
+      let(:visit_path) { sys_auth_setting_path }
+      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/setting")
+    end
+  end
+
+  context "診断" do
+    context "MAIL Test" do
+      let(:visit_path) { sys_diag_mails_path }
+      include_examples "has parent and leaf crumbs", I18n.t("sys.diag"), :sys_diag_main_path, "MAIL Test"
+    end
+
+    context "Server Info" do
+      let(:visit_path) { sys_diag_server_path }
+      include_examples "has parent and leaf crumbs", I18n.t("sys.diag"), :sys_diag_main_path, "Server Info"
+    end
+
+    context "Application Log" do
+      it "shows '#{I18n.t('sys.diag')}' as the parent crumb" do
+        visit sys_diag_app_log_path
+
+        within "#crumbs" do
+          parent_crumb = find_link(I18n.t("sys.diag"))
+          expect(parent_crumb[:href]).to end_with(sys_diag_main_path)
+        end
+      end
+    end
+  end
+
+  context "ジョブ" do
+    context "実行履歴" do
+      let(:visit_path) { job_sys_logs_path }
+      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.log")
+    end
+
+    context "タスク" do
+      let(:visit_path) { job_sys_tasks_path }
+      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.task")
+    end
+
+    context "実行予約" do
+      let(:visit_path) { job_sys_reservations_path }
+      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.reservation")
+    end
+
+    context "miChecker結果" do
+      let(:visit_path) { job_sys_michecker_results_path }
+      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, Cms::Michecker::Result.model_name.human
+    end
+
+    context "状態" do
+      let(:visit_path) { job_sys_status_path }
+      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.status")
+    end
+  end
+end

--- a/spec/features/sys/breadcrumbs_spec.rb
+++ b/spec/features/sys/breadcrumbs_spec.rb
@@ -37,7 +37,8 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
 
     context "OAuthアプリ" do
       let(:visit_path) { sys_auth_oauth2_applications_path }
-      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, SS::OAuth2::Application::Base.model_name.human
+      include_examples "has parent and leaf crumbs",
+                       I18n.t("sys.auth"), :sys_auth_path, SS::OAuth2::Application::Base.model_name.human
     end
 
     context "設定" do
@@ -87,7 +88,8 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
 
     context "miChecker結果" do
       let(:visit_path) { job_sys_michecker_results_path }
-      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, Cms::Michecker::Result.model_name.human
+      include_examples "has parent and leaf crumbs",
+                       I18n.t("job.main"), :job_sys_main_path, Cms::Michecker::Result.model_name.human
     end
 
     context "状態" do

--- a/spec/features/sys/breadcrumbs_spec.rb
+++ b/spec/features/sys/breadcrumbs_spec.rb
@@ -95,4 +95,19 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
       include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.status")
     end
   end
+
+  #
+  # システム設定 > 操作履歴 > アーカイブ。現状は leaf が「操作履歴」になっていたが、
+  # 本ページは履歴のアーカイブ一覧であるため leaf を「アーカイブ」へ修正する。
+  #
+  context "操作履歴アーカイブ" do
+    it "shows 'アーカイブ' as the leaf crumb" do
+      visit sys_history_archives_path
+
+      within "#crumbs" do
+        archive_label = I18n.t("mongoid.models.gws/history_archive_file")
+        expect(page).to have_content(archive_label)
+      end
+    end
+  end
 end

--- a/spec/features/sys/breadcrumbs_spec.rb
+++ b/spec/features/sys/breadcrumbs_spec.rb
@@ -4,17 +4,22 @@ require 'spec_helper'
 # システム設定配下のパンくずリストに、親階層 (認証 / 診断 / ジョブ) が
 # 表示されることを feature レベルで保証する。
 #
+# NOTE: ラベルは lambda で受け取り、example 実行時 (= ログイン後のロケール) に
+# 評価する。spec 読み込み時に I18n.t を評価して固定すると、ログインユーザーの
+# lang (SS::LocaleSupport.current_lang による en/ja のランダムサンプリング) で
+# 描画されたページと不一致になり、ロケール次第で flaky に落ちるため。
+#
 describe "sys breadcrumbs", type: :feature, dbscope: :example do
   before { login_sys_user }
 
-  shared_examples "has parent and leaf crumbs" do |parent_label, parent_path_name, leaf_label|
-    it "shows '#{parent_label} > #{leaf_label}' under システム設定" do
+  shared_examples "has parent and leaf crumbs" do |parent_path_name|
+    it "shows the parent and leaf crumbs under システム設定" do
       visit visit_path
 
       within "#crumbs" do
-        parent_crumb = find_link(parent_label)
+        parent_crumb = find_link(instance_exec(&parent_label))
         expect(parent_crumb[:href]).to end_with(send(parent_path_name))
-        expect(page).to have_content(leaf_label)
+        expect(page).to have_content(instance_exec(&leaf_label))
       end
     end
   end
@@ -22,44 +27,57 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
   context "認証" do
     context "SAML" do
       let(:visit_path) { sys_auth_samls_path }
-      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/saml")
+      let(:parent_label) { -> { I18n.t("sys.auth") } }
+      let(:leaf_label) { -> { I18n.t("sys.auth/saml") } }
+      include_examples "has parent and leaf crumbs", :sys_auth_path
     end
 
     context "OpenID Connect" do
       let(:visit_path) { sys_auth_open_id_connects_path }
-      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/open_id_connect")
+      let(:parent_label) { -> { I18n.t("sys.auth") } }
+      let(:leaf_label) { -> { I18n.t("sys.auth/open_id_connect") } }
+      include_examples "has parent and leaf crumbs", :sys_auth_path
     end
 
     context "環境変数" do
       let(:visit_path) { sys_auth_environments_path }
-      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/environment")
+      let(:parent_label) { -> { I18n.t("sys.auth") } }
+      let(:leaf_label) { -> { I18n.t("sys.auth/environment") } }
+      include_examples "has parent and leaf crumbs", :sys_auth_path
     end
 
     context "OAuthアプリ" do
       let(:visit_path) { sys_auth_oauth2_applications_path }
-      include_examples "has parent and leaf crumbs",
-                       I18n.t("sys.auth"), :sys_auth_path, SS::OAuth2::Application::Base.model_name.human
+      let(:parent_label) { -> { I18n.t("sys.auth") } }
+      let(:leaf_label) { -> { SS::OAuth2::Application::Base.model_name.human } }
+      include_examples "has parent and leaf crumbs", :sys_auth_path
     end
 
     context "設定" do
       let(:visit_path) { sys_auth_setting_path }
-      include_examples "has parent and leaf crumbs", I18n.t("sys.auth"), :sys_auth_path, I18n.t("sys.auth/setting")
+      let(:parent_label) { -> { I18n.t("sys.auth") } }
+      let(:leaf_label) { -> { I18n.t("sys.auth/setting") } }
+      include_examples "has parent and leaf crumbs", :sys_auth_path
     end
   end
 
   context "診断" do
     context "MAIL Test" do
       let(:visit_path) { sys_diag_mails_path }
-      include_examples "has parent and leaf crumbs", I18n.t("sys.diag"), :sys_diag_main_path, "MAIL Test"
+      let(:parent_label) { -> { I18n.t("sys.diag") } }
+      let(:leaf_label) { -> { "MAIL Test" } }
+      include_examples "has parent and leaf crumbs", :sys_diag_main_path
     end
 
     context "Server Info" do
       let(:visit_path) { sys_diag_server_path }
-      include_examples "has parent and leaf crumbs", I18n.t("sys.diag"), :sys_diag_main_path, "Server Info"
+      let(:parent_label) { -> { I18n.t("sys.diag") } }
+      let(:leaf_label) { -> { "Server Info" } }
+      include_examples "has parent and leaf crumbs", :sys_diag_main_path
     end
 
     context "Application Log" do
-      it "shows '#{I18n.t('sys.diag')}' as the parent crumb" do
+      it "shows the parent crumb under システム設定" do
         visit sys_diag_app_log_path
 
         within "#crumbs" do
@@ -73,28 +91,37 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
   context "ジョブ" do
     context "実行履歴" do
       let(:visit_path) { job_sys_logs_path }
-      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.log")
+      let(:parent_label) { -> { I18n.t("job.main") } }
+      let(:leaf_label) { -> { I18n.t("job.log") } }
+      include_examples "has parent and leaf crumbs", :job_sys_main_path
     end
 
     context "タスク" do
       let(:visit_path) { job_sys_tasks_path }
-      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.task")
+      let(:parent_label) { -> { I18n.t("job.main") } }
+      let(:leaf_label) { -> { I18n.t("job.task") } }
+      include_examples "has parent and leaf crumbs", :job_sys_main_path
     end
 
     context "実行予約" do
       let(:visit_path) { job_sys_reservations_path }
-      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.reservation")
+      let(:parent_label) { -> { I18n.t("job.main") } }
+      let(:leaf_label) { -> { I18n.t("job.reservation") } }
+      include_examples "has parent and leaf crumbs", :job_sys_main_path
     end
 
     context "miChecker結果" do
       let(:visit_path) { job_sys_michecker_results_path }
-      include_examples "has parent and leaf crumbs",
-                       I18n.t("job.main"), :job_sys_main_path, Cms::Michecker::Result.model_name.human
+      let(:parent_label) { -> { I18n.t("job.main") } }
+      let(:leaf_label) { -> { Cms::Michecker::Result.model_name.human } }
+      include_examples "has parent and leaf crumbs", :job_sys_main_path
     end
 
     context "状態" do
       let(:visit_path) { job_sys_status_path }
-      include_examples "has parent and leaf crumbs", I18n.t("job.main"), :job_sys_main_path, I18n.t("job.status")
+      let(:parent_label) { -> { I18n.t("job.main") } }
+      let(:leaf_label) { -> { I18n.t("job.status") } }
+      include_examples "has parent and leaf crumbs", :job_sys_main_path
     end
   end
 
@@ -104,9 +131,9 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
   #
   context "操作履歴" do
     let(:visit_path) { history_sys_logs_path }
-    include_examples "has parent and leaf crumbs",
-                     I18n.t("mongoid.models.gws/history"), :history_sys_logs_path,
-                     I18n.t("history.log")
+    let(:parent_label) { -> { I18n.t("mongoid.models.gws/history") } }
+    let(:leaf_label) { -> { I18n.t("history.log") } }
+    include_examples "has parent and leaf crumbs", :history_sys_logs_path
   end
 
   #
@@ -115,8 +142,8 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
   #
   context "操作履歴アーカイブ" do
     let(:visit_path) { sys_history_archives_path }
-    include_examples "has parent and leaf crumbs",
-                     I18n.t("mongoid.models.gws/history"), :history_sys_logs_path,
-                     I18n.t("mongoid.models.gws/history_archive_file")
+    let(:parent_label) { -> { I18n.t("mongoid.models.gws/history") } }
+    let(:leaf_label) { -> { I18n.t("mongoid.models.gws/history_archive_file") } }
+    include_examples "has parent and leaf crumbs", :history_sys_logs_path
   end
 end

--- a/spec/features/sys/breadcrumbs_spec.rb
+++ b/spec/features/sys/breadcrumbs_spec.rb
@@ -99,6 +99,17 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
   end
 
   #
+  # システム設定 > 操作履歴 > 操作履歴。操作履歴一覧ページのパンくずに
+  # 親階層「操作履歴」と leaf「操作履歴」が表示されることを保証する。
+  #
+  context "操作履歴" do
+    let(:visit_path) { history_sys_logs_path }
+    include_examples "has parent and leaf crumbs",
+                     I18n.t("mongoid.models.gws/history"), :history_sys_logs_path,
+                     I18n.t("history.log")
+  end
+
+  #
   # システム設定 > 操作履歴 > アーカイブ。アーカイブ一覧ページのパンくずに
   # 親階層「操作履歴」と leaf「アーカイブ」が表示されることを保証する。
   #

--- a/spec/features/sys/breadcrumbs_spec.rb
+++ b/spec/features/sys/breadcrumbs_spec.rb
@@ -13,13 +13,16 @@ describe "sys breadcrumbs", type: :feature, dbscope: :example do
   before { login_sys_user }
 
   shared_examples "has parent and leaf crumbs" do |parent_path_name|
+    # leaf を最後・親をその直前のクラムとして位置で検証する。操作履歴のように
+    # 親と leaf のラベル (とリンク先) が一致するケースでも find_link の
+    # Capybara::Ambiguous を避け、かつ親クラムが挿入されていることを厳密に確認できる。
     it "shows the parent and leaf crumbs under システム設定" do
       visit visit_path
 
       within "#crumbs" do
-        parent_crumb = find_link(instance_exec(&parent_label))
-        expect(parent_crumb[:href]).to end_with(send(parent_path_name))
-        expect(page).to have_content(instance_exec(&leaf_label))
+        items = all("li.breadcrumb-item")
+        expect(items.last).to have_text(instance_exec(&leaf_label))
+        expect(items[-2]).to have_link(instance_exec(&parent_label), href: send(parent_path_name))
       end
     end
   end

--- a/spec/lib/migrations/cms/20200521000000_recover_missing_attachments_spec.rb
+++ b/spec/lib/migrations/cms/20200521000000_recover_missing_attachments_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe SS::Migration20200521000000, dbscope: :example do
   end
 
   describe "#change" do
+    # このマイグレーションは Cms::Page / SS::File をサイト非依存で全件走査する（unscoped）ため、
+    # 直前に実行された spec（特に feature spec のアプリサーバースレッド）が残したページ／ファイルが
+    # 走査対象に混入すると、欠損ファイルの復旧先が本来のページとずれて不安定になることがある。
+    # spec ファイルの並び順（シャード分割）に依存して顕在化するため、
+    # フィクスチャ生成前に DB をクリーンにし、本 example のデータだけを対象にする。
+    prepend_before do
+      clean_database
+    end
+
     let!(:site) { cms_site }
     let!(:user1) { create :cms_user, name: unique_id, group_ids: cms_user.group_ids, cms_role_ids: cms_user.cms_role_ids }
     let!(:user2) { create :cms_user, name: unique_id, group_ids: cms_user.group_ids, cms_role_ids: cms_user.cms_role_ids }


### PR DESCRIPTION
## Summary
- システム設定配下の各機能（認証 / 診断 / ジョブ）のパンくずに親階層を追加
  - 認証 (SAML / OpenID Connect / 環境変数 / OAuth アプリ / 設定)
  - 診断 (MAIL Test / Server Info / Application Log)
  - ジョブ (実行履歴 / タスク / 実行予約 / miChecker 結果 / 状態)
- 操作履歴アーカイブのパンくず leaf を「操作履歴」→「アーカイブ」へ修正（別コミット）
- feature spec で親階層 / leaf 表記を検証

## Test plan
- [x] `bundle exec rspec spec/features/sys/breadcrumbs_spec.rb`
- [x] システム設定配下の各管理画面で、パンくずに親階層が含まれることを目視確認
- [x] `sys/history_archives` のパンくず leaf が「アーカイブ」と表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 管理画面のパンくずリストを広範囲で強化。ジョブ、認証、診断、操作履歴などで親ページのリンク追加や階層整備を行い、現在位置がより明確になりました。

* **Tests**
  * システム設定配下のパンくず表示を包括的に検証する機能テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->