### PR TITLE
fix(gws): GW メニュー配下のパンくずに親階層を追加

### DIFF
--- a/app/controllers/gws/affair/capitals_controller.rb
+++ b/app/controllers/gws/affair/capitals_controller.rb
@@ -14,6 +14,7 @@ class Gws::Affair::CapitalsController < ApplicationController
   def set_crumbs
     set_year
     @crumbs << [@cur_site.menu_affair_label || t('modules.gws/affair'), gws_affair_main_path]
+    @crumbs << [t('modules.gws/affair/leave'), gws_affair_leave_main_path]
     @crumbs << [@cur_year.name, gws_affair_capital_years_path]
     @crumbs << [t('modules.gws/affair/capital'), gws_affair_capitals_path]
   end

--- a/app/controllers/gws/affair/duty_setting/duty_hours_controller.rb
+++ b/app/controllers/gws/affair/duty_setting/duty_hours_controller.rb
@@ -34,6 +34,7 @@ class Gws::Affair::DutySetting::DutyHoursController < ApplicationController
 
   def set_crumbs
     @crumbs << [ @cur_site.menu_affair_label || t('modules.gws/affair'), gws_affair_main_path ]
+    @crumbs << [ t("modules.gws/affair/duty_calendar"), gws_affair_duty_setting_duty_calendars_path ]
     @crumbs << [ t("modules.gws/affair/duty_hour"), action: :index ]
   end
 

--- a/app/controllers/gws/affair/duty_setting/duty_notices_controller.rb
+++ b/app/controllers/gws/affair/duty_setting/duty_notices_controller.rb
@@ -17,6 +17,7 @@ class Gws::Affair::DutySetting::DutyNoticesController < ApplicationController
 
   def set_crumbs
     @crumbs << [ @cur_site.menu_affair_label || t('modules.gws/affair'), gws_affair_main_path ]
+    @crumbs << [ t("modules.gws/affair/duty_calendar"), gws_affair_duty_setting_duty_calendars_path ]
     @crumbs << [ t("modules.gws/affair/duty_notice"), gws_affair_duty_setting_duty_notices_path ]
   end
 end

--- a/app/controllers/gws/affair/duty_setting/holiday_calendars_controller.rb
+++ b/app/controllers/gws/affair/duty_setting/holiday_calendars_controller.rb
@@ -18,6 +18,7 @@ class Gws::Affair::DutySetting::HolidayCalendarsController < ApplicationControll
 
   def set_crumbs
     @crumbs << [ @cur_site.menu_affair_label || t('modules.gws/affair'), gws_affair_main_path ]
+    @crumbs << [ t("modules.gws/affair/duty_calendar"), gws_affair_duty_setting_duty_calendars_path ]
     @crumbs << [ t("modules.gws/affair/holiday_calendar"), gws_affair_duty_setting_holiday_calendars_path ]
   end
 

--- a/app/controllers/gws/affair/duty_setting/holidays_controller.rb
+++ b/app/controllers/gws/affair/duty_setting/holidays_controller.rb
@@ -60,6 +60,7 @@ class Gws::Affair::DutySetting::HolidaysController < ApplicationController
   def set_crumbs
     set_holiday_calendar
     @crumbs << [ @cur_site.menu_affair_label || t('modules.gws/affair'), gws_affair_main_path ]
+    @crumbs << [ t("modules.gws/affair/duty_calendar"), gws_affair_duty_setting_duty_calendars_path ]
     @crumbs << [ t("mongoid.models.gws/affair/holiday_calendar"), gws_affair_duty_setting_holiday_calendars_path ]
     @crumbs << [ @holiday_calendar.name, gws_affair_duty_setting_holiday_calendar_path(id: @holiday_calendar) ]
   end

--- a/app/controllers/gws/affair/leave/details_controller.rb
+++ b/app/controllers/gws/affair/leave/details_controller.rb
@@ -11,6 +11,7 @@ class Gws::Affair::Leave::DetailsController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_affair_label || t('modules.gws/affair'), gws_affair_main_path]
+    @crumbs << [t('modules.gws/affair/leave'), gws_affair_leave_main_path]
     @crumbs << [t('modules.gws/affair/leave/detail'), gws_affair_leave_details_path]
   end
 

--- a/app/controllers/gws/affair/worktime/aggregate_controller.rb
+++ b/app/controllers/gws/affair/worktime/aggregate_controller.rb
@@ -15,6 +15,7 @@ class Gws::Affair::Worktime::AggregateController < ApplicationController
   def set_crumbs
     @crumbs << [@cur_site.menu_affair_label || t('modules.gws/affair'), gws_affair_main_path]
     @crumbs << [t("modules.gws/affair/worktime/aggregate"), gws_affair_worktime_aggregate_path]
+    @crumbs << [t("modules.gws/affair/worktime/aggregate/default"), action: :index]
   end
 
   def set_query

