### PR TITLE
[fix][gws] グループウェアのサイドメニューの表示文言とアイコンを変更

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1028,8 +1028,21 @@ _:future,
     }
 
     &.search {
-      background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23888888'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 33px center;
-      background-size: 16px 16px;
+      position: relative;
+      background: none;
+
+      &::before {
+        // Material Icons Outlined: search
+        content: "\e8b6";
+        font-family: "Material Icons Outlined";
+        font-size: 18px;
+        line-height: 1;
+        color: #888888;
+        position: absolute;
+        top: 50%;
+        left: 34px;
+        transform: translateY(-50%);
+      }
     }
 
     &:hover {
@@ -1050,8 +1063,11 @@ _:future,
     }
 
     &.search:hover {
-      background: init.$gray1 url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23f25a38'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 33px center;
-      background-size: 16px 16px;
+      background: init.$gray1;
+
+      &::before {
+        color: init.$orange;
+      }
     }
   }
   h3 a {
@@ -1173,13 +1189,29 @@ _:future,
       }
 
       &.search {
-        background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23888888'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 58px center;
-        background-size: 16px 16px;
+        position: relative;
+        background: none;
+
+        &::before {
+          // Material Icons Outlined: search
+          content: "\e8b6";
+          font-family: "Material Icons Outlined";
+          font-size: 18px;
+          line-height: 1;
+          color: #888888;
+          position: absolute;
+          top: 50%;
+          left: 59px;
+          transform: translateY(-50%);
+        }
       }
 
       &.search:hover {
-        background: init.$gray1 url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23f25a38'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 58px center;
-        background-size: 16px 16px;
+        background: init.$gray1;
+
+        &::before {
+          color: init.$orange;
+        }
       }
     }
   }
@@ -1201,6 +1233,10 @@ _:future,
       span {
         padding: 5px 15px 5px 35px;
         background-position: 15px center;
+      }
+
+      a.search::before {
+        left: 15px;
       }
     }
   }

--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1037,7 +1037,6 @@ _:future,
         font-family: "Material Icons Outlined";
         font-size: 18px;
         line-height: 1;
-        color: #888888;
         position: absolute;
         top: 50%;
         left: 34px;
@@ -1198,7 +1197,6 @@ _:future,
           font-family: "Material Icons Outlined";
           font-size: 18px;
           line-height: 1;
-          color: #888888;
           position: absolute;
           top: 50%;
           left: 59px;

--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1027,6 +1027,11 @@ _:future,
       background: url(/assets/img/ic-trash.png) no-repeat 35px center;
     }
 
+    &.search {
+      background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23888888'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 33px center;
+      background-size: 16px 16px;
+    }
+
     &:hover {
       background: init.$gray1 url(/assets/img/ic-arrow16-on.png) no-repeat 35px
         center;
@@ -1042,6 +1047,11 @@ _:future,
 
     &.trash:hover {
       background: init.$gray1 url(/assets/img/ic-trash.png) no-repeat 35px center;
+    }
+
+    &.search:hover {
+      background: init.$gray1 url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23f25a38'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 33px center;
+      background-size: 16px 16px;
     }
   }
   h3 a {
@@ -1161,6 +1171,16 @@ _:future,
       &.management:hover {
         background: init.$gray1 url(/assets/img/ic-setting.png) no-repeat 60px center;
       }
+
+      &.search {
+        background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23888888'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 58px center;
+        background-size: 16px 16px;
+      }
+
+      &.search:hover {
+        background: init.$gray1 url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='%23f25a38'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 58px center;
+        background-size: 16px 16px;
+      }
     }
   }
   .navi-link:hover {
@@ -1176,6 +1196,8 @@ _:future,
       a:hover.management,
       a.trash,
       a:hover.trash,
+      a.search,
+      a:hover.search,
       span {
         padding: 5px 15px 5px 35px;
         background-position: 15px center;

--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1037,10 +1037,10 @@ _:future,
         position: absolute;
         top: 50%;
         left: 34px;
+        transform: translateY(-50%);
         font-family: "Material Icons Outlined";
         font-size: 18px;
         line-height: 1;
-        transform: translateY(-50%);
       }
     }
 
@@ -1197,10 +1197,10 @@ _:future,
           position: absolute;
           top: 50%;
           left: 59px;
+          transform: translateY(-50%);
           font-family: "Material Icons Outlined";
           font-size: 18px;
           line-height: 1;
-          transform: translateY(-50%);
         }
       }
 

--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1034,12 +1034,12 @@ _:future,
       &::before {
         // Material Icons Outlined: search
         content: "\e8b6";
-        font-family: "Material Icons Outlined";
-        font-size: 18px;
-        line-height: 1;
         position: absolute;
         top: 50%;
         left: 34px;
+        font-family: "Material Icons Outlined";
+        font-size: 18px;
+        line-height: 1;
         transform: translateY(-50%);
       }
     }
