### PR TITLE
[fix][gws][workfolow2] empty zip issue in attachments download

### DIFF
--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -310,7 +310,7 @@ class Gws::Share::FilesController < ApplicationController
   end
 
   def download_all
-    zip = Gws::Compressor.new(@cur_user, items: @items)
+    zip = Gws::Compressor.new(@cur_user, model: Gws::Share::File, items: @items)
     zip.url = sns_download_job_files_url(user: zip.user, filename: zip.filename)
 
     if zip.deley_download?

--- a/app/controllers/gws/share/folders_controller.rb
+++ b/app/controllers/gws/share/folders_controller.rb
@@ -102,7 +102,7 @@ class Gws::Share::FoldersController < ApplicationController
     set_item
     @items = SS::File.where(folder_id: params[:id].to_i, deleted: nil)
 
-    zip = Gws::Compressor.new(@cur_user, items: @items, name: "#{@item.trailing_name}.zip")
+    zip = Gws::Compressor.new(@cur_user, model: Gws::Share::File, items: @items, name: "#{@item.trailing_name}.zip")
     zip.url = sns_download_job_files_url(user: zip.user, filename: zip.filename, name: zip.name)
 
     if zip.deley_download?

--- a/app/controllers/gws/workflow/files_controller.rb
+++ b/app/controllers/gws/workflow/files_controller.rb
@@ -262,7 +262,7 @@ class Gws::Workflow::FilesController < ApplicationController
     end
 
     filename = "workflow_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.zip"
-    zip = Gws::Compressor.new(@cur_user, items: files, filename: filename)
+    zip = Gws::Compressor.new(@cur_user, model: SS::File, items: files, filename: filename)
     zip.url = sns_download_job_files_url(user: zip.user, filename: zip.filename)
 
     if zip.deley_download?
@@ -287,7 +287,7 @@ class Gws::Workflow::FilesController < ApplicationController
     end
 
     filename = "workflow_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.zip"
-    zip = Gws::Compressor.new(@cur_user, items: files, filename: filename)
+    zip = Gws::Compressor.new(@cur_user, model: SS::File, items: files, filename: filename)
     zip.url = sns_download_job_files_url(user: zip.user, filename: zip.filename)
 
     if zip.deley_download?

--- a/app/controllers/gws/workflow2/files_controller.rb
+++ b/app/controllers/gws/workflow2/files_controller.rb
@@ -382,7 +382,7 @@ class Gws::Workflow2::FilesController < ApplicationController
     end
 
     filename = "workflow_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.zip"
-    zip = Gws::Compressor.new(@cur_user, items: files, filename: filename)
+    zip = Gws::Compressor.new(@cur_user, model: SS::File, items: files, filename: filename)
     zip.url = sns_download_job_files_url(user: zip.user, filename: zip.filename)
 
     if zip.deley_download?

--- a/app/controllers/gws/workflow2/files_controller.rb
+++ b/app/controllers/gws/workflow2/files_controller.rb
@@ -407,7 +407,7 @@ class Gws::Workflow2::FilesController < ApplicationController
     end
 
     filename = "workflow_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.zip"
-    zip = Gws::Compressor.new(@cur_user, items: files, filename: filename)
+    zip = Gws::Compressor.new(@cur_user, model: SS::File, items: files, filename: filename)
     zip.url = sns_download_job_files_url(user: zip.user, filename: zip.filename)
 
     if zip.deley_download?

--- a/app/jobs/gws/compress_job.rb
+++ b/app/jobs/gws/compress_job.rb
@@ -1,6 +1,6 @@
 class Gws::CompressJob < Gws::ApplicationJob
   def perform(attr)
-    zip = Gws::Compressor.new(user, attr)
+    zip = Gws::Compressor.new(user, **attr)
 
     Rails.logger.error("Error : Failed to compress share_files.") unless zip.save
 

--- a/app/jobs/gws/tabular/file/zip_export_job.rb
+++ b/app/jobs/gws/tabular/file/zip_export_job.rb
@@ -14,10 +14,9 @@ class Gws::Tabular::File::ZipExportJob < Gws::ApplicationJob
 
     filename = "gws_tabular_files.zip"
     @zip = Gws::Compressor.new(
-      user, {
-        model: @model, items: @model.none, filename: filename,
-        name: "#{@cur_form.i18n_name}_#{Time.zone.now.to_i}.zip"
-      }
+      user,
+      model: @model, items: @model.none, filename: filename,
+      name: "#{@cur_form.i18n_name}_#{Time.zone.now.to_i}.zip"
     )
     @zip.url = download_file_url(filename)
 