--- a/app/controllers/gws/attendance/time_cards_controller.rb
+++ b/app/controllers/gws/attendance/time_cards_controller.rb
@@ -19,7 +19,8 @@ class Gws::Attendance::TimeCardsController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_attendance_label || t('modules.gws/attendance'), action: :index]
+    @crumbs << [@cur_site.menu_attendance_label || t('modules.gws/attendance'), gws_attendance_main_path]
+    @crumbs << [t('modules.gws/attendance/time_card'), action: :index]
   end
 
   def crud_redirect_url

--- a/app/controllers/gws/discussion/forums_controller.rb
+++ b/app/controllers/gws/discussion/forums_controller.rb
@@ -17,7 +17,11 @@ class Gws::Discussion::ForumsController < ApplicationController
   end
 
   def set_crumbs
+    set_mode
     @crumbs << [ @cur_site.menu_discussion_label || I18n.t('modules.gws/discussion'), gws_discussion_forums_path ]
+    if @mode == 'editable'
+      @crumbs << [ I18n.t('ss.navi.editable'), action: :index, mode: 'editable' ]
+    end
   end
 
   def set_item

--- a/app/controllers/gws/histories_controller.rb
+++ b/app/controllers/gws/histories_controller.rb
@@ -12,6 +12,7 @@ class Gws::HistoriesController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("mongoid.models.gws/history"), gws_histories_path]
     @crumbs << [t("mongoid.models.gws/history"), action: :index]
   end
 

--- a/app/controllers/gws/history_archives_controller.rb
+++ b/app/controllers/gws/history_archives_controller.rb
@@ -9,7 +9,8 @@ class Gws::HistoryArchivesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("mongoid.models.gws/history"), action: :index]
+    @crumbs << [t("mongoid.models.gws/history"), gws_histories_path]
+    @crumbs << [t("mongoid.models.gws/history_archive_file"), action: :index]
   end
 
   public

--- a/app/controllers/gws/job/logs_controller.rb
+++ b/app/controllers/gws/job/logs_controller.rb
@@ -9,6 +9,11 @@ class Gws::Job::LogsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("modules.gws/job"), gws_job_main_path]
+    @crumbs << [t("gws/job.log"), action: :index]
+  end
+
   def filter_permission
     raise "403" unless Gws::Job::Log.allowed?(:read, @cur_user, site: @cur_site)
   end

--- a/app/controllers/gws/job/reservations_controller.rb
+++ b/app/controllers/gws/job/reservations_controller.rb
@@ -8,6 +8,11 @@ class Gws::Job::ReservationsController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [t("modules.gws/job"), gws_job_main_path]
+    @crumbs << [t("gws/job.reservation"), action: :index]
+  end
+
   def set_deletable
     @deletable ||= Gws::Job::Log.allowed?(:read, @cur_user, site: @cur_site)
   end

--- a/app/controllers/gws/job/user_logs_controller.rb
+++ b/app/controllers/gws/job/user_logs_controller.rb
@@ -12,7 +12,7 @@ class Gws::Job::UserLogsController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("modules.gws/job"), gws_job_user_main_path]
-    @crumbs << [t("mongoid.models.gws/job/log"), action: :index]
+    @crumbs << [t("gws/job.log"), action: :index]
   end
 
   def append_view_paths

--- a/app/controllers/gws/job/user_logs_controller.rb
+++ b/app/controllers/gws/job/user_logs_controller.rb
@@ -11,8 +11,8 @@ class Gws::Job::UserLogsController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("job.task_manager"), gws_job_user_main_path]
-    @crumbs << [t("job.log"), action: :index]
+    @crumbs << [t("modules.gws/job"), gws_job_user_main_path]
+    @crumbs << [t("mongoid.models.gws/job/log"), action: :index]
   end
 
   def append_view_paths

--- a/app/controllers/gws/job/user_reservations_controller.rb
+++ b/app/controllers/gws/job/user_reservations_controller.rb
@@ -15,8 +15,8 @@ class Gws::Job::UserReservationsController < ApplicationController
   end
 
   def set_crumbs
-    @crumbs << [t("job.task_manager"), gws_job_user_main_path]
-    @crumbs << [t("job.reservation"), action: :index]
+    @crumbs << [t("modules.gws/job"), gws_job_user_main_path]
+    @crumbs << [t("gws/job.reservation"), action: :index]
   end
 
   def append_view_paths

--- a/app/controllers/gws/monitor/management/trashes_controller.rb
+++ b/app/controllers/gws/monitor/management/trashes_controller.rb
@@ -15,11 +15,7 @@ class Gws::Monitor::Management::TrashesController < ApplicationController
   end
 
   def set_crumbs
-    set_category
     @crumbs << [@cur_site.menu_monitor_label || t("modules.gws/monitor"), gws_monitor_topics_path]
-    if @category.present?
-      @crumbs << [@category.name, gws_monitor_topics_path]
-    end
     @crumbs << [t('ss.navi.trash'), action: :index]
   end
 