@@ -1194,12 +1194,12 @@ _:future,
         &::before {
           // Material Icons Outlined: search
           content: "\e8b6";
-          font-family: "Material Icons Outlined";
-          font-size: 18px;
-          line-height: 1;
           position: absolute;
           top: 50%;
           left: 59px;
+          font-family: "Material Icons Outlined";
+          font-size: 18px;
+          line-height: 1;
           transform: translateY(-50%);
         }
       }

--- a/app/controllers/concerns/gws/base_filter.rb
+++ b/app/controllers/concerns/gws/base_filter.rb
@@ -2,6 +2,21 @@ module Gws::BaseFilter
   extend ActiveSupport::Concern
   include SS::BaseFilter
 
+  # 「設定」モジュール（旧「標準機能」）のサイドメニュー（conf_navi 系）を表示する
+  # コントローラの navi_view 一覧。これらのページに限り、パンくずへ「設定」階層を挿入する。
+  # 判定を navi_view に紐付けることで、設定モジュールのコントローラが増えても
+  # この一覧に追記するだけで追従できる。
+  SETTINGS_NAVI_VIEWS = %w(
+    gws/main/conf_navi
+    gws/user_conf/navi
+    gws/histories/navi
+    gws/search_form/main/conf_navi
+    gws/job/main/conf_navi
+    gws/ldap/main/navi
+    gws/tabular/gws/main/conf_navi
+    gws/elasticsearch/diagnostic/main/conf_navi
+  ).freeze
+
   included do
     self.user_class = Gws::User
     self.log_class = Gws::History
@@ -19,6 +34,9 @@ module Gws::BaseFilter
     # SS::BaseFilter#set_model の呼び出しはここ。set_current_site の後ろで set_crumbs の前
     before_action :set_model
     before_action :set_crumbs
+    # 各コントローラの set_crumbs で機能名 crumb が積まれた「後」に実行し、
+    # site crumb の直後へ「設定」を挿入する（set_conf_crumb 参照）。
+    before_action :set_conf_crumb
     after_action :put_history_log, if: ->{ @cur_user }
     navi_view "gws/main/navi"
   end
@@ -45,6 +63,24 @@ module Gws::BaseFilter
     @cur_site = SS.current_site = Gws::Group.find(params[:site])
     @cur_user.cur_site = @cur_site if @cur_user
     @crumbs << [@cur_site.name, gws_portal_path]
+  end
+
+  # 「設定」モジュール配下のページのパンくずに「設定」階層を挿入する。
+  #
+  # Gws::BaseFilter は全 GWS コントローラが include するため、無条件に挿入すると
+  # スケジュールやお知らせなど設定と無関係なページのパンくずにまで「設定」が
+  # 混入してしまう。そこで navi_view_file が設定系メニュー（SETTINGS_NAVI_VIEWS）
+  # のときに限定して挿入する。
+  #
+  # set_crumbs の後に実行され、site crumb の直後（index 1）へ挿入するため、
+  # 1 階層メニューは「サイト名 > 設定 > 機能」、多階層メニューは
+  # 「サイト名 > 設定 > 機能 > …」の並びになる。
+  # ラベルはサイドメニュー見出しと同じ gws.site_config（設定 / Settings）を用い、
+  # 「設定」のランディングページは存在しないためリンク無し（プレーンテキスト）とする。
+  def set_conf_crumb
+    return unless SETTINGS_NAVI_VIEWS.include?(navi_view_file)
+    return if @crumbs.blank?
+    @crumbs.insert(1, [t("gws.site_config")])
   end
 
   def set_current_group

--- a/app/controllers/concerns/gws/base_filter.rb
+++ b/app/controllers/concerns/gws/base_filter.rb
@@ -75,12 +75,14 @@ module Gws::BaseFilter
   # set_crumbs の後に実行され、site crumb の直後（index 1）へ挿入するため、
   # 1 階層メニューは「サイト名 > 設定 > 機能」、多階層メニューは
   # 「サイト名 > 設定 > 機能 > …」の並びになる。
-  # ラベルはサイドメニュー見出しと同じ gws.site_config（設定 / Settings）を用い、
-  # 「設定」のランディングページは存在しないためリンク無し（プレーンテキスト）とする。
+  # ラベルはサイドメニュー見出しと同じ gws.site_config（設定 / Settings）。
+  # 設定専用のランディングは無いが、他の crumb と見た目（breadcrumb-link）を
+  # 揃えるため、設定メニュー先頭の「組織情報」(gws_site_path) へのリンクとする
+  # （親モジュールの crumb を main ページへリンクする既存パターンに倣う）。
   def set_conf_crumb
     return unless SETTINGS_NAVI_VIEWS.include?(navi_view_file)
     return if @crumbs.blank?
-    @crumbs.insert(1, [t("gws.site_config")])
+    @crumbs.insert(1, [t("gws.site_config"), gws_site_path])
   end
 
   def set_current_group

--- a/app/controllers/gws/bookmark/items_controller.rb
+++ b/app/controllers/gws/bookmark/items_controller.rb
@@ -21,6 +21,7 @@ class Gws::Bookmark::ItemsController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_bookmark_label || t("mongoid.models.gws/bookmark/item"), action: :index]
+    @crumbs << [t("ss.navi.readable"), action: :index]
   end
 
   def set_item