--- a/app/models/gws/compressor.rb
+++ b/app/models/gws/compressor.rb
@@ -1,6 +1,9 @@
 class Gws::Compressor
   attr_accessor :user, :model, :items, :filename, :name, :root, :path, :url
 
+  DEFAULT_MIN_FILESIZE = 100 * 1_024 * 1_024
+  DEFAULT_MIN_COUNT = 100
+
   def initialize(user, attr = {})
     self.user     = user
     self.model    = attr[:model] || Gws::Share::File
@@ -16,6 +19,48 @@ class Gws::Compressor
     self.url  = attr[:url] || file.url(name: name)
   end
 
+  class << self
+    def default_min_filesize
+      deley_download = SS.config.env.deley_download
+      return DEFAULT_MIN_FILESIZE if deley_download.blank?
+      return DEFAULT_MIN_FILESIZE unless deley_download.key?('min_filesize')
+
+      ret = deley_download['min_filesize'].to_i
+      ret >= 0 ? ret : DEFAULT_MIN_FILESIZE
+    end
+
+    def default_min_count
+      deley_download = SS.config.env.deley_download
+      return DEFAULT_MIN_COUNT if deley_download.blank?
+      return DEFAULT_MIN_COUNT unless deley_download.key?('min_count')
+
+      ret = deley_download['min_count'].to_i
+      ret >= 0 ? ret : DEFAULT_MIN_FILESIZE
+    end
+
+    def min_filesize
+      return @min_filesize if instance_variable_defined?(:@min_filesize)
+      @min_filesize = default_min_filesize
+    end
+
+    def min_count
+      return @min_count if instance_variable_defined?(:@min_count)
+      @min_count = default_min_count
+    end
+
+    if Rails.env.test?
+      def min_filesize=(value)
+        raise ArgumentError if !value.numeric? || value < 0
+        @min_filesize = value
+      end
+
+      def min_count=(value)
+        raise ArgumentError if !value.numeric? || value < 0
+        @min_count = value
+      end
+    end
+  end
+
   def serialize
     { model: model.name, items: items.map(&:id), filename: filename, name: name, url: url }
   end
@@ -26,8 +71,8 @@ class Gws::Compressor
 
   def deley_download?
     sizes = items.map(&:size)
-    return true if sizes.sum >= SS.config.env.deley_download['min_filesize'].to_i
-    return true if sizes.size >= SS.config.env.deley_download['min_count'].to_i
+    return true if sizes.sum >= self.class.min_filesize
+    return true if sizes.size >= self.class.min_count
 
     false
   end

--- a/app/models/gws/compressor.rb
+++ b/app/models/gws/compressor.rb
@@ -4,19 +4,20 @@ class Gws::Compressor
   DEFAULT_MIN_FILESIZE = 100 * 1_024 * 1_024
   DEFAULT_MIN_COUNT = 100
 
-  def initialize(user, attr = {})
+  def initialize(user, model:, items:, **kwargs)
+    model = model.to_s.constantize unless model.is_a?(Class)
+    items = model.in(id: items) if items.is_a?(Array)
+
     self.user     = user
-    self.model    = attr[:model] || Gws::Share::File
-    self.model    = model.to_s.constantize if !model.is_a?(Class)
-    self.items    = attr[:items]
-    self.items    = model.in(id: items) if items.is_a?(Array)
-    self.filename = attr[:filename] || "share_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.zip"
-    self.name     = attr[:name]
+    self.model    = model
+    self.items    = items
+    self.filename = kwargs[:filename] || "share_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.zip"
+    self.name     = kwargs[:name]
 
     file = SS::DownloadJobFile.new(user, filename)
     self.root = file.class.root
     self.path = file.path
-    self.url  = attr[:url] || file.url(name: name)
+    self.url  = kwargs[:url] || file.url(name: name)
   end
 
   class << self

