### PR TITLE
[feat][gws]Tabularのキーワード検索で選択肢カラムの値を検索対象にする

### DIFF
--- a/app/models/gws/tabular/column/enum_field.rb
+++ b/app/models/gws/tabular/column/enum_field.rb
@@ -32,6 +32,7 @@ class Gws::Tabular::Column::EnumField < Gws::Column::Base
     field_name = store_as_in_file
     file_model.field field_name, type: SS::Extensions::Words
     file_model.permit_params field_name => []
+    file_model.keyword_fields << field_name
     file_model.before_validation do
       values = send(field_name)
       if values

--- a/spec/models/gws/tabular/file/enum_field_spec.rb
+++ b/spec/models/gws/tabular/file/enum_field_spec.rb
@@ -123,6 +123,26 @@ describe Gws::Tabular::File, type: :model, dbscope: :example do
       end
     end
 
+    context "keyword search" do
+      let(:input_type) { "radio" }
+      let(:column1_value) { select_options.sample }
+
+      let!(:item) do
+        item = file_model.new(cur_site: site, cur_space: space, cur_form: form)
+        item.send("col_#{column1.id}=", Array(column1_value))
+        item.save!
+        item
+      end
+
+      it "finds the item by its enum value" do
+        expect(file_model.search(keyword: column1_value).pluck(:id)).to include(item.id)
+      end
+
+      it "does not find the item by an unrelated keyword" do
+        expect(file_model.search(keyword: "not-#{unique_id}").pluck(:id)).not_to include(item.id)
+      end
+    end
+
     context "#to_liquid" do
       let(:item) do
         item = file_model.new(cur_site: site, cur_space: space, cur_form: form)


### PR DESCRIPTION
## 概要

GWS Tabular のファイル一覧（右上のキーワード検索ボックス）で、選択肢（Enum: ラジオ / チェックボックス / プルダウン）カラムの値が検索でヒットしない問題を修正します。

## 原因

キーワード検索（`s[keyword]`）は `keyword_fields` に登録されたフィールドだけを正規表現の部分一致で検索します（`app/models/concerns/ss/scope/base.rb` の `keyword_in`）。

- テキスト / 数値 / ルックアップカラムは `configure_file` 内で `keyword_fields << field_name` を行っており検索対象になっている
- 一方、**選択肢（EnumField）カラムは `keyword_fields` に登録していなかった**ため、その値は一切検索対象にならなかった

このため、例えば選択肢カラムに格納された「ホンダ」は検索でヒットせず、テキストカラムの「配達」はヒットする、という挙動になっていました。文字種（カタカナ / 漢字）は無関係です。

## 修正内容

`app/models/gws/tabular/column/enum_field.rb` の `configure_file` に、他のカラム種別と同じ 1 行を追加し、選択肢カラムのフィールドを `keyword_fields` に登録します。

```ruby
file_model.field field_name, type: SS::Extensions::Words
file_model.permit_params field_name => []
file_model.keyword_fields << field_name   # 追加
```

`SS::Extensions::Words` は配列ですが、MongoDB の正規表現マッチは配列要素のいずれかに一致すればヒットします。Enum の格納値は選択肢ラベルそのものなので、入力どおりに検索できます。

## テスト

`spec/models/gws/tabular/file/enum_field_spec.rb` に、選択肢の値で検索してヒットすること / 無関係なキーワードではヒットしないことを確認するモデルテストを追加しました。

https://claude.ai/code/session_01GzfKAfkeP5ZTvXnaTm9AZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzfKAfkeP5ZTvXnaTm9AZC)_