--- a/app/controllers/gws/discussion/forums_controller.rb
+++ b/app/controllers/gws/discussion/forums_controller.rb
@@ -21,6 +21,8 @@ class Gws::Discussion::ForumsController < ApplicationController
     @crumbs << [ @cur_site.menu_discussion_label || I18n.t('modules.gws/discussion'), gws_discussion_forums_path ]
     if @mode == 'editable'
       @crumbs << [ I18n.t('ss.navi.editable'), action: :index, mode: 'editable' ]
+    else
+      @crumbs << [ I18n.t('ss.navi.readable'), action: :index, mode: 'readable' ]
     end
   end
 

--- a/app/controllers/gws/memo/messages_controller.rb
+++ b/app/controllers/gws/memo/messages_controller.rb
@@ -42,6 +42,7 @@ class Gws::Memo::MessagesController < ApplicationController
 
     set_cur_folder
     @crumbs << [@cur_site.menu_memo_label || t('mongoid.models.gws/memo/message'), gws_memo_messages_path ]
+    @crumbs << [t('gws/memo.navi.messages'), gws_memo_messages_path]
     if @cur_folder.folder_path != 'INBOX'
       @cur_folder.ancestor_or_self.each do |folder|
         @crumbs << [folder.current_name, gws_memo_messages_path(folder: folder.folder_path)]

--- a/app/controllers/gws/personal_address/addresses_controller.rb
+++ b/app/controllers/gws/personal_address/addresses_controller.rb
@@ -15,6 +15,7 @@ class Gws::PersonalAddress::AddressesController < ApplicationController
   def set_crumbs
     set_address_group
     @crumbs << [@cur_site.menu_personal_address_label || t("modules.gws/personal_address"), gws_personal_address_addresses_path]
+    @crumbs << [t("ss.navi.readable"), action: :index]
     @crumbs << [@address_group.name, action: :index] if @address_group
   end
 

--- a/app/controllers/gws/presence/custom_group/users_controller.rb
+++ b/app/controllers/gws/presence/custom_group/users_controller.rb
@@ -9,7 +9,8 @@ class Gws::Presence::CustomGroup::UsersController < ApplicationController
 
   def set_crumbs
     set_group
-    @crumbs << [t("modules.gws/presence"), gws_presence_users_path]
+    @crumbs << [t("modules.gws/presence"), gws_presence_main_path]
+    @crumbs << [t("modules.gws/presence/users"), gws_presence_users_path]
     @crumbs << [@custom_group.name, gws_presence_custom_group_users_path(group: @custom_group.id)]
   end
 

--- a/app/controllers/gws/presence/group/users_controller.rb
+++ b/app/controllers/gws/presence/group/users_controller.rb
@@ -9,7 +9,8 @@ class Gws::Presence::Group::UsersController < ApplicationController
 
   def set_crumbs
     set_group
-    @crumbs << [t("modules.gws/presence"), gws_presence_users_path]
+    @crumbs << [t("modules.gws/presence"), gws_presence_main_path]
+    @crumbs << [t("modules.gws/presence/users"), gws_presence_users_path]
     @crumbs << [@group.trailing_name, gws_presence_group_users_path(group: @group.id)]
   end
 

--- a/app/controllers/gws/presence/users_controller.rb
+++ b/app/controllers/gws/presence/users_controller.rb
@@ -7,7 +7,8 @@ class Gws::Presence::UsersController < ApplicationController
 
   def set_crumbs
     set_group
-    @crumbs << [t("modules.gws/presence"), gws_presence_users_path]
+    @crumbs << [t("modules.gws/presence"), gws_presence_main_path]
+    @crumbs << [t("modules.gws/presence/users"), gws_presence_users_path]
   end
 
   def set_group

--- a/app/controllers/gws/report/files_controller.rb
+++ b/app/controllers/gws/report/files_controller.rb
@@ -17,7 +17,8 @@ class Gws::Report::FilesController < ApplicationController
   def set_crumbs
     @crumbs << [@cur_site.menu_report_label || t('modules.gws/report'), action: :index]
     if params[:state].present?
-      @crumbs << [t("gws/report.options.file_state.#{params[:state]}"), gws_report_files_path(state: params[:state])]
+      label = params[:state] == 'closed' ? t('gws/report.navi.draft') : t("gws/report.options.file_state.#{params[:state]}")
+      @crumbs << [label, gws_report_files_path(state: params[:state])]
     end
   end
 

--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -27,6 +27,7 @@ class Gws::Share::FilesController < ApplicationController
   def set_crumbs
     set_folder
     @crumbs << [@cur_site.menu_share_label || t("mongoid.models.gws/share"), gws_share_files_path(category: params[:category])]
+    @crumbs << [t("ss.navi.readable"), gws_share_files_path(category: params[:category])]
     if @folder.present?
       folder_hierarchy_count = @folder.name.split("/").count - 1
       0.upto(folder_hierarchy_count) do |i|

