### PR TITLE
[modify][gws]アンケート集計グラフのサイズを最大500px・センター寄せに調整

### DIFF
--- a/app/assets/stylesheets/gws/survey/_gws.scss
+++ b/app/assets/stylesheets/gws/survey/_gws.scss
@@ -148,6 +148,8 @@
     }
   }
   .chart {
+    max-width: 500px;
+    margin: 0 auto;
     padding: 15px 10px;
   }
   .btn-download {


### PR DESCRIPTION
## 改善内容

グループウェアのアンケート集計のグラフが大きいため、サイズを調整しました。

最大 500px・センター寄せで表示するようにしています。

https://demo.ss-proj.org/.g51/survey/-/-/editables/6a1ca4c0bb93d1f908db9868/files/summary

<img width="1673" height="995" alt="スクリーンショット 2026-06-16 14 50 58（2）" src="https://github.com/user-attachments/assets/47d57023-f1b9-4b2c-b157-b4498227b860" />


<img width="924" height="985" alt="スクリーンショット 2026-06-16 14 51 08（2）" src="https://github.com/user-attachments/assets/21811454-340a-4d8b-b940-a4f902c7e23e" />


## 変更内容

**変更ファイル:** `app/assets/stylesheets/gws/survey/_gws.scss`

```scss
.chart {
  max-width: 500px;   // 追加: 最大幅を500pxに制限
  margin: 0 auto;     // 追加: センター寄せ
  padding: 15px 10px;
}
```

## 仕組み・選定理由

- 集計グラフは `app/views/gws/survey/editable_files/_summary.html.erb` で Chart.js（円グラフ）として描画され、`options: { responsive: true }` が指定されているため、canvas は親要素 `.chart` の幅にあわせて自動リサイズされます。
- そのため、親コンテナ `.chart` に `max-width: 500px` を設定するだけで、グラフが最大 500px に収まり、それより広い画面では 500px で頭打ちになります。
- `margin: 0 auto` でセンター寄せにしています。
- この `.chart` ルールは `.gws-survey` 配下にネストされているため、**アンケート（survey）画面のグラフにのみ**適用され、他機能のグラフには影響しません。

https://claude.ai/code/session_01LjEaPebrgEjky9oxW2wbAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjEaPebrgEjky9oxW2wbAx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル改善**
  * GWS調査のチャート表示が改善されました。チャートの最大横幅を制限し、画面中央に自動的に配置されるよう調整されました。これにより、より整理された一貫したレイアウト表示が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->