### PR TITLE
[fix] nil error if gws site is selected as a from address

### DIFF
--- a/app/controllers/sys/diag/mails_controller.rb
+++ b/app/controllers/sys/diag/mails_controller.rb
@@ -42,9 +42,12 @@ class Sys::Diag::MailsController < ApplicationController
       id = id.to_i
       case type
       when "cms"
-        SS.cms_sites(cur_user).find { _1.id == id }.sender_address
+        site = SS.cms_sites(cur_user).find { _1.id == id }
+        site.sender_address
       when "gws"
-        SS.gws_sites(cur_user).find { _1.id == id }.sender_address
+        site = SS.gws_sites(cur_user).find { _1.id == id }
+        site = site.gws_group
+        site.sender_address
       else
         nil
       end

--- a/app/views/sys/diag/mails/index.html.erb
+++ b/app/views/sys/diag/mails/index.html.erb
@@ -5,14 +5,14 @@
 
 <% from_site_options = capture do %>
   <% if cms_sites.present? %>
-    <optgroup label=<%= t "cms.site" %>>
+    <optgroup label="<%= t "cms.site" %>">
       <% cms_sites.each do |cms_site| %>
         <option value="cms:<%= cms_site.id %>" data-description="<%= cms_site.sender_address %>"><%= cms_site.name %></option>
       <% end %>
     </optgroup>
   <% end %>
   <% if gws_sites.present? %>
-    <optgroup label=<%= t "gws.group" %>>
+    <optgroup label="<%= t "gws.group" %>">
       <% gws_sites.each do |gws_site| %>
         <option value="gws:<%= gws_site.id %>" data-description="<%= gws_site.sender_address %>"><%= gws_site.name %></option>
       <% end %>

--- a/app/views/sys/diag/mails/index.html.erb
+++ b/app/views/sys/diag/mails/index.html.erb
@@ -4,16 +4,20 @@
 %>
 
 <% from_site_options = capture do %>
-  <optgroup label=<%= t "cms.site" %>>
-    <% cms_sites.each do |cms_site| %>
-      <option value="cms:<%= cms_site.id %>" data-description="<%= cms_site.sender_address %>"><%= cms_site.name %></option>
-    <% end %>
-  </optgroup>
-  <optgroup label=<%= t "gws.group" %>>
-    <% gws_sites.each do |gws_site| %>
-      <option value="gws:<%= gws_site.id %>" data-description="<%= gws_site.sender_address %>"><%= gws_site.name %></option>
-    <% end %>
-  </optgroup>
+  <% if cms_sites.present? %>
+    <optgroup label=<%= t "cms.site" %>>
+      <% cms_sites.each do |cms_site| %>
+        <option value="cms:<%= cms_site.id %>" data-description="<%= cms_site.sender_address %>"><%= cms_site.name %></option>
+      <% end %>
+    </optgroup>
+  <% end %>
+  <% if gws_sites.present? %>
+    <optgroup label=<%= t "gws.group" %>>
+      <% gws_sites.each do |gws_site| %>
+        <option value="gws:<%= gws_site.id %>" data-description="<%= gws_site.sender_address %>"><%= gws_site.name %></option>
+      <% end %>
+    </optgroup>
+  <% end %>
 <% end %>
 
 <%= form_for :item, url: { action: :create }, html: { id: "item-form", multipart: true } do |f| %>
@@ -21,21 +25,28 @@
     <article id="http-tester">
       <div class="view">
         <h2>Mail From</h2>
-        <div class="input-group gap-5 align-items-center">
-          <label style="display: inline-flex; align-items: center; word-break: keep-all;">
-            <%= f.radio_button :from_type, "site" %> サイトから選択:
-          </label>
-          <span data-controller="ss--select-with-description">
-            <%= f.select :from_site, from_site_options %>
-            <span class="description"></span>
-          </span>
-        </div>
-        <div class="input-group gap-5 align-items-center">
-          <label style="display: inline-flex; align-items: center; word-break: keep-all;">
-            <%= f.radio_button :from_type, "manual" %> 手動で入力:
-          </label>
-          <%= f.text_field :from_manual %>
-        </div>
+        <% if from_site_options.present? %>
+          <div class="input-group gap-5 align-items-center">
+            <label style="display: inline-flex; align-items: center; word-break: keep-all;">
+              <%= f.radio_button :from_type, "site" %> サイトから選択:
+            </label>
+            <span data-controller="ss--select-with-description">
+              <%= f.select :from_site, from_site_options %>
+              <span class="description"></span>
+            </span>
+          </div>
+          <div class="input-group gap-5 align-items-center">
+            <label style="display: inline-flex; align-items: center; word-break: keep-all;">
+              <%= f.radio_button :from_type, "manual" %> 手動で入力:
+            </label>
+            <%= f.text_field :from_manual %>
+          </div>
+        <% else %>
+          <div>
+            <%= f.hidden_field :from_type, value: "manual", id: nil %>
+            <%= f.text_field :from_manual %>
+          </div>
+        <% end %>
 
         <h2>Mail To</h2>
         <div><%= f.text_field :to %></div>

--- a/spec/features/sys/diag/mails_spec.rb
+++ b/spec/features/sys/diag/mails_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "sys_diag_mails", type: :feature, dbscope: :example, js: true do
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  after do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  context "with gws site as a from address" do
+    let!(:group) { create :gws_group, sender_name: unique_id, sender_email: unique_email }
+
+    before do
+      sys_user.add_to_set(group_ids: group.id)
+    end
+
+    it do
+      login_sys_user to: sys_diag_mails_path
+      within "form#item-form" do
+        select group.name, from: "item[from_site]"
+        click_on I18n.t("ss.buttons.send")
+      end
+      wait_for_notice "Sent Successfully"
+
+      expect(ActionMailer::Base.deliveries.length).to eq 1
+      mail = ActionMailer::Base.deliveries.first
+      expect(mail.from.first).to eq group.sender_email
+      expect(mail.to.first).to eq sys_user.email
+      expect(mail_subject(mail)).to eq "TEST MAIL"
+      expect(mail_body(mail)).to include("Message")
+      expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
+    end
+  end
+end

