### PR TITLE
[fix][cms]サイト内検索のパンくずの表示崩れを修正

### DIFF
--- a/app/controllers/cms/search_contents/files_controller.rb
+++ b/app/controllers/cms/search_contents/files_controller.rb
@@ -14,7 +14,7 @@ class Cms::SearchContents::FilesController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("cms.search_contents"), cms_search_contents_pages_path]
-    @crumbs << [t("cms.search_contents_files"), url_for(action: :index)]
+    @crumbs << [t("cms.search_contents_files"), action: :index]
   end
 
   def fix_params

--- a/app/controllers/cms/search_contents/html_controller.rb
+++ b/app/controllers/cms/search_contents/html_controller.rb
@@ -75,7 +75,9 @@ class Cms::SearchContents::HtmlController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("cms.search_contents"), cms_search_contents_pages_path]
-    @crumbs << [t("cms.search_contents_html"), action: :index]
+    # I18n.t を使う: t("..._html") は Rails 規約で html_safe 文字列になり、パンくずの
+    # .breadcrumb-title span ラッパーが付与されず末尾項目の表示がずれるため、プレーン文字列で渡す
+    @crumbs << [I18n.t("cms.search_contents_html"), action: :index]
   end
 
   def replace_html_with_string(string, replacement)

--- a/app/controllers/cms/search_contents/html_controller.rb
+++ b/app/controllers/cms/search_contents/html_controller.rb
@@ -75,7 +75,7 @@ class Cms::SearchContents::HtmlController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("cms.search_contents"), cms_search_contents_pages_path]
-    @crumbs << [t("cms.search_contents_html"), url_for(action: :index)]
+    @crumbs << [t("cms.search_contents_html"), action: :index]
   end
 
   def replace_html_with_string(string, replacement)

--- a/app/controllers/cms/search_contents/pages_controller.rb
+++ b/app/controllers/cms/search_contents/pages_controller.rb
@@ -13,7 +13,7 @@ class Cms::SearchContents::PagesController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("cms.search_contents"), cms_search_contents_pages_path]
-    @crumbs << [t("cms.search_contents_pages"), url_for(action: :index)]
+    @crumbs << [t("cms.search_contents_pages"), action: :index]
   end
 
   def fix_params


### PR DESCRIPTION
## 概要

サイト内検索（HTML検索と置換など）のパンくずの末尾項目の表示がずれていた問題を修正しました。

## 原因

パンくずの末尾（現在ページ）のリンクに `external`（外部リンク）クラスが付与されていたことが原因です。

- `html_controller.rb` の `set_crumbs` では `url_for(action: :index)` を使用していました。
- **コントローラ上**の `url_for` はデフォルトでホスト付きの**絶対URL**（`http://127.0.0.1:3000/...`）を生成します。
- フロントの `SS.renderExternalLinks`（`app/assets/javascripts/ss/lib/base.js.erb`）が `a[href^=http]` に一致するリンクへ自動で `external` クラスを付与するため、絶対URLになっていたパンくずが外部リンク扱いされ、外部リンク用スタイルが当たって表示がずれていました。

正しく表示されている `sitemap_controller.rb` は、`url_for` を呼ばずにオプションのハッシュ（`action: :index`）を渡し、パンくずの ERB（ビュー側）で `url_for` させていました。ビュー側の `url_for` は相対パスを生成するため `external` が付きません。

## 修正内容

`sitemap_controller` のパターンに合わせ、`url_for(action: :index)` → `action: :index`（ハッシュ渡し）に変更しました。同じ不具合を持っていた `pages` / `files` の各コントローラも併せて修正しています。

- `app/controllers/cms/search_contents/html_controller.rb`
- `app/controllers/cms/search_contents/pages_controller.rb`
- `app/controllers/cms/search_contents/files_controller.rb`

**修正前**
<img width="317" height="99" alt="スクリーンショット 2026-06-05 090956" src="https://github.com/user-attachments/assets/e84fc5fe-35c2-4e7c-af79-1db003481958" />

**修正後**
<img width="1016" height="40" alt="パンくず表示修正" src="https://github.com/user-attachments/assets/ca6348c2-00ac-4c51-bc6e-72fb332b5d90" />

## 関連PR

CMS / SYS / GWS のメニュー配下のパンくずを整備した一連のPRと同系列の修正です。本PRはCMSのパンくず表示崩れの修正にあたります。

- #6054 [fix] cms : add parent crumbs under CMS menu（CMS サイト設定配下のパンくず親階層追加）
- #6055 [fix] sys : add parent crumbs under システム設定
- #6060 fix(gws): GW メニュー配下のパンくずに親階層を追加
- #6069 [fix][cms] correct i18n key in source cleaner settings breadcrumb spec

https://claude.ai/code/session_01XCcAEFYmT1dTzG3n25uc6V

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCcAEFYmT1dTzG3n25uc6V)_


## Summary by CodeRabbit

* **Refactor**
  * CMS検索ページのパンくずナビゲーション生成を統一・改善しました。
  * 表示ズレを防ぐための翻訳呼び出し方式を調整し、パンくずのラベル表示がより安定しました。