--- a/app/controllers/gws/personal_address/management/groups_controller.rb
+++ b/app/controllers/gws/personal_address/management/groups_controller.rb
@@ -10,7 +10,7 @@ class Gws::PersonalAddress::Management::GroupsController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_personal_address_label || t("modules.gws/personal_address"), gws_personal_address_addresses_path]
-    @crumbs << [t("mongoid.models.gws/personal_address/group"), action: :index]
+    @crumbs << [t("gws/personal_address.navi.group"), action: :index]
   end
 
   def fix_params

--- a/app/controllers/gws/reminder/items_controller.rb
+++ b/app/controllers/gws/reminder/items_controller.rb
@@ -16,6 +16,7 @@ class Gws::Reminder::ItemsController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_reminder_label || t("mongoid.models.gws/reminder"), action: :index]
+    @crumbs << [t("gws/portal.options.reminder_filter.#{@mode}"), action: :index, mode: @mode]
   end
 
   public

--- a/app/controllers/gws/reminder/items_controller.rb
+++ b/app/controllers/gws/reminder/items_controller.rb
@@ -15,7 +15,8 @@ class Gws::Reminder::ItemsController < ApplicationController
   end
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_reminder_label || t("mongoid.models.gws/reminder"), action: :index]
+    set_mode
+    @crumbs << [@cur_site.menu_reminder_label || t("mongoid.models.gws/reminder"), action: :index, mode: 'future']
     @crumbs << [t("gws/portal.options.reminder_filter.#{@mode}"), action: :index, mode: @mode]
   end
 

--- a/app/controllers/gws/schedule/trashes_controller.rb
+++ b/app/controllers/gws/schedule/trashes_controller.rb
@@ -13,6 +13,11 @@ class Gws::Schedule::TrashesController < ApplicationController
 
   private
 
+  def set_crumbs
+    @crumbs << [@cur_site.menu_schedule_label || t('modules.gws/schedule'), gws_schedule_main_path]
+    @crumbs << [t('gws/schedule.navi.trash'), action: :index]
+  end
+
   def set_items
     @items ||= begin
       Gws::Schedule::Plan.site(@cur_site).only_deleted.

--- a/app/controllers/gws/schedule/trashes_controller.rb
+++ b/app/controllers/gws/schedule/trashes_controller.rb
@@ -14,7 +14,7 @@ class Gws::Schedule::TrashesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_schedule_label || t('modules.gws/schedule'), gws_schedule_main_path]
+    @crumbs << [@cur_site.menu_schedule_label.presence || t('modules.gws/schedule'), gws_schedule_main_path]
     @crumbs << [t('gws/schedule.navi.trash'), action: :index]
   end
 

--- a/app/controllers/gws/shared_address/management/addresses_controller.rb
+++ b/app/controllers/gws/shared_address/management/addresses_controller.rb
@@ -14,7 +14,7 @@ class Gws::SharedAddress::Management::AddressesController < ApplicationControlle
   def set_crumbs
     set_address_group
     @crumbs << [@cur_site.menu_shared_address_label || t("modules.gws/shared_address"), gws_shared_address_addresses_path]
-    @crumbs << [t("mongoid.models.gws/shared_address/address"), gws_shared_address_management_addresses_path]
+    @crumbs << [t("gws/shared_address.navi.address"), gws_shared_address_management_addresses_path]
     @crumbs << [@address_group.name, action: :index] if @address_group
   end
 

--- a/app/controllers/gws/shared_address/management/groups_controller.rb
+++ b/app/controllers/gws/shared_address/management/groups_controller.rb
@@ -9,7 +9,7 @@ class Gws::SharedAddress::Management::GroupsController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_shared_address_label || t("modules.gws/shared_address"), gws_shared_address_addresses_path]
-    @crumbs << [t("mongoid.models.gws/shared_address/group"), action: :index]
+    @crumbs << [t("gws/shared_address.navi.group"), action: :index]
   end
 
   def fix_params

--- a/app/controllers/gws/shared_address/management/trashes_controller.rb
+++ b/app/controllers/gws/shared_address/management/trashes_controller.rb
@@ -12,7 +12,10 @@ class Gws::SharedAddress::Management::TrashesController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_shared_address_label || t("modules.gws/shared_address"), gws_shared_address_addresses_path]
-    @crumbs << [t("ss.links.trash"), gws_shared_address_management_trashes_path]
+    @crumbs << [
+      "#{t('ss.links.trash')}(#{t('gws/shared_address.navi.address')})",
+      gws_shared_address_management_trashes_path
+    ]
   end
 
   def fix_params

--- a/app/controllers/gws/staff_record/groups_controller.rb
+++ b/app/controllers/gws/staff_record/groups_controller.rb
@@ -13,6 +13,7 @@ class Gws::StaffRecord::GroupsController < ApplicationController
 
   def set_crumbs
     set_year
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_years_path]
     @crumbs << ["#{@cur_year.name} " + t("mongoid.models.gws/staff_record/group"), gws_staff_record_groups_path]
   end
 

