### PR TITLE
[modify][gws][schedule] 「繰り返し設定」の文言改善とツールチップ追加 (#5615)

### DIFF
--- a/config/locales/gws/schedule/en.yml
+++ b/config/locales/gws/schedule/en.yml
@@ -425,7 +425,7 @@ en:
         -
         - 'e.g.) April 1, 2024 (the first Monday)'
         - 'Date: the 1st of every month'
-        - 'Day of the week: the first Monday of every month'
+        - 'Day of week: the first Monday of every month'
       wdays:
         - Select the day of the week.
     gws/addon/schedule/repeat:

--- a/config/locales/gws/schedule/en.yml
+++ b/config/locales/gws/schedule/en.yml
@@ -422,6 +422,10 @@ en:
         - Enter an end date.
       repeat_base:
         - Select the repetition criteria.
+        -
+        - 'e.g.) April 1, 2024 (the first Monday)'
+        - 'Date: the 1st of every month'
+        - 'Day of the week: the first Monday of every month'
       wdays:
         - Select the day of the week.
     gws/addon/schedule/repeat:

--- a/config/locales/gws/schedule/ja.yml
+++ b/config/locales/gws/schedule/ja.yml
@@ -85,10 +85,10 @@ ja:
         wday: 曜日
       repeat_type:
         none: 繰り返しなし
-        daily: 毎日
-        weekly: 毎週
-        monthly: 毎月
-        yearly: 毎年
+        daily: 日ごと
+        weekly: 週ごと
+        monthly: 月ごと
+        yearly: 年ごと
       schedule_attachment_state:
         allow: 許可する
         deny: 許可しない
@@ -422,6 +422,10 @@ ja:
         - 終了日を入力します。
       repeat_base:
         - 繰り返しの基準を選択します。
+        -
+        - 例）2024年4月1日（第一月曜日）
+        - 日付：月ごと1日
+        - 曜日：月ごと第一月曜日
       wdays:
         - 曜日を選択します。
     gws/addon/schedule/repeat:


### PR DESCRIPTION
## 概要
- 繰り返し設定の選択肢を「毎日/毎週/毎月/毎年」から「日ごと/週ごと/月ごと/年ごと」に変更 （繰り返し間隔と組み合わせた際に「2日ごと」なのに「毎日」と表示される矛盾を解消）
- 「月ごと」選択時の「繰り返しの基準」ツールチップに、日付/曜日の例文を追加