--- a/app/models/gws/compressor.rb
+++ b/app/models/gws/compressor.rb
@@ -36,7 +36,7 @@ class Gws::Compressor
       return DEFAULT_MIN_COUNT unless deley_download.key?('min_count')
 
       ret = deley_download['min_count'].to_i
-      ret >= 0 ? ret : DEFAULT_MIN_FILESIZE
+      ret >= 0 ? ret : DEFAULT_MIN_COUNT
     end
 
     def min_filesize

--- a/spec/features/gws/share/files/download_all_spec.rb
+++ b/spec/features/gws/share/files/download_all_spec.rb
@@ -36,12 +36,16 @@ describe "gws_share_files", type: :feature, dbscope: :example, js: true do
 
     context "when zip file is created in background job" do
       before do
-        @save_config = SS.config.env.deley_download
-        SS.config.replace_value_at(:env, :deley_download, { "min_filesize" => 0, "min_count" => 0 })
+        @save_min_filesize = Gws::Compressor.min_filesize
+        @save_min_count = Gws::Compressor.min_count
+
+        Gws::Compressor.min_filesize = 0
+        Gws::Compressor.min_count = 0
       end
 
       after do
-        SS.config.replace_value_at(:env, :deley_download, @save_config)
+        Gws::Compressor.min_filesize = @save_min_filesize
+        Gws::Compressor.min_count = @save_min_count
       end
 
       it do

--- a/spec/features/gws/share/folders_spec.rb
+++ b/spec/features/gws/share/folders_spec.rb
@@ -251,12 +251,16 @@ describe "gws_share_folders", type: :feature, dbscope: :example, js: true do
 
     context "when zip file is created in background job" do
       before do
-        @save_config = SS.config.env.deley_download
-        SS.config.replace_value_at(:env, :deley_download, { "min_filesize" => 0, "min_count" => 0 })
+        @save_min_filesize = Gws::Compressor.min_filesize
+        @save_min_count = Gws::Compressor.min_count
+
+        Gws::Compressor.min_filesize = 0
+        Gws::Compressor.min_count = 0
       end
 
       after do
-        SS.config.replace_value_at(:env, :deley_download, @save_config)
+        Gws::Compressor.min_filesize = @save_min_filesize
+        Gws::Compressor.min_count = @save_min_count
       end
 
       it do

--- a/spec/features/gws/workflow/files/csv_download_spec.rb
+++ b/spec/features/gws/workflow/files/csv_download_spec.rb
@@ -161,7 +161,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
     end
 
     context "too match files to download" do
-      let(:file_count) { SS.config.env.deley_download['min_count'].to_i }
+      let(:file_count) { Gws::Compressor.min_count }
 
       before do
         file_ids = []

--- a/spec/features/gws/workflow/files/csv_download_spec.rb
+++ b/spec/features/gws/workflow/files/csv_download_spec.rb
@@ -142,7 +142,7 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
       end
     end
 
-    context "all files download" do
+    context "all files download on the fly" do
       it do
         visit gws_workflow_files_path(site: site, state: "all")
         wait_for_event_fired("ss:checked-all-list-items") { find(".gws-workflow .list-head input[type=checkbox]").click }
@@ -156,22 +156,89 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
         entry_names = ::Zip::File.open(downloads.first) do |entries|
           entries.map { |entry| entry.name }
         end