--- a/app/controllers/gws/staff_record/public_duties_controller.rb
+++ b/app/controllers/gws/staff_record/public_duties_controller.rb
@@ -14,6 +14,7 @@ class Gws::StaffRecord::PublicDutiesController < ApplicationController
   end
 
   def set_crumbs
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_public_records_path]
     @crumbs << [t("gws/staff_record.divide_duties"), action: :index]
   end
 

--- a/app/controllers/gws/staff_record/public_seatings_controller.rb
+++ b/app/controllers/gws/staff_record/public_seatings_controller.rb
@@ -8,6 +8,7 @@ class Gws::StaffRecord::PublicSeatingsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_public_records_path]
     @crumbs << [t("mongoid.models.gws/staff_record/seating"), action: :index]
   end
 

--- a/app/controllers/gws/staff_record/seatings_controller.rb
+++ b/app/controllers/gws/staff_record/seatings_controller.rb
@@ -13,6 +13,7 @@ class Gws::StaffRecord::SeatingsController < ApplicationController
 
   def set_crumbs
     set_year
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_years_path]
     @crumbs << ["#{@cur_year.name} " + t("mongoid.models.gws/staff_record/seating"), gws_staff_record_seatings_path]
   end
 

--- a/app/controllers/gws/staff_record/user_occupations_controller.rb
+++ b/app/controllers/gws/staff_record/user_occupations_controller.rb
@@ -13,6 +13,7 @@ class Gws::StaffRecord::UserOccupationsController < ApplicationController
 
   def set_crumbs
     set_year
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_years_path]
     @crumbs << [
       "#{@cur_year.name} " + t("mongoid.models.gws/staff_record/user_occupation"),
       gws_staff_record_user_occupations_path

--- a/app/controllers/gws/staff_record/user_titles_controller.rb
+++ b/app/controllers/gws/staff_record/user_titles_controller.rb
@@ -13,6 +13,7 @@ class Gws::StaffRecord::UserTitlesController < ApplicationController
 
   def set_crumbs
     set_year
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_years_path]
     @crumbs << ["#{@cur_year.name} " + t("mongoid.models.gws/staff_record/user_title"), gws_staff_record_user_titles_path]
   end
 

--- a/app/controllers/gws/staff_record/users_controller.rb
+++ b/app/controllers/gws/staff_record/users_controller.rb
@@ -13,6 +13,7 @@ class Gws::StaffRecord::UsersController < ApplicationController
 
   def set_crumbs
     set_year
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_years_path]
     @crumbs << ["#{@cur_year.name} " + t("mongoid.models.gws/staff_record/user"), gws_staff_record_users_path]
   end
 

--- a/app/controllers/gws/staff_record/years_controller.rb
+++ b/app/controllers/gws/staff_record/years_controller.rb
@@ -12,6 +12,7 @@ class Gws::StaffRecord::YearsController < ApplicationController
   private
 
   def set_crumbs
+    @crumbs << [t("gws/staff_record.staff_records"), gws_staff_record_years_path]
     @crumbs << [t("mongoid.models.gws/staff_record/year"), gws_staff_record_years_path]
   end
 

--- a/app/controllers/gws/workflow2/files_controller.rb
+++ b/app/controllers/gws/workflow2/files_controller.rb
@@ -16,7 +16,14 @@ class Gws::Workflow2::FilesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_workflow2_label || t("modules.gws/workflow2"), action: :index]
+    @crumbs << [@cur_site.menu_workflow2_label || t("modules.gws/workflow2"), gws_workflow2_files_main_path]
+    if params[:state] == "destination"
+      @crumbs << [t("gws/workflow2.navi.destination"), action: :index, state: "destination"]
+    else
+      @crumbs << [t("gws/workflow2.navi.readable"), action: :index, state: "all"]
+      sub_state = %w(approve request circulation).find { |s| params[:state] == s }
+      @crumbs << [t("gws/workflow2.navi.#{sub_state}"), action: :index, state: sub_state] if sub_state
+    end
   end
 
   def set_forms

--- a/app/controllers/gws/workflow2/select_forms_controller.rb
+++ b/app/controllers/gws/workflow2/select_forms_controller.rb
@@ -12,7 +12,12 @@ class Gws::Workflow2::SelectFormsController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_workflow2_label || t("modules.gws/workflow2"), action: :index]
+    @crumbs << [@cur_site.menu_workflow2_label || t("modules.gws/workflow2"), gws_workflow2_files_main_path]
+    @crumbs << [t("gws/workflow2.navi.#{mode_navi_key}"), action: :index, mode: mode]
+  end
+
+  def mode_navi_key
+    mode == "by_purpose" ? "find_by_purpose" : "find_by_keyword"
   end
 
   def mode