--- a/app/controllers/gws/shared_address/addresses_controller.rb
+++ b/app/controllers/gws/shared_address/addresses_controller.rb
@@ -14,6 +14,7 @@ class Gws::SharedAddress::AddressesController < ApplicationController
   def set_crumbs
     set_address_group
     @crumbs << [@cur_site.menu_shared_address_label || t("modules.gws/shared_address"), gws_shared_address_addresses_path]
+    @crumbs << [t("ss.navi.readable"), action: :index]
     @crumbs << [@address_group.name, action: :index] if @address_group
   end
 

--- a/app/controllers/gws/survey/readables_controller.rb
+++ b/app/controllers/gws/survey/readables_controller.rb
@@ -27,7 +27,7 @@ class Gws::Survey::ReadablesController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_survey_label || t('modules.gws/survey'), gws_survey_main_path]
-    @crumbs << [t('ss.navi.readable'), action: :index, folder_id: '-', category_id: '-']
+    @crumbs << [t('gws/survey.navi.readable'), action: :index, folder_id: '-', category_id: '-']
   end
 
   def set_categories

--- a/app/controllers/gws/workflow/files_controller.rb
+++ b/app/controllers/gws/workflow/files_controller.rb
@@ -14,7 +14,13 @@ class Gws::Workflow::FilesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_workflow_label || t("modules.gws/workflow"), action: :index]
+    @crumbs << [@cur_site.menu_workflow_label || t("modules.gws/workflow"), gws_workflow_files_main_path]
+    sub_state = %w(approve request).find { |s| params[:state] == s }
+    if sub_state
+      @crumbs << [t("gws/workflow.options.file_state.#{sub_state}"), gws_workflow_files_path(state: sub_state)]
+    else
+      @crumbs << [t("ss.navi.readable"), gws_workflow_files_main_path]
+    end
   end
 
   def set_forms

--- a/app/controllers/gws/workflow2/form/applications_controller.rb
+++ b/app/controllers/gws/workflow2/form/applications_controller.rb
@@ -11,7 +11,8 @@ class Gws::Workflow2::Form::ApplicationsController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_workflow2_label || t('modules.gws/workflow2'), gws_workflow2_setting_path]
+    @crumbs << [@cur_site.menu_workflow2_label || t('modules.gws/workflow2'), gws_workflow2_files_main_path]
+    @crumbs << [t("gws/workflow2.navi.form.main"), gws_workflow2_setting_path]
     @crumbs << [t("gws/workflow2.navi.form.application"), url_for(action: :index)]
   end
 

--- a/app/controllers/gws/workflow2/form/categories_controller.rb
+++ b/app/controllers/gws/workflow2/form/categories_controller.rb
@@ -25,6 +25,7 @@ class Gws::Workflow2::Form::CategoriesController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_workflow2_label || t("modules.gws/workflow2"), gws_workflow2_files_main_path]
+    @crumbs << [t("gws/workflow2.navi.form.main"), gws_workflow2_setting_path]
     @crumbs << [t("gws/workflow2.navi.form.category"), url_for(action: :index)]
   end
 

--- a/app/controllers/gws/workflow2/form/externals_controller.rb
+++ b/app/controllers/gws/workflow2/form/externals_controller.rb
@@ -11,7 +11,8 @@ class Gws::Workflow2::Form::ExternalsController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [@cur_site.menu_workflow2_label || t('modules.gws/workflow2'), gws_workflow2_setting_path]
+    @crumbs << [@cur_site.menu_workflow2_label || t('modules.gws/workflow2'), gws_workflow2_files_main_path]
+    @crumbs << [t("gws/workflow2.navi.form.main"), gws_workflow2_setting_path]
     @crumbs << [t("gws/workflow2.navi.form.external"), url_for(action: :index)]
   end
 

--- a/app/controllers/gws/workflow2/form/purposes_controller.rb
+++ b/app/controllers/gws/workflow2/form/purposes_controller.rb
@@ -25,6 +25,7 @@ class Gws::Workflow2::Form::PurposesController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_workflow2_label || t("modules.gws/workflow2"), gws_workflow2_files_main_path]
+    @crumbs << [t("gws/workflow2.navi.form.main"), gws_workflow2_setting_path]
     @crumbs << [t("gws/workflow2.navi.form.purpose"), url_for(action: :index)]
   end
 

--- a/app/controllers/gws/workflow2/select_forms_controller.rb
+++ b/app/controllers/gws/workflow2/select_forms_controller.rb
@@ -13,6 +13,10 @@ class Gws::Workflow2::SelectFormsController < ApplicationController
 
   def set_crumbs
     @crumbs << [@cur_site.menu_workflow2_label || t("modules.gws/workflow2"), gws_workflow2_files_main_path]
+    @crumbs << [
+      t("gws/workflow2.navi.new_application"),
+      gws_workflow2_select_forms_path(state: "all", mode: "by_keyword")
+    ]
     @crumbs << [t("gws/workflow2.navi.#{mode_navi_key}"), action: :index, mode: mode]
   end
 

