### PR TITLE
[fix][cms] correct i18n key in source cleaner settings breadcrumb spec

### DIFF
--- a/spec/features/cms/breadcrumbs_spec.rb
+++ b/spec/features/cms/breadcrumbs_spec.rb
@@ -344,7 +344,7 @@ describe "cms breadcrumbs", type: :feature, dbscope: :example do
       let(:visit_path) { cms_source_cleaner_site_setting_path(site) }
       include_examples "linked parent and leaf",
                        I18n.t("cms.source_cleaner"), :cms_source_cleaner_main_path,
-                       I18n.t("cms.site_setting")
+                       I18n.t("translate.site_setting")
     end
   end
 


### PR DESCRIPTION
## 概要

`spec/features/cms/breadcrumbs_spec.rb` のソースクリーニング設定ページのパンくずテストが、葉ラベルの検証に存在しない i18n キー `cms.site_setting` を使用しており、`Translation missing: ja.cms.site_setting` となって**master 上で deterministic に失敗**していました。

このキーは存在しません（`ja.cms.site_setting` => nil）。実際のソースクリーニング設定ページ（`app/views/cms/source_cleaner/main/_navi.html.erb`）は設定ラベルに `translate.site_setting`（= "設定"）を使用しており、同じ spec 内の Translate 設定のパンくずテストも `I18n.t("translate.site_setting")` を使っています。これに合わせて正しいキーへ修正します。

## 変更点

- `spec/features/cms/breadcrumbs_spec.rb`: `I18n.t("cms.site_setting")` → `I18n.t("translate.site_setting")`（1行）

## 背景

この失敗は #6054 (`[fix] cms : add parent crumbs under CMS menu`) で追加されたテストに含まれていたキー誤りです。master の CI を緑に戻します。

https://claude.ai/code/session_01EkHnqg38fYferpfPnCdMB9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkHnqg38fYferpfPnCdMB9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **Bug Fixes**
  * ソースクリーニング設定画面のパンくず表示における翻訳キーを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->