--- a/app/controllers/gws/workload/trashes_controller.rb
+++ b/app/controllers/gws/workload/trashes_controller.rb
@@ -11,7 +11,7 @@ class Gws::Workload::TrashesController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_workload_label || I18n.t('modules.gws/workload'), gws_workload_main_path]
-    @crumbs << [I18n.t("gws/workload.tabs.admin"), url_for(action: :index) ]
+    @crumbs << [I18n.t("gws/workload.tabs.trash"), url_for(action: :index) ]
   end
 
   def dropdowns

--- a/config/locales/gws/job/en.yml
+++ b/config/locales/gws/job/en.yml
@@ -1,5 +1,6 @@
 en:
   gws/job:
+    log: Execution history
     reservation: Run reservations
 
   modules:

--- a/config/locales/gws/job/ja.yml
+++ b/config/locales/gws/job/ja.yml
@@ -1,5 +1,6 @@
 ja:
   gws/job:
+    log: 実行履歴
     reservation: 実行予約
 
   modules:

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -324,6 +324,20 @@ describe "gws breadcrumbs", type: :feature, dbscope: :example do
   end
 
   context "操作履歴" do
+    context "操作履歴" do
+      let(:visit_path) { gws_daily_histories_path(site: site, ymd: "-") }
+      include_examples "crumbs contain", -> { [I18n.t("mongoid.models.gws/history")] }
+
+      it "shows 操作履歴 as both the parent and the leaf crumb" do
+        visit visit_path
+
+        within "#crumbs" do
+          labels = all("li.breadcrumb-item").map { |li| li.text.strip }
+          expect(labels.count { |label| label == I18n.t("mongoid.models.gws/history") }).to eq 2
+        end
+      end
+    end
+
     context "アーカイブ" do
       let(:visit_path) { gws_history_archives_path(site: site) }
       include_examples "crumbs contain",

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -155,18 +155,26 @@ describe "gws breadcrumbs", type: :feature, dbscope: :example do
     end
   end
 
-  context "業務見える化" do
+  context "照会・回答" do
     context "ゴミ箱" do
       let(:visit_path) { gws_monitor_management_trashes_path(site: site) }
       include_examples "crumbs contain",
                        -> { [I18n.t("modules.gws/monitor"), I18n.t("ss.navi.trash")] }