--- a/spec/features/sys/diag/mails_spec.rb
+++ b/spec/features/sys/diag/mails_spec.rb
@@ -9,6 +9,85 @@ describe "sys_diag_mails", type: :feature, dbscope: :example, js: true do
     ActionMailer::Base.deliveries.clear
   end
 
+  context "without sites" do
+    let(:from) { unique_email }
+
+    it do
+      login_sys_user to: sys_diag_mails_path
+      within "form#item-form" do
+        fill_in "item[from_manual]", with: from
+        click_on I18n.t("ss.buttons.send")
+      end
+      wait_for_notice "Sent Successfully"
+
+      expect(ActionMailer::Base.deliveries.length).to eq 1
+      mail = ActionMailer::Base.deliveries.first
+      expect(mail.from.first).to eq from
+      expect(mail.to.first).to eq sys_user.email
+      expect(mail_subject(mail)).to eq "TEST MAIL"
+      expect(mail_body(mail)).to include("Message")
+      expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
+    end
+  end
+
+  context "with manual from" do
+    let!(:group) { create :sys_group }
+    let!(:site) do
+      create :cms_site_unique, sender_name: unique_id, sender_email: unique_email, group_ids: [ group.id ]
+    end
+    let(:from) { unique_email }
+
+    before do
+      sys_user.add_to_set(group_ids: group.id)
+    end
+
+    it do
+      login_sys_user to: sys_diag_mails_path
+      within "form#item-form" do
+        choose "手動で入力"
+        fill_in "item[from_manual]", with: from
+        click_on I18n.t("ss.buttons.send")
+      end
+      wait_for_notice "Sent Successfully"
+
+      expect(ActionMailer::Base.deliveries.length).to eq 1
+      mail = ActionMailer::Base.deliveries.first
+      expect(mail.from.first).to eq from
+      expect(mail.to.first).to eq sys_user.email
+      expect(mail_subject(mail)).to eq "TEST MAIL"
+      expect(mail_body(mail)).to include("Message")
+      expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
+    end
+  end
+
+  context "with cms site as a from address" do
+    let!(:group) { create :sys_group }
+    let!(:site) do
+      create :cms_site_unique, sender_name: unique_id, sender_email: unique_email, group_ids: [ group.id ]
+    end
+
+    before do
+      sys_user.add_to_set(group_ids: group.id)
+    end
+
+    it do
+      login_sys_user to: sys_diag_mails_path
+      within "form#item-form" do
+        select site.name, from: "item[from_site]"
+        click_on I18n.t("ss.buttons.send")
+      end
+      wait_for_notice "Sent Successfully"
+
+      expect(ActionMailer::Base.deliveries.length).to eq 1
+      mail = ActionMailer::Base.deliveries.first
+      expect(mail.from.first).to eq site.sender_email
+      expect(mail.to.first).to eq sys_user.email
+      expect(mail_subject(mail)).to eq "TEST MAIL"
+      expect(mail_body(mail)).to include("Message")
+      expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
+    end
+  end
+
   context "with gws site as a from address" do
     let!(:group) { create :gws_group, sender_name: unique_id, sender_email: unique_email }
 

--- a/spec/features/sys/diag/main_spec.rb
+++ b/spec/features/sys/diag/main_spec.rb
@@ -1,39 +1,17 @@
 require 'spec_helper'
 
-describe "sys_test", type: :feature, dbscope: :example, js: true do
-  subject(:index_path) { sys_diag_main_path }
-
-  before do
-    ActionMailer::Base.deliveries.clear
-  end
-
-  after do
-    ActionMailer::Base.deliveries.clear
-  end
-
-  it "without auth" do
-    login_ss_user to: index_path
-    expect(page).to have_title(/403 Forbidden/)
+describe "sys_test", type: :feature, dbscope: :example do
+  context "without auth" do
+    it do
+      login_ss_user to: sys_diag_main_path
+      expect(page).to have_title(/403 Forbidden/)
+    end
   end
 
   context "with auth" do
-    let(:from) { unique_email }
     it do
-      login_sys_user to: index_path
-      within "form#item-form" do
-        choose "手動で入力"
-        fill_in "item[from_manual]", with: from
-        click_on I18n.t("ss.buttons.send")
-      end
-      wait_for_notice "Sent Successfully"
-
-      expect(ActionMailer::Base.deliveries.length).to eq 1
-      mail = ActionMailer::Base.deliveries.first
-      expect(mail.from.first).to eq from
-      expect(mail.to.first).to eq sys_user.email
-      expect(mail_subject(mail)).to eq "TEST MAIL"
-      expect(mail_body(mail)).to include("Message")
-      expect(mail.message_id).to end_with("@#{SS.config.gws.canonical_domain}.mail")
+      login_sys_user to: sys_diag_main_path
+      expect(current_path).to eq sys_diag_mails_path
     end
   end
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

サイトから選択でグループウェアサイトを選択すると nil エラーが発生するのを修正


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 診断メール送信時の送信元アドレス取得を修正。GWSグループ経由の送信元を優先して取得するようにしました。

* **改善**
  * メール送信フォームの送信元選択UIを改善。CMSサイトとGWSグループがある場合にoptgroupで選択肢を表示し、送信元が無い場合は手動入力のみ表示します。

* **Tests**
  * 診断メール送信のfeatureテストを追加（複数パターン検証）。既存のメインspecは検証内容を簡略化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->