--- a/app/controllers/kana/dictionaries_controller.rb
+++ b/app/controllers/kana/dictionaries_controller.rb
@@ -9,7 +9,8 @@ class Kana::DictionariesController < ApplicationController
   private
 
   def set_crumbs
-    @crumbs << [t("kana.dictionary"), action: :index]
+    @crumbs << [t("modules.kana"), nil]
+    @crumbs << [t("kana.dictionary_list"), action: :index]
   end
 
   def fix_params

--- a/app/models/gws/schedule.rb
+++ b/app/models/gws/schedule.rb
@@ -125,7 +125,7 @@ module Gws::Schedule
 
     helpers = Rails.application.routes.url_helpers
     path_proc = ->(*args, **kwargs) { helpers.gws_schedule_search_path(*args, site: cur_site, **kwargs) }
-    SS::MenuItem.new(label: I18n.t('gws/schedule.tabs.search'), path_proc: path_proc)
+    SS::MenuItem.new(label: I18n.t('gws/schedule.tabs.search'), path_proc: path_proc, css_classes: %w(search))
   end
 
   def menu_item_gws_schedule_csv(cur_site, cur_user)

--- a/app/views/cms/main/_conf_navi.html.erb
+++ b/app/views/cms/main/_conf_navi.html.erb
@@ -42,7 +42,7 @@
     <h3><%= link_to t("cms.syntax_check"), cms_syntax_checker_main_path %></h3>
   <% end %>
   <% if SS.config.kana.disable.blank? && Kana::Dictionary.allowed?(:read, @cur_user, site: @cur_site) %>
-    <h3><%= link_to t("kana.dictionary"), kana_dictionaries_path %></h3>
+    <h3><%= link_to t("kana.dictionary_list"), kana_dictionaries_path %></h3>
   <% end %>
   <% if Chorg::Revision.allowed?(:read, @cur_user, site: @cur_site) %>
     <h3><%= link_to t("chorg.revision"), chorg_main_path %></h3>

--- a/app/views/gws/main/_conf_navi.html.erb
+++ b/app/views/gws/main/_conf_navi.html.erb
@@ -1,5 +1,5 @@
 <nav class="mod-navi main-features">
-  <h2><%= t "modules.gws" %></h2>
+  <h2><%= t "gws.site_config" %></h2>
   <% if @cur_user.gws_role_permit_any?(@cur_site, :read_gws_organization) %>
     <h3><%= link_to t('gws.site_info'), gws_site_path %></h3>
   <% end %>

--- a/app/views/gws/memo/messages/_navi.html.erb
+++ b/app/views/gws/memo/messages/_navi.html.erb
@@ -1,6 +1,6 @@
 <nav class="mod-navi current-navi">
   <%= gws_menu_icon(:memo, gws_memo_messages_path) %>
-  <h3><%= link_to t('modules.gws/memo'), gws_memo_messages_path %></h3>
+  <h3><%= link_to t('gws/memo.navi.messages'), gws_memo_messages_path %></h3>
   <h3><%= link_to t('mongoid.models.gws/memo/folder'), gws_memo_folders_path, class: "management" %></h3>
   <h3><%= link_to t('mongoid.models.gws/memo/filter'), gws_memo_filters_path, class: "management" %></h3>
   <h3><%= link_to t('mongoid.models.gws/memo/signature'), gws_memo_signatures_path, class: "management" %></h3>

--- a/app/views/gws/report/main/_navi.html.erb
+++ b/app/views/gws/report/main/_navi.html.erb
@@ -2,7 +2,7 @@
   <%= gws_menu_icon(:report, gws_report_files_main_path) %>
   <h3><%= link_to t('gws/report.options.file_state.inbox'), gws_report_files_path(state: 'inbox') %></h3>
   <h3><%= link_to t('gws/report.options.file_state.sent'), gws_report_files_path(state: 'sent') %></h3>
-  <h3><%= link_to t('gws/report.options.file_state.closed'), gws_report_files_path(state: 'closed') %></h3>
+  <h3><%= link_to t('gws/report.navi.draft'), gws_report_files_path(state: 'closed') %></h3>
   <h3><%= link_to t('gws/report.options.file_state.readable'), gws_report_files_path(state: 'readable') %></h3>
 
   <% if Gws::Report::File.allowed?(:trash, @cur_user, site: @cur_site) %>

--- a/app/views/gws/workflow2/main/_navi.html.erb
+++ b/app/views/gws/workflow2/main/_navi.html.erb
@@ -18,8 +18,8 @@
   <%= gws_menu_icon(:workflow2, gws_workflow2_files_main_path) %>
 
   <h3><%= link_to t('gws/workflow2.navi.new_application'), gws_workflow2_select_forms_path(state: "all", mode: "by_keyword") %></h3>