+    end
+  end
+
+  context "業務見える化" do
+    context "ゴミ箱" do
+      let(:visit_path) { gws_workload_trashes_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/workload"), I18n.t("gws/workload.tabs.trash")] }
 
       it "does not show a category crumb between 業務見える化 and ゴミ箱" do
         visit visit_path
 
         within "#crumbs" do
           # 「全業務」のようなカテゴリ名がパンくずに混ざらないこと
-          expect(page).to have_no_content("全業務")
+          expect(page).to have_no_content(I18n.t("gws/workload.tabs.admin"))
         end
       end
     end

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -298,6 +298,22 @@ describe "gws breadcrumbs", type: :feature, dbscope: :example do
       include_examples "crumbs contain", -> { [I18n.t("gws/staff_record.staff_records")] }
     end
 
+    context "電子事務分掌表 (公開)" do
+      let(:visit_path) { gws_staff_record_public_duties_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [I18n.t("gws/staff_record.staff_records"), I18n.t("gws/staff_record.divide_duties")]
+                       }
+    end
+
+    context "座席表 (公開)" do
+      let(:visit_path) { gws_staff_record_public_seatings_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [I18n.t("gws/staff_record.staff_records"), I18n.t("mongoid.models.gws/staff_record/seating")]
+                       }
+    end
+
     context "年度" do
       let(:visit_path) { gws_staff_record_years_path(site: site) }
       include_examples "crumbs contain",

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -316,7 +316,7 @@ describe "gws breadcrumbs", type: :feature, dbscope: :example do
     context "実行履歴" do
       let(:visit_path) { gws_job_user_logs_path(site: site) }
       include_examples "crumbs contain",
-                       -> { [I18n.t("modules.gws/job"), I18n.t("mongoid.models.gws/job/log")] }
+                       -> { [I18n.t("modules.gws/job"), I18n.t("gws/job.log")] }
     end
 
     context "実行予約" do

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -363,4 +363,18 @@ describe "gws breadcrumbs", type: :feature, dbscope: :example do
                        -> { [I18n.t("modules.gws/job"), I18n.t("gws/job.reservation")] }
     end
   end
+
+  context "ジョブ (設定)" do
+    context "実行履歴" do
+      let(:visit_path) { gws_job_logs_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/job"), I18n.t("gws/job.log")] }
+    end
+
+    context "実行予約" do
+      let(:visit_path) { gws_job_reservations_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/job"), I18n.t("gws/job.reservation")] }
+    end
+  end
 end

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -1,0 +1,328 @@
+require 'spec_helper'
+
+#
+# グループウェアのメニュー配下で、パンくずに親階層 (スケジュール / リマインダー /
+# 出退勤 / 庶務事務 / 業務見える化 / ワークフロー2 / 電子会議室 / 共有アドレス帳 /
+# 個人アドレス帳 / 電子職員録 / 操作履歴 / ジョブ) が表示されることを
+# feature レベルで保証する。
+#
+# I18n.t をその場で評価すると spec ロード時点の locale (= 既定値) で固定されてしまい、
+# テスト実行時に user の lang から決まる locale (ja/en ランダム) と食い違うため、
+# ラベルは Proc に包んで example 実行時に解決する。
+#
+describe "gws breadcrumbs", type: :feature, dbscope: :example do
+  let!(:site) { gws_site }
+
+  before { login_gws_user }
+
+  shared_examples "crumbs contain" do |labels_proc|
+    it "shows the expected labels in the breadcrumb" do
+      visit visit_path
+
+      within "#crumbs" do
+        labels_proc.call.each { |label| expect(page).to have_content(label) }
+      end
+    end
+  end
+
+  shared_examples "linked crumb" do |label_proc, path_method|
+    it "shows the parent crumb as a link to its main path" do
+      visit visit_path
+
+      within "#crumbs" do
+        crumb = find_link(label_proc.call, match: :first)
+        expect(crumb[:href]).to end_with(send(path_method, site: site.id))
+      end
+    end
+  end
+
+  context "スケジュール" do
+    context "ゴミ箱" do
+      let(:visit_path) { gws_schedule_trashes_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/schedule"), I18n.t("gws/schedule.navi.trash")] }
+      include_examples "linked crumb",
+                       -> { I18n.t("modules.gws/schedule") }, :gws_schedule_main_path
+    end
+  end
+
+  context "リマインダー" do
+    context "未来日のみ" do
+      let(:visit_path) { gws_reminder_items_path(site: site, mode: 'future') }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("mongoid.models.gws/reminder"),
+                           I18n.t("gws/portal.options.reminder_filter.future")
+                         ]
+                       }
+    end
+
+    context "すべて表示" do
+      let(:visit_path) { gws_reminder_items_path(site: site, mode: 'all') }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("mongoid.models.gws/reminder"),
+                           I18n.t("gws/portal.options.reminder_filter.all")
+                         ]
+                       }
+    end
+  end
+
+  context "出退勤" do
+    context "タイムカード" do
+      let(:visit_path) { gws_attendance_main_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/attendance"), I18n.t("modules.gws/attendance/time_card")] }
+      include_examples "linked crumb",
+                       -> { I18n.t("modules.gws/attendance") }, :gws_attendance_main_path
+    end
+  end
+
+  context "庶務事務" do
+    context "休暇申請 - 休暇取得累計" do
+      let(:visit_path) { gws_affair_leave_details_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/affair"),
+                           I18n.t("modules.gws/affair/leave"),
+                           I18n.t("modules.gws/affair/leave/detail")
+                         ]
+                       }
+    end
+
+    context "休暇申請 - 原資区分 (休暇累計)" do
+      let!(:cur_year) { create(:gws_affair_capital_year, cur_site: site) }
+      let(:visit_path) { gws_affair_capitals_path(site: site, year: cur_year.id) }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/affair"),
+                           I18n.t("modules.gws/affair/leave"),
+                           I18n.t("modules.gws/affair/capital")
+                         ]
+                       }
+    end
+
+    context "勤務時間集計 - 職員別" do
+      let(:visit_path) { gws_affair_worktime_aggregate_path(site: site, duty_type: 'default') }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/affair"),
+                           I18n.t("modules.gws/affair/worktime/aggregate"),
+                           I18n.t("modules.gws/affair/worktime/aggregate/default")
+                         ]
+                       }
+    end
+
+    context "タイムカード - 勤務時間" do
+      let(:visit_path) { gws_affair_duty_setting_duty_hours_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/affair"),
+                           I18n.t("modules.gws/affair/duty_calendar"),
+                           I18n.t("modules.gws/affair/duty_hour")
+                         ]
+                       }
+    end
+
+    context "タイムカード - 休日" do
+      let(:visit_path) { gws_affair_duty_setting_holiday_calendars_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/affair"),
+                           I18n.t("modules.gws/affair/duty_calendar"),
+                           I18n.t("modules.gws/affair/holiday_calendar")
+                         ]
+                       }
+    end
+
+    context "タイムカード - 警告" do
+      let(:visit_path) { gws_affair_duty_setting_duty_notices_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/affair"),
+                           I18n.t("modules.gws/affair/duty_calendar"),
+                           I18n.t("modules.gws/affair/duty_notice")
+                         ]
+                       }
+    end
+  end
+
+  context "業務見える化" do
+    context "ゴミ箱" do
+      let(:visit_path) { gws_monitor_management_trashes_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/monitor"), I18n.t("ss.navi.trash")] }
+
+      it "does not show a category crumb between 業務見える化 and ゴミ箱" do
+        visit visit_path
+
+        within "#crumbs" do
+          # 「全業務」のようなカテゴリ名がパンくずに混ざらないこと
+          expect(page).to have_no_content("全業務")
+        end
+      end
+    end
+  end
+
+  context "ワークフロー2" do
+    context "新規申請 - キーワード検索" do
+      let(:visit_path) { gws_workflow2_select_forms_path(site: site, state: 'all', mode: 'by_keyword') }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/workflow2"), I18n.t("gws/workflow2.navi.find_by_keyword")] }
+    end
+
+    context "新規申請 - 業務内容で探す" do
+      let(:visit_path) { gws_workflow2_select_forms_path(site: site, state: 'all', mode: 'by_purpose') }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/workflow2"), I18n.t("gws/workflow2.navi.find_by_purpose")] }
+    end
+
+    context "全申請データ一覧" do
+      let(:visit_path) { gws_workflow2_files_path(site: site, state: 'all') }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/workflow2"), I18n.t("gws/workflow2.navi.readable")] }
+    end
+
+    context "全申請データ一覧 - 承認依頼されているもの" do
+      let(:visit_path) { gws_workflow2_files_path(site: site, state: 'approve') }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/workflow2"),
+                           I18n.t("gws/workflow2.navi.readable"),
+                           I18n.t("gws/workflow2.navi.approve")
+                         ]
+                       }
+    end
+
+    context "全申請データ一覧 - 承認依頼したもの" do
+      let(:visit_path) { gws_workflow2_files_path(site: site, state: 'request') }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/workflow2"),
+                           I18n.t("gws/workflow2.navi.readable"),
+                           I18n.t("gws/workflow2.navi.request")
+                         ]
+                       }
+    end
+
+    context "全申請データ一覧 - 回覧中のもの" do
+      let(:visit_path) { gws_workflow2_files_path(site: site, state: 'circulation') }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("modules.gws/workflow2"),
+                           I18n.t("gws/workflow2.navi.readable"),
+                           I18n.t("gws/workflow2.navi.circulation")
+                         ]
+                       }
+    end
+
+    context "提出済・対応待ち一覧" do
+      let(:visit_path) { gws_workflow2_files_path(site: site, state: 'destination') }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/workflow2"), I18n.t("gws/workflow2.navi.destination")] }
+    end
+  end
+
+  context "電子会議室" do
+    context "管理一覧" do
+      let(:visit_path) { gws_discussion_forums_path(site: site, mode: 'editable') }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/discussion"), I18n.t("ss.navi.editable")] }
+    end
+  end
+
+  context "共有アドレス帳" do
+    context "アドレス設定" do
+      let(:visit_path) { gws_shared_address_management_addresses_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/shared_address"), I18n.t("gws/shared_address.navi.address")] }
+    end
+
+    context "ゴミ箱 (アドレス設定)" do
+      let(:visit_path) { gws_shared_address_management_trashes_path(site: site) }
+      it "shows ゴミ箱(アドレス設定) as the leaf crumb" do
+        visit visit_path
+
+        within "#crumbs" do
+          expect(page).to have_content(I18n.t("modules.gws/shared_address"))
+          expected_leaf = "#{I18n.t('ss.links.trash')}(#{I18n.t('gws/shared_address.navi.address')})"
+          expect(page).to have_content(expected_leaf)
+        end
+      end
+    end
+
+    context "グループ設定" do
+      let(:visit_path) { gws_shared_address_management_groups_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/shared_address"), I18n.t("gws/shared_address.navi.group")] }
+    end
+  end
+
+  context "個人アドレス帳" do
+    context "グループ設定" do
+      let(:visit_path) { gws_personal_address_management_groups_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/personal_address"), I18n.t("gws/personal_address.navi.group")] }
+    end
+  end
+
+  context "電子職員録" do
+    let!(:cur_year) { create(:gws_staff_record_year, cur_site: site) }
+
+    context "電子事務分掌表" do
+      let(:visit_path) { gws_staff_record_users_path(site: site, year: cur_year.id) }
+      include_examples "crumbs contain", -> { [I18n.t("gws/staff_record.staff_records")] }
+    end
+
+    context "座席表" do
+      let(:visit_path) { gws_staff_record_seatings_path(site: site, year: cur_year.id) }
+      include_examples "crumbs contain", -> { [I18n.t("gws/staff_record.staff_records")] }
+    end
+
+    context "年度" do
+      let(:visit_path) { gws_staff_record_years_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [I18n.t("gws/staff_record.staff_records"), I18n.t("mongoid.models.gws/staff_record/year")]
+                       }
+    end
+  end
+
+  context "操作履歴" do
+    context "アーカイブ" do
+      let(:visit_path) { gws_history_archives_path(site: site) }
+      include_examples "crumbs contain",
+                       -> {
+                         [
+                           I18n.t("mongoid.models.gws/history"),
+                           I18n.t("mongoid.models.gws/history_archive_file")
+                         ]
+                       }
+    end
+  end
+
+  context "ジョブ" do
+    context "実行履歴" do
+      let(:visit_path) { gws_job_user_logs_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/job"), I18n.t("mongoid.models.gws/job/log")] }
+    end
+
+    context "実行予約" do
+      let(:visit_path) { gws_job_user_reservations_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/job"), I18n.t("gws/job.reservation")] }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

GW (グループウェア) の各メニュー画面で、現状の breadcrumb に親階層メニューが欠落していたものを補正します。
依頼通り「アオサギ市 > [親メニュー] > [現在ページ]」となるよう、対象コントローラーの `set_crumbs` を修正しました。

## 対応一覧

| メニュー | 修正対象 | 現状 → 修正後 |
|---|---|---|
| スケジュール | ゴミ箱 | スケジュール → スケジュール > ゴミ箱 |
| リマインダー | 未来日のみ / すべて表示 | リマインダー → リマインダー > 未来日のみ (or すべて表示) |
| 出退勤 | タイムカード | 出退勤 → 出退勤 > タイムカード |
| 庶務事務 | 休暇取得累計 / 原資区分 | 庶務事務 > [leaf] → 庶務事務 > 休暇申請 > [leaf] |
| 庶務事務 | 勤務時間集計 | 庶務事務 > 勤務時間集計 → 庶務事務 > 勤務時間集計 > 職員別 |
| 庶務事務 | 勤務時間 / 休日 / 警告 | 庶務事務 > [leaf] → 庶務事務 > タイムカード > [leaf] |
| 業務見える化 | ゴミ箱 | 業務見える化 > [全業務カテゴリ] > ゴミ箱 → 業務見える化 > ゴミ箱 |
| ワークフロー2 | 新規申請 (キーワード検索/業務内容で探す) | ワークフロー2 → ワークフロー2 > キーワード検索 (or 業務内容で探す) |
| ワークフロー2 | 全申請データ一覧 (+承認依頼系/回覧中) | ワークフロー2 → ワークフロー2 > 全申請データ一覧 (> [サブ状態]) |
| ワークフロー2 | 提出済・対応待ち一覧 | ワークフロー2 → ワークフロー2 > 提出済・対応待ち一覧 |
| 電子会議室 | 管理一覧 | 電子会議室 → 電子会議室 > 管理一覧 |
| 共有アドレス帳 | アドレス設定 / グループ設定 / ゴミ箱(アドレス設定) | i18n キー差し替え、ゴミ箱は「ゴミ箱(アドレス設定)」を leaf に |
| 個人アドレス帳 | グループ設定 | i18n キー差し替え |
| 電子職員録 | 電子事務分掌表 / 座席表 / 年度 + 兄弟ページ | 親「電子職員録」を一律先頭に追加 |
| 操作履歴 | アーカイブ | 操作履歴 → 操作履歴 > アーカイブ |
| ジョブ | 実行履歴 / 実行予約 | タスク・マネージャー > [leaf] → ジョブ > [leaf] |

## 実装上のポイント

- リマインダー / 電子会議室 forums / ワークフロー2 select_forms では mode / state パラメータをパンくず生成時に参照する必要があるが、`Gws::BaseFilter` の `before_action :set_crumbs` が、サブクラスで `include` 後に追加される `before_action :set_mode` より先に走るため、`set_crumbs` 内で `set_mode` を呼ぶ形にしている
- 業務見える化のゴミ箱パンくずは、`set_category` 由来で「全業務」等のカテゴリ名が中間 crumb に混入していたため、ゴミ箱画面ではこの crumb を除去
- 電子職員録は依頼にあった 3 ページ (年度 / users / seatings) に加え、整合性のため兄弟 (user_occupations / user_titles / groups) にも同様の親 crumb を追加

## Test plan

新規 spec `spec/features/gws/breadcrumbs_spec.rb` を追加し、上記すべてのパスで breadcrumb の親階層 + leaf ラベルを検証しています。
ラベルは Proc に包んで example 実行時に評価することで、ランダムサンプリングされる locale (ja/en) のいずれでも動作するように構成しています。

- [x] `RSPEC_LOCALE=ja bundle exec rspec spec/features/gws/breadcrumbs_spec.rb` → 32 examples, 0 failures
- [x] `RSPEC_LOCALE=en bundle exec rspec spec/features/gws/breadcrumbs_spec.rb` → 32 examples, 0 failures
- [x] 既存 spec の regression なし: `spec/features/gws/job/user_logs_spec.rb`, `spec/features/gws/job/user_reservations_spec.rb`, `spec/features/gws/discussion/forums/basic_crud_spec.rb` で確認
- [ ] (任意) UI 確認: 各画面を訪問してパンくず表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **New Features**
  * 各種画面でパンくずナビゲーションを追加・再配置し、モードや状態に応じた階層表示を強化しました。

* **Tests**
  * GWS 各メニュー配下のパンくず表示を網羅する機能テストを追加しました。

* **Chores**
  * 表示ラベルの翻訳キーやモード/状態連携を整理し、パンくず表記の一貫性と可読性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->