+        expect(entry_names).to have(2).items
+        expect(entry_names).to include(file1.download_filename, file2.download_filename)
+      end
+    end
+
+    context "all files download with job" do
+      before do
+        @save_min_filesize = Gws::Compressor.min_filesize
+        @save_min_count = Gws::Compressor.min_count
+
+        Gws::Compressor.min_filesize = 0
+        Gws::Compressor.min_count = 0
+      end
+
+      after do
+        Gws::Compressor.min_filesize = @save_min_filesize
+        Gws::Compressor.min_count = @save_min_count
+      end
+
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
+      end
+
+      it do
+        visit gws_workflow_files_path(site: site, state: "all")
+        wait_for_event_fired("ss:checked-all-list-items") { find(".gws-workflow .list-head input[type=checkbox]").click }
+
+        accept_confirm do
+          click_on I18n.t("gws/survey.buttons.zip_all_files")
+        end
+        wait_for_notice I18n.t('gws.notice.delay_download_with_message').split(/\R/).first
+
+        expect(Job::Log.all.count).to eq 1
+        Job::Log.all.each do |log|
+          expect(log.logs).to include(/INFO -- : .* Started Job/)
+          expect(log.logs).to include(/INFO -- : .* Completed Job/)
+        end
+
+        zip_file_path = nil
+        expect(SS::Notification.all.count).to eq 1
+        SS::Notification.all.first.tap do |notification|
+          expect(notification.member_ids).to include(gws_user.id)
+          expect(notification.subject).to eq I18n.t("gws/share.mailers.compressed.subject", locale: :ja)
+          expect(notification.format).to eq 'text'
+          expect(notification.text).to include("ダウンロードの準備が完了しました。")
+
+          match_data = notification.text.match(/^https?:\/\/\w+.+$/mi)
+          if match_data
+            zip_file_path = match_data.to_s
+            zip_file_path = Addressable::URI.parse(zip_file_path).path
+            zip_file_path = File.basename(zip_file_path)
+          end
+        end
+
+        zip_file = SS::DownloadJobFile.find(gws_user, zip_file_path)
+        entry_names = ::Zip::File.open(zip_file.path) do |entries|
+          entries.map { |entry| entry.name }
+        end
+        expect(entry_names).to have(2).items
         expect(entry_names).to include(file1.download_filename, file2.download_filename)
       end
     end
 
     context "too match files to download" do
-      let(:file_count) { Gws::Compressor.min_count }
-
       before do
-        file_ids = []
-        0.upto(file_count - item1.file_ids.length - 1).each do
-          file = tmp_ss_file(contents: '0123456789', user: admin)
-          file_ids << file.id
-        end
+        @save_min_filesize = Gws::Compressor.min_filesize
+        @save_min_count = Gws::Compressor.min_count
 
-        item1.file_ids = item1.file_ids + file_ids
-        item1.save!
+        Gws::Compressor.min_filesize = 0
+        Gws::Compressor.min_count = 0
+      end
+
+      after do
+        Gws::Compressor.min_filesize = @save_min_filesize
+        Gws::Compressor.min_count = @save_min_count
+      end
+
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
       end
 
       it do
@@ -182,13 +249,39 @@ describe Gws::Workflow::FilesController, type: :feature, dbscope: :example, js: 
         accept_confirm(I18n.t("ss.confirm.download")) do
           click_on I18n.t("gws/workflow.links.download_attachment")
         end
-
-        wait_for_notice I18n.t('gws.notice.delay_download_with_message').sub(/\n.*$/, '')
-        expect(enqueued_jobs.size).to eq 1
-        expect(enqueued_jobs.first[:job]).to eq Gws::CompressJob
+        wait_for_notice I18n.t('gws.notice.delay_download_with_message').split(/\R/).first
 
         # wait workflow route shown to avoid causing exceptions
         expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
+
+        expect(Job::Log.all.count).to eq 1
+        Job::Log.all.each do |log|
+          expect(log.logs).to include(/INFO -- : .* Started Job/)
+          expect(log.logs).to include(/INFO -- : .* Completed Job/)
+        end
+
+        zip_file_path = nil
+        expect(SS::Notification.all.count).to eq 1
+        SS::Notification.all.first.tap do |notification|
+          expect(notification.member_ids).to include(gws_user.id)
+          expect(notification.subject).to eq I18n.t("gws/share.mailers.compressed.subject", locale: :ja)
+          expect(notification.format).to eq 'text'
+          expect(notification.text).to include("ダウンロードの準備が完了しました。")
+
+          match_data = notification.text.match(/^https?:\/\/\w+.+$/mi)
+          if match_data
+            zip_file_path = match_data.to_s
+            zip_file_path = Addressable::URI.parse(zip_file_path).path
+            zip_file_path = File.basename(zip_file_path)
+          end
+        end
+
+        zip_file = SS::DownloadJobFile.find(gws_user, zip_file_path)
+        entry_names = ::Zip::File.open(zip_file.path) do |entries|
+          entries.map { |entry| entry.name }
+        end
+        expect(entry_names).to have(1).items
+        expect(entry_names).to include(file1.download_filename)
       end
     end
   end