-  <h4><%= link_to t('gws/workflow2.navi.find_by_keyword'), gws_workflow2_select_forms_path(state: "all", mode: "by_keyword") %></h4>
-  <h4><%= link_to t('gws/workflow2.navi.find_by_purpose'), gws_workflow2_select_forms_path(state: "all", mode: "by_purpose") %></h4>
+  <h4 class="search"><%= link_to t('gws/workflow2.navi.find_by_keyword'), gws_workflow2_select_forms_path(state: "all", mode: "by_keyword") %></h4>
+  <h4 class="search"><%= link_to t('gws/workflow2.navi.find_by_purpose'), gws_workflow2_select_forms_path(state: "all", mode: "by_purpose") %></h4>
 
   <h3><%= link_to t('gws/workflow2.navi.readable'), gws_workflow2_files_path(state: :all) %></h3>
   <h4><%= link_to t('gws/workflow2.navi.approve'), gws_workflow2_files_path(state: :approve) %></h4>
@@ -35,7 +35,7 @@
   <% if workflow_form_lins.present? %>
     <h3><%= link_to t("gws/workflow2.navi.form.main"), sns_redirect_path(ref: workflow_form_lins.first[1]), class: "management" %></h3>
     <% workflow_form_lins.each do |label, path| %>
-      <h4><%= link_to label, path, class: "management" %></h4>
+      <h4 class="management"><%= link_to label, path, class: "management" %></h4>
     <% end %>
   <% end %>
 </nav>

--- a/app/views/kana/main/_conf_navi.html.erb
+++ b/app/views/kana/main/_conf_navi.html.erb
@@ -3,7 +3,7 @@
     <h2><%= t "modules.kana" %></h2>
 
     <% if Kana::Dictionary.allowed?(:read, @cur_user, site: @cur_site) %>
-      <h3><%= link_to t("kana.dictionary"), kana_dictionaries_path %></h3>
+      <h3><%= link_to t("kana.dictionary_list"), kana_dictionaries_path %></h3>
     <% end %>
     <% if Kana::Dictionary.allowed?(:build, @cur_user, site: @cur_site) %>
       <h3><%= link_to t("kana.diagnostic"), kana_diagnostic_path %></h3>

--- a/config/locales/gws/circular/en.yml
+++ b/config/locales/gws/circular/en.yml
@@ -2,8 +2,8 @@ en:
   gws/circular:
     setting: Settings for circulars
     tabs:
-      post: Received circulars
-      admin: Created circulars
+      post: Received list
+      admin: Management list
       trash: Trash
     links:
       back_to_admin: Back to created circulars

--- a/config/locales/gws/circular/ja.yml
+++ b/config/locales/gws/circular/ja.yml
@@ -2,8 +2,8 @@ ja:
   gws/circular:
     setting: 回覧板設定
     tabs:
-      post: 受信した回覧
-      admin: 作成した回覧
+      post: 受信一覧
+      admin: 管理一覧
       trash: ゴミ箱
     links:
       back_to_admin: 作成した回覧へ戻る

--- a/config/locales/gws/memo/en.yml
+++ b/config/locales/gws/memo/en.yml
@@ -4,6 +4,8 @@ en:
     no_subjects: 'No title'
     no_senders: 'No name'
     unseen: Unread
+    navi:
+      messages: Message list
     options:
       priority:
         '1': Highest

--- a/config/locales/gws/memo/ja.yml
+++ b/config/locales/gws/memo/ja.yml
@@ -4,6 +4,8 @@ ja:
     no_subjects: 'No title'
     no_senders: 'No name'
     unseen: 未読
+    navi:
+      messages: メッセージ一覧
     options:
       priority:
         '1': 最高

--- a/config/locales/gws/monitor/en.yml
+++ b/config/locales/gws/monitor/en.yml
@@ -150,9 +150,9 @@ en:
     errors:
       denied_comment: You are not allowed to post comments.
     tabs:
-      unanswer: Unanswered
-      answer: Answered
-      admin: Created inquiries
+      unanswer: Unanswered list
+      answer: Answered list
+      admin: Management list
       article_management: Inquiry (management)
       management_admin: Inquiry (management)
     management:

--- a/config/locales/gws/monitor/ja.yml
+++ b/config/locales/gws/monitor/ja.yml
@@ -150,9 +150,9 @@ ja:
     errors:
       denied_comment: コメントの投稿は許可されていません。
     tabs:
-      unanswer: 未回答
-      answer: 回答済み
-      admin: 作成した設問
+      unanswer: 未回答一覧
+      answer: 回答済み一覧
+      admin: 管理一覧
       article_management: 設問（管理）
       management_admin: 設問（管理）
     management:

--- a/config/locales/gws/report/en.yml
+++ b/config/locales/gws/report/en.yml
@@ -1,5 +1,7 @@
 en:
   gws/report:
+    navi:
+      draft: Draft list
     links:
       publish: Send
       depublish: Cancel sending

--- a/config/locales/gws/report/ja.yml
+++ b/config/locales/gws/report/ja.yml
@@ -1,5 +1,7 @@
 ja:
   gws/report:
+    navi:
+      draft: 下書き一覧
     links:
       publish: 送信する
       depublish: 送信を取り消す