--- a/spec/features/gws/workflow2/files/csv_download_spec.rb
+++ b/spec/features/gws/workflow2/files/csv_download_spec.rb
@@ -178,7 +178,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
       end
     end
 
-    context "all files download" do
+    context "all files download by generating a zip on the fly" do
       it do
         visit gws_workflow2_files_path(site: site, state: "all")
         wait_for_event_fired("ss:checked-all-list-items") { find(".gws-workflow .list-head input[type=checkbox]").click }
@@ -190,6 +190,66 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         wait_for_download
 
         entry_names = ::Zip::File.open(downloads.first) do |entries|
+          entries.map { |entry| entry.name }
+        end
+        expect(entry_names).to have(2).items
+        expect(entry_names).to include(file1.download_filename, file2.download_filename)
+      end
+    end
+
+    context "all files download by generating a zip by job" do
+      before do
+        @save_min_filesize = Gws::Compressor.min_filesize
+        @save_min_count = Gws::Compressor.min_count
+
+        Gws::Compressor.min_filesize = 0
+        Gws::Compressor.min_count = 0
+      end
+
+      after do
+        Gws::Compressor.min_filesize = @save_min_filesize
+        Gws::Compressor.min_count = @save_min_count
+      end
+
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
+      end
+
+      it do
+        visit gws_workflow2_files_path(site: site, state: "all")
+        wait_for_event_fired("ss:checked-all-list-items") { find(".gws-workflow .list-head input[type=checkbox]").click }
+
+        accept_confirm(I18n.t("ss.confirm.download")) do
+          click_on I18n.t("gws/survey.buttons.zip_all_files")
+        end
+        wait_for_notice I18n.t('gws.notice.delay_download_with_message').split(/\R/).first
+
+        expect(Job::Log.all.count).to eq 1
+        Job::Log.all.each do |log|
+          expect(log.logs).to include(/INFO -- : .* Started Job/)
+          expect(log.logs).to include(/INFO -- : .* Completed Job/)
+        end
+
+        zip_file_path = nil
+        expect(SS::Notification.all.count).to eq 1
+        SS::Notification.all.first.tap do |notification|
+          expect(notification.member_ids).to include(gws_user.id)
+          expect(notification.subject).to eq I18n.t("gws/share.mailers.compressed.subject", locale: :ja)
+          expect(notification.format).to eq 'text'
+          expect(notification.text).to include("ダウンロードの準備が完了しました。")
+
+          match_data = notification.text.match(/^https?:\/\/\w+.+$/mi)
+          if match_data
+            zip_file_path = match_data.to_s
+            zip_file_path = Addressable::URI.parse(zip_file_path).path
+            zip_file_path = File.basename(zip_file_path)
+          end
+        end
+
+        zip_file = SS::DownloadJobFile.find(gws_user, zip_file_path)
+        entry_names = ::Zip::File.open(zip_file.path) do |entries|
           entries.map { |entry| entry.name }
         end
         expect(entry_names).to have(2).items

--- a/spec/features/gws/workflow2/files/csv_download_spec.rb
+++ b/spec/features/gws/workflow2/files/csv_download_spec.rb
@@ -159,7 +159,7 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
   end
 
   context "attachments download" do
-    context "custom form file download" do
+    context "custom form file download on the fly" do
       it do
         visit gws_workflow2_files_path(site: site, state: "all")
         click_on item1.name
@@ -171,6 +171,66 @@ describe Gws::Workflow2::FilesController, type: :feature, dbscope: :example, js:
         wait_for_download
 
         entry_names = ::Zip::File.open(downloads.first) do |entries|