--- a/config/locales/gws/survey/en.yml
+++ b/config/locales/gws/survey/en.yml
@@ -40,7 +40,7 @@ en:
     buttons:
       zip_all_files: Attached file
     navi:
-      readable: Inbox
+      readable: Received list
 
   gws_role:
     use_gws_survey: Use of questionnaires

--- a/config/locales/gws/survey/ja.yml
+++ b/config/locales/gws/survey/ja.yml
@@ -40,7 +40,7 @@ ja:
     buttons:
       zip_all_files: 添付ファイル
     navi:
-      readable: 受信トレイ
+      readable: 受信一覧
 
   gws_role:
     use_gws_survey: アンケートの利用

--- a/config/locales/gws/workflow2/en.yml
+++ b/config/locales/gws/workflow2/en.yml
@@ -40,7 +40,7 @@ en:
       purposes:
         index: Select a purpose
     navi:
-      new_application: New
+      new_application: Create new application
       find_by_keyword: By Keyword
       find_by_purpose: By Business
       readable: All Applications

--- a/config/locales/gws/workflow2/ja.yml
+++ b/config/locales/gws/workflow2/ja.yml
@@ -40,7 +40,7 @@ ja:
       purposes:
         index: 目的別を選択する
     navi:
-      new_application: 新規申請
+      new_application: 新規申請作成
       find_by_keyword: キーワード検索
       find_by_purpose: 業務内容で探す
       readable: 全申請データ一覧

--- a/config/locales/kana/ja.yml
+++ b/config/locales/kana/ja.yml
@@ -1,6 +1,7 @@
 ja:
   kana:
     dictionary: かな辞書
+    dictionary_list: かな辞書一覧
     diagnostic: 診断
     build_start: 辞書の作成を開始しました。
     build_success: 辞書の作成に成功しました。
@@ -21,7 +22,7 @@ ja:
         build_description: 以下のかな辞書から辞書をビルドし、システムに反映します。
 
   modules:
-    kana: かな
+    kana: かな辞書
 
   cms_role:
     read_kana_dictionaries: かな辞書の閲覧

--- a/config/locales/ss/en.yml
+++ b/config/locales/ss/en.yml
@@ -134,7 +134,7 @@ en:
       unseen: Unread list
       seen: Read list
       trash: Trash
-      calendar: Calendar
+      calendar: Calendar view
     links:
       add: Add
       cms: Site management

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -134,7 +134,7 @@ ja:
       unseen: 未読一覧
       seen: 既読一覧
       trash: ゴミ箱
-      calendar: カレンダー
+      calendar: カレンダー表示
     links:
       add: 追加する
       cms: サイト管理

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -377,4 +377,24 @@ describe "gws breadcrumbs", type: :feature, dbscope: :example do
                        -> { [I18n.t("modules.gws/job"), I18n.t("gws/job.reservation")] }
     end
   end
+
+  # 「設定」モジュール配下のページでは、サイト名と機能名の間に「設定」階層が入ること。
+  context "設定" do
+    context "組織情報" do
+      let(:visit_path) { gws_site_path(site: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("gws.site_config"), I18n.t("gws.site_info")] }
+    end
+
+    # 設定モジュール以外のページには「設定」階層が混入しないこと（リグレッション）。
+    context "設定モジュール外には混入しない" do
+      let(:visit_path) { gws_schedule_trashes_path(site: site) }
+      it "does not insert the 設定 crumb on non-settings pages" do
+        visit visit_path
+        within "#crumbs" do
+          expect(page).to have_no_content(I18n.t("gws.site_config"))
+        end
+      end
+    end
+  end
 end

--- a/spec/features/gws/breadcrumbs_spec.rb
+++ b/spec/features/gws/breadcrumbs_spec.rb
@@ -397,4 +397,13 @@ describe "gws breadcrumbs", type: :feature, dbscope: :example do
       end
     end
   end
+
+  # 在席管理は「在席管理 > 在席状況 > グループ」とサイドメニューの階層に合わせる。
+  context "在席管理" do
+    context "在席状況 (グループ)" do
+      let(:visit_path) { gws_presence_group_users_path(site: site, group: site) }
+      include_examples "crumbs contain",
+                       -> { [I18n.t("modules.gws/presence"), I18n.t("modules.gws/presence/users")] }
+    end
+  end
 end

--- a/spec/features/gws/survey/categories_spec.rb
+++ b/spec/features/gws/survey/categories_spec.rb
@@ -68,7 +68,9 @@ describe "gws_survey_categories", type: :feature, dbscope: :example, js: true do
     context "readable" do
       it do
         visit gws_survey_main_path(site: site)
-        click_on I18n.t("gws/survey.navi.readable")
+        within ".current-navi" do
+          click_on I18n.t("gws/survey.navi.readable")
+        end
 
         within ".list-items" do
           expect(page).to have_css(".list-item", text: form1.name)


### PR DESCRIPTION
## 概要

グループウェアのサイドメニューについて、変更案に基づき **(1) 表示文言の変更**、**(2) アイコンの変更**、**(3) パンくず（breadcrumb）の整合・階層追加** を行いました。「アイコン変更」と記載された項目はシラサギで利用されている既存アイコンを利用し、それ以外は表示文言のみの変更です。