+          entries.map { |entry| entry.name }
+        end
+        expect(entry_names).to have(2).items
+        expect(entry_names).to include(file1.download_filename, file2.download_filename)
+      end
+    end
+
+    context "custom form file download with job" do
+      before do
+        @save_min_filesize = Gws::Compressor.min_filesize
+        @save_min_count = Gws::Compressor.min_count
+
+        Gws::Compressor.min_filesize = 0
+        Gws::Compressor.min_count = 0
+      end
+
+      after do
+        Gws::Compressor.min_filesize = @save_min_filesize
+        Gws::Compressor.min_count = @save_min_count
+      end
+
+      around do |example|
+        perform_enqueued_jobs do
+          example.run
+        end
+      end
+
+      it do
+        visit gws_workflow2_files_path(site: site, state: "all")
+        click_on item1.name
+        wait_for_turbo_frame "#workflow-approver-frame"
+        accept_confirm(I18n.t("ss.confirm.download")) do
+          click_on I18n.t("gws/workflow.links.download_attachment")
+        end
+        wait_for_notice I18n.t('gws.notice.delay_download_with_message').split(/\R/).first
+
+        expect(Job::Log.all.count).to eq 1
+        Job::Log.all.each do |log|
+          expect(log.logs).to include(/INFO -- : .* Started Job/)
+          expect(log.logs).to include(/INFO -- : .* Completed Job/)
+        end
+
+        zip_file_path = nil
+        expect(SS::Notification.all.count).to eq 1
+        SS::Notification.all.first.tap do |notification|
+          expect(notification.member_ids).to include(gws_user.id)
+          expect(notification.subject).to eq I18n.t("gws/share.mailers.compressed.subject", locale: :ja)
+          expect(notification.format).to eq 'text'
+          expect(notification.text).to include("ダウンロードの準備が完了しました。")
+
+          match_data = notification.text.match(/^https?:\/\/\w+.+$/mi)
+          if match_data
+            zip_file_path = match_data.to_s
+            zip_file_path = Addressable::URI.parse(zip_file_path).path
+            zip_file_path = File.basename(zip_file_path)
+          end
+        end
+
+        zip_file = SS::DownloadJobFile.find(gws_user, zip_file_path)
+        entry_names = ::Zip::File.open(zip_file.path) do |entries|
           entries.map { |entry| entry.name }
         end
         expect(entry_names).to have(2).items

--- a/spec/jobs/gws/comparess_job_spec.rb
+++ b/spec/jobs/gws/comparess_job_spec.rb
@@ -5,7 +5,7 @@ describe Gws::CompressJob, dbscope: :example do
   let(:user) { gws_user }
   let!(:file1) { create(:gws_share_file) }
   let(:zip) do
-    zip = Gws::Compressor.new(user, items: Gws::Share::File.site(site).all)
+    zip = Gws::Compressor.new(user, model: Gws::Share::File.name, items: Gws::Share::File.site(site).all)
     zip.url = Rails.application.routes.url_helpers.sns_download_job_files_url(
       host: "#{unique_id}.example.jp", user: zip.user, filename: zip.filename
     )

--- a/spec/jobs/gws/compress_job_spec.rb
+++ b/spec/jobs/gws/compress_job_spec.rb
@@ -9,7 +9,7 @@ describe Gws::CompressJob, dbscope: :example do
   describe '#perform' do
     context 'normal notify' do
       it do
-        zip = Gws::Compressor.new(user, items: files)
+        zip = Gws::Compressor.new(user, model: Gws::Share::File, items: files)
         zip.url = sns_download_job_files_url(host: 'localhost', user: zip.user, filename: zip.filename)
 
         job = Gws::CompressJob.bind(site_id: site.id, user_id: user.id)

--- a/spec/models/gws/compressor_spec.rb
+++ b/spec/models/gws/compressor_spec.rb
@@ -5,7 +5,7 @@ describe Gws::Compressor, type: :model, dbscope: :example do
   let(:files) { SS::File.in(id: [ file1.id, file2.id ]).order_by(id: 1) }
   let(:filename) { "#{unique_id}.zip" }
   let(:compressor) do
-    compressor = Gws::Compressor.new(user, items: files, filename: filename)
+    compressor = Gws::Compressor.new(user, model: SS::File.name, items: files, filename: filename)
     compressor.url = "http://#{unique_id}.example.jp/"
     compressor
   end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

添付ファイルダウンロードで空のZIPがダウンロードされる問題の修正

## 変更内容

- 類似の問題が他にもあったので修正。
- 問題の起きづらいインターフェースへ変更


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 圧縮処理の初期化方法を改め、対象ファイルのモデル指定と最小閾値の管理を明確化しました（動作や出力には影響なし）。

* **Tests**
  * バックグラウンドでのZIP生成や通知・ログ、生成ZIP内の内容検証を強化するなど、圧縮ワークフローをより詳細に確認するテストを追加・更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shirasagi/shirasagi/pull/6059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->