あわせて、CMS サイト設定の「かな」メニューについても表示文言とパンくずの整合を行っています（**4. かな辞書メニューの整合（CMS）** 参照）。

## 1. 表示文言の変更（サイドメニュー）

| 機能 | 変更前 → 変更後 | 変更箇所 |
|---|---|---|
| お知らせ | カレンダー → **カレンダー表示** | `ss` `navi.calendar` |
| メッセージ | メッセージ → **メッセージ一覧** | `gws/memo` に `navi.messages` を新設 |
| レポート | 下書き → **下書き一覧** | `gws/report` に `navi.draft` を新設 |
| ワークフロー2 | 新規申請 → **新規申請作成** | `gws/workflow2` `navi.new_application` |
| 回覧板 | 受信した回覧 → **受信一覧** / 作成した回覧 → **管理一覧** | `gws/circular` `tabs.post` / `tabs.admin` |
| 照会・回答 | 未回答 → **未回答一覧** / 回答済み → **回答済み一覧** / 作成した設問 → **管理一覧** | `gws/monitor` `tabs.*` |
| アンケート | 受信トレイ → **受信一覧** | `gws/survey` `navi.readable` |

## 2. アイコンの変更（シラサギ既存アイコンを利用）

- **虫眼鏡（Material Icons Outlined の `search` / コードポイント `U+E8B6`）**: スケジュール「検索」、ワークフロー2「キーワード検索」「業務内容で探す」
  - `::before` の `content: &#34;\e8b6&#34;` + `font-family: &#34;Material Icons Outlined&#34;` で**コードポイント表示**（既存の `.icon-material::before` と同じ方式）。色はリンク文字色を継承し、ホバー時オレンジ。`.search` クラスを新設（h3 / h4・hover・モバイル対応）。
- **歯車（既存 `ic-setting.png`）**: ワークフロー2「申請フォーム設定」配下の各項目（`<h4>` に `management` クラスを付与）。

## 3. パンくずの整合・階層追加

**(a) 文言変更に追従したパンくずの整合**
- メッセージ：`メッセージ &gt; メッセージ一覧` を表示（`set_crumbs` にリーフ追加）。
- レポート：`state=closed` のリーフを `下書き` → `下書き一覧`。
- アンケート：readable のリーフを `ss.navi.readable`（閲覧一覧）→ `gws/survey.navi.readable`（受信一覧）に変更しメニューと一致。
- お知らせ（カレンダー表示）・回覧板・照会回答は、メニューと同一の i18n キーをパンくずでも参照しているため自動で反映。

**(b) 不足していた階層の追加**
- 一覧（閲覧一覧）階層の追加：**お気に入り / 共有ファイル / 電子会議室 / 共有アドレス帳 / 個人アドレス帳**（`◯◯ &gt; 閲覧一覧`）。
- ワークフロー2 申請フォーム設定：`ワークフロー2 &gt; 申請フォーム設定 &gt; 申請フォーム/外部申請リンク/カテゴリー/業務別`。
- ワークフロー（旧）：`ワークフロー &gt; 閲覧一覧 / 承認依頼されたもの / 承認申請したもの`。

※ スケジュール ゴミ箱・リマインダー・出退勤・庶務事務（休暇累計/勤務時間集計/タイムカード配下）・業務見える化 ゴミ箱・ワークフロー2（全申請データ一覧 等）・電子職員録・共有/個人アドレス帳の設定系は、既存実装で対応済みのため変更していません。

## 4. かな辞書メニューの整合（CMS サイト設定）

CMS サイト設定の「かな」メニューについて、表示文言とパンくずを整理しました。

- サイドメニューのセクション見出し（`modules.kana`）を「かな」→「**かな辞書**」に変更。
- かな辞書一覧へのリンク文言を「かな辞書」→「**かな辞書一覧**」に変更（`kana.dictionary_list` を新設し、かな用ナビ／サイト設定ナビの両方で利用）。
- かな辞書一覧のパンくずを `かな辞書` → `かな辞書 &gt; かな辞書一覧` の2階層に変更（診断画面と同じく `modules.kana` を親に利用）。

## 関連PR

CMS / SYS / GWS のメニュー配下のパンくず親階層を整備した一連のPRと同系列の修正です。特に **#6054** は同じ「かな」メニュー配下のパンくず（`トップ &gt; かな &gt; 診断`）を整備しており、本PRの「`トップ &gt; かな辞書 &gt; かな辞書一覧`」追加はその続きにあたります。

- #6054 [fix] cms : add parent crumbs under CMS menu（CMS サイト設定配下。`かな &gt; 診断` を含む）
- #6055 [fix] sys : add parent crumbs under システム設定
- #6060 fix(gws): GW メニュー配下のパンくずに親階層を追加
- #6069 [fix][cms] correct i18n key in source cleaner settings breadcrumb spec

https://claude.ai/code/session_01VG8Tm6Xw84pDCUxMrqhXmJ