### PR TITLE
[feat][gws][tabular]: 汎用DBの一覧に絞り込みレール（タクソノミー）を追加

### DIFF
--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -243,6 +243,9 @@
 }
 
 .gws-tabular-applied-filters-clear {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
   margin-left: auto;
   font-size: 0.85rem;
 }

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -174,6 +174,56 @@
   }
 }
 
+// 一覧上部に「適用中の条件」をチップで表示する帯
+.gws-tabular-applied-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.gws-tabular-applied-filters-label {
+  color: #616161;
+  font-size: 0.85rem;
+}
+
+.gws-tabular-applied-filters-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.gws-tabular-applied-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px 2px 10px;
+  border: 1px solid init.$gray2;
+  border-radius: 14px;
+  background-color: #f5f5f5;
+  font-size: 0.85rem;
+}
+
+.gws-tabular-applied-filter-remove {
+  display: inline-flex;
+  align-items: center;
+  color: #757575;
+  text-decoration: none;
+
+  &:hover {
+    color: #333;
+  }
+}
+
+.gws-tabular-applied-filters-clear {
+  margin-left: auto;
+  font-size: 0.85rem;
+}
+
 .list-head {
   .badge {
     padding: 2px 4px;

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -98,22 +98,39 @@
   }
 
   .gws-tabular-file-search-options {
+    // 選択肢が多いときは縦に伸び過ぎないようスクロールさせる
+    max-height: 220px;
     margin: 0;
     padding: 0;
+    overflow-y: auto;
     list-style: none;
   }
 
   .gws-tabular-file-search-option {
     label {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       gap: 4px;
       margin: 2px 0;
       cursor: pointer;
     }
 
     input[type="checkbox"] {
-      margin: 0;
+      flex: 0 0 auto;
+      // テキストの1行目に揃える
+      margin: 2px 0 0;
+    }
+
+    span {
+      // 横にはみ出す長いラベルは最大2行で省略表示する
+      display: -webkit-box;
+      min-width: 0;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+      text-overflow: ellipsis;
+      word-break: break-word;
     }
   }
 
@@ -144,6 +161,12 @@
       flex: 1 1 0;
       text-align: center;
     }
+  }
+
+  // キーワード直下に置く検索ボタンはキーワード欄の余白を流用する
+  .gws-tabular-file-search-actions-top {
+    margin-top: 0;
+    margin-bottom: 12px;
   }
 
   // モバイルではレールが全幅になるため、各項目を多段に並べて余白を埋め、

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -250,7 +250,19 @@
   align-items: center;
   gap: 2px;
   margin-left: auto;
+  padding: 2px 10px;
+  border: 1px solid init.$gray2;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #616161;
   font-size: 0.85rem;
+  text-decoration: none;
+
+  &:hover {
+    border-color: #bdbdbd;
+    background-color: #f0f0f0;
+    color: #333;
+  }
 }
 
 // 適用中条件チップ帯のアイコンは material-icons-outlined フォントのコードポイントを

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -33,6 +33,113 @@
   }
 }
 
+// 一覧画面を「左:一覧 / 右:絞り込みレール」の2カラムに分割する
+.gws-tabular-file-index-columns {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+
+  &.gws-tabular-file-index-columns-no-rail {
+    display: block;
+  }
+
+  @include init.mb {
+    flex-direction: column;
+  }
+}
+
+.gws-tabular-file-index-list {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.gws-tabular-file-index-rail {
+  flex: 0 0 240px;
+  width: 240px;
+
+  @include init.mb {
+    flex: 1 1 auto;
+    width: 100%;
+    order: -1;
+  }
+}
+
+.gws-tabular-file-search {
+  padding: 12px;
+  border: 1px solid init.$gray2;
+  border-radius: 4px;
+  background-color: #fafafa;
+
+  .index-search {
+    display: block;
+  }
+
+  .gws-tabular-file-search-keyword {
+    margin-bottom: 12px;
+
+    input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+    }
+  }
+
+  .gws-tabular-file-search-section {
+    margin-bottom: 12px;
+  }
+
+  .gws-tabular-file-search-section-head {
+    margin: 0 0 6px;
+    font-size: 0.9rem;
+    font-weight: bold;
+    color: #616161;
+  }
+
+  .gws-tabular-file-search-options {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .gws-tabular-file-search-option {
+    label {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin: 2px 0;
+      cursor: pointer;
+    }
+
+    input[type="checkbox"] {
+      margin: 0;
+    }
+  }
+
+  .gws-tabular-file-search-date-range {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+    }
+  }
+
+  .gws-tabular-file-search-date-sep {
+    text-align: center;
+    color: #9e9e9e;
+  }
+
+  .gws-tabular-file-search-actions {
+    margin-top: 12px;
+
+    .btn {
+      width: 100%;
+    }
+  }
+}
+
 .list-head {
   .badge {
     padding: 2px 4px;

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -207,6 +207,9 @@
 }
 
 .gws-tabular-applied-filters-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
   color: #616161;
   font-size: 0.85rem;
 }

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -90,8 +90,8 @@
 
   .gws-tabular-file-search-section-head {
     margin: 0 0 6px;
-    font-size: 0.9rem;
     color: #616161;
+    font-size: 0.9rem;
     font-weight: bold;
   }
 

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -60,8 +60,8 @@
 
   @include init.mb {
     flex: 1 1 auto;
-    width: 100%;
     order: -1;
+    width: 100%;
   }
 }
 
@@ -79,8 +79,8 @@
     margin-bottom: 12px;
 
     input[type="text"] {
-      width: 100%;
       box-sizing: border-box;
+      width: 100%;
     }
   }
 
@@ -91,14 +91,14 @@
   .gws-tabular-file-search-section-head {
     margin: 0 0 6px;
     font-size: 0.9rem;
-    font-weight: bold;
     color: #616161;
+    font-weight: bold;
   }
 
   .gws-tabular-file-search-options {
-    list-style: none;
     margin: 0;
     padding: 0;
+    list-style: none;
   }
 
   .gws-tabular-file-search-option {
@@ -121,14 +121,14 @@
     gap: 4px;
 
     input[type="text"] {
-      width: 100%;
       box-sizing: border-box;
+      width: 100%;
     }
   }
 
   .gws-tabular-file-search-date-sep {
-    text-align: center;
     color: #9e9e9e;
+    text-align: center;
   }
 
   .gws-tabular-file-search-actions {

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -253,6 +253,35 @@
   font-size: 0.85rem;
 }
 
+// 適用中条件チップ帯のアイコンは material-icons-outlined フォントのコードポイントを
+// SCSS 側で指定する（HTML にアイコン名を埋め込まない）。
+.gws-tabular-applied-filters-label::before,
+.gws-tabular-applied-filter-remove::before,
+.gws-tabular-applied-filters-clear::before {
+  flex: 0 0 auto;
+  font-family: "Material Icons Outlined";
+  font-size: 15px;
+  font-style: normal;
+  font-weight: normal;
+  font-feature-settings: "liga";
+  letter-spacing: normal;
+  line-height: 1;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.gws-tabular-applied-filters-label::before {
+  content: "\ef4f"; // filter_alt
+}
+
+.gws-tabular-applied-filter-remove::before {
+  content: "\e5cd"; // close
+}
+
+.gws-tabular-applied-filters-clear::before {
+  content: "\eb32"; // filter_alt_off
+}
+
 .list-head {
   .badge {
     padding: 2px 4px;

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -45,6 +45,8 @@
 
   @include init.mb {
     flex-direction: column;
+    // 縦並びでは交差軸が横方向になるため、リストとレールを揃えて全幅にする
+    align-items: stretch;
   }
 }
 
@@ -55,8 +57,8 @@
 }
 
 .gws-tabular-file-index-rail {
-  flex: 0 0 240px;
-  width: 240px;
+  flex: 0 0 320px;
+  width: 320px;
 
   @include init.mb {
     flex: 1 1 auto;
@@ -117,25 +119,57 @@
 
   .gws-tabular-file-search-date-range {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     gap: 4px;
 
     input[type="text"] {
+      flex: 1 1 0;
+      min-width: 0;
       box-sizing: border-box;
-      width: 100%;
     }
   }
 
   .gws-tabular-file-search-date-sep {
+    flex: 0 0 auto;
     color: #9e9e9e;
-    text-align: center;
   }
 
   .gws-tabular-file-search-actions {
     margin-top: 12px;
+    display: flex;
+    gap: 6px;
 
     .btn {
-      width: 100%;
+      flex: 1 1 0;
+      box-sizing: border-box;
+      text-align: center;
+    }
+  }
+
+  // モバイルではレールが全幅になるため、各項目を多段に並べて余白を埋め、
+  // 選択肢は横に折り返してバランスを取る
+  @include init.mb {
+    .index-search {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 12px 20px;
+      align-items: start;
+    }
+
+    .gws-tabular-file-search-keyword,
+    .gws-tabular-file-search-actions {
+      grid-column: 1 / -1;
+      margin: 0;
+    }
+
+    .gws-tabular-file-search-section {
+      margin-bottom: 0;
+    }
+
+    .gws-tabular-file-search-options {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px 16px;
     }
   }
 }

--- a/app/assets/stylesheets/gws/tabular/_gws.scss
+++ b/app/assets/stylesheets/gws/tabular/_gws.scss
@@ -123,9 +123,9 @@
     gap: 4px;
 
     input[type="text"] {
+      box-sizing: border-box;
       flex: 1 1 0;
       min-width: 0;
-      box-sizing: border-box;
     }
   }
 
@@ -135,13 +135,13 @@
   }
 
   .gws-tabular-file-search-actions {
-    margin-top: 12px;
     display: flex;
+    margin-top: 12px;
     gap: 6px;
 
     .btn {
-      flex: 1 1 0;
       box-sizing: border-box;
+      flex: 1 1 0;
       text-align: center;
     }
   }

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -130,10 +130,19 @@ class Gws::Tabular::FilesController < ApplicationController
       # 右レールの絞り込み条件（params[:s][:col]）をプレーンなハッシュへ正規化して受け渡す。
       # 日付欄などはここで文字列のまま保持し、各項目の検索条件メソッドで正規化する。
       if params[:s].present? && params[:s][:col].present?
-        s.col = params[:s][:col].permit!.to_h
+        s.col = permit_search_col_params(params[:s][:col])
       end
       s
     end
+  end
+
+  # 項目ごとの絞り込み条件を明示的に permit する。
+  # 列挙型はスカラー値の配列（[]）、日付型は from / to の2欄を許可する。
+  def permit_search_col_params(col_params)
+    filters = col_params.keys.index_with do |column_id|
+      col_params[column_id].respond_to?(:keys) ? %i[from to] : []
+    end
+    col_params.permit(filters).to_h
   end
 
   def base_items

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -117,6 +117,13 @@ class Gws::Tabular::FilesController < ApplicationController
     end
   end
 
+  ##
+  # Builds and memoized an OpenStruct of search parameters for the current request and context.
+  # Adds contextual fields (cur_site, cur_user, cur_form, cur_release), ensures workflow action defaults
+  # to "all" when the form's workflow is enabled, and normalizes right-rail column filters from
+  # params[:s][:col] into a plain hash via permit_search_col_params while leaving raw values (e.g. date
+  # strings) for per-column normalization.
+  # @return [OpenStruct] The search parameters object with contextual fields and optional normalized `col` hash.
   def set_search_params
     @s ||= begin
       s = OpenStruct.new(params[:s])
@@ -138,7 +145,10 @@ class Gws::Tabular::FilesController < ApplicationController
 
   # 項目ごとの絞り込み条件を明示的に permit する。
   # 列挙型はスカラー値の配列（[]）、日付型は from / to の2欄を許可する。
-  # `?s[col]=x` のように非ハッシュが渡された場合は空ハッシュへ正規化する。
+  ##
+  # Normalize and permit column search parameters for right-rail filters.
+  # @param [#permit, #keys, nil] col_params - The incoming params-like object for `s[:col]`. If it does not respond to `permit` and `keys`, it will be treated as absent.
+  # @return [Hash] A plain Hash of permitted column filters keyed by column id. Each value is either an Array (for multi-value filters) or a Hash with `from` and `to` keys (for range/date filters).
   def permit_search_col_params(col_params)
     return {} unless col_params.respond_to?(:permit) && col_params.respond_to?(:keys)
 
@@ -149,6 +159,11 @@ class Gws::Tabular::FilesController < ApplicationController
     col_params.permit(filters).to_h
   end
 
+  ##
+  # Builds the base query relation for tabular files scoped to the current site.
+  # It excludes deleted records, restricts results to items readable by the current user,
+  # and applies the current view's ordering when available.
+  # @return [Object] The query relation (criteria) for items scoped to the site, without deleted records, readable by the current user, and ordered by the current view if present.
   def base_items
     @base_items ||= begin
       criteria = @model.site(@cur_site)

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -147,8 +147,10 @@ class Gws::Tabular::FilesController < ApplicationController
   # 列挙型はスカラー値の配列（[]）、日付型は from / to の2欄を許可する。
   ##
   # Normalize and permit column search parameters for right-rail filters.
-  # @param [#permit, #keys, nil] col_params - The incoming params-like object for `s[:col]`. If it does not respond to `permit` and `keys`, it will be treated as absent.
-  # @return [Hash] A plain Hash of permitted column filters keyed by column id. Each value is either an Array (for multi-value filters) or a Hash with `from` and `to` keys (for range/date filters).
+  # @param [#permit, #keys, nil] col_params - The incoming params-like object for `s[:col]`.
+  #   If it does not respond to `permit` and `keys`, it will be treated as absent.
+  # @return [Hash] A plain Hash of permitted column filters keyed by column id. Each value is either
+  #   an Array (for multi-value filters) or a Hash with `from` and `to` keys (for range/date filters).
   def permit_search_col_params(col_params)
     return {} unless col_params.respond_to?(:permit) && col_params.respond_to?(:keys)
 
@@ -163,7 +165,8 @@ class Gws::Tabular::FilesController < ApplicationController
   # Builds the base query relation for tabular files scoped to the current site.
   # It excludes deleted records, restricts results to items readable by the current user,
   # and applies the current view's ordering when available.
-  # @return [Object] The query relation (criteria) for items scoped to the site, without deleted records, readable by the current user, and ordered by the current view if present.
+  # @return [Object] The query relation (criteria) for items scoped to the site, without deleted records,
+  #   readable by the current user, and ordered by the current view if present.
   def base_items
     @base_items ||= begin
       criteria = @model.site(@cur_site)

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -138,9 +138,13 @@ class Gws::Tabular::FilesController < ApplicationController
 
   # 項目ごとの絞り込み条件を明示的に permit する。
   # 列挙型はスカラー値の配列（[]）、日付型は from / to の2欄を許可する。
+  # `?s[col]=x` のように非ハッシュが渡された場合は空ハッシュへ正規化する。
   def permit_search_col_params(col_params)
+    return {} unless col_params.respond_to?(:permit) && col_params.respond_to?(:keys)
+
     filters = col_params.keys.index_with do |column_id|
-      col_params[column_id].respond_to?(:keys) ? %i[from to] : []
+      value = col_params[column_id]
+      value.respond_to?(:keys) ? %i[from to] : []
     end
     col_params.permit(filters).to_h
   end

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -127,6 +127,11 @@ class Gws::Tabular::FilesController < ApplicationController
       if cur_form.workflow_enabled?
         s.act ||= "all"
       end
+      # 右レールの絞り込み条件（params[:s][:col]）をプレーンなハッシュへ正規化して受け渡す。
+      # 日付欄などはここで文字列のまま保持し、各項目の検索条件メソッドで正規化する。
+      if params[:s].present? && params[:s][:col].present?
+        s.col = params[:s][:col].permit!.to_h
+      end
       s
     end
   end

--- a/app/controllers/gws/tabular/trash_files_controller.rb
+++ b/app/controllers/gws/tabular/trash_files_controller.rb
@@ -4,6 +4,11 @@ class Gws::Tabular::TrashFilesController < ApplicationController
 
   model Gws::Tabular::File
 
+  # 一覧テンプレート（default_view/list/liquid）は FilesController と共用しており、
+  # 適用中条件チップのパーシャルが Gws::Tabular::FilesHelper を参照する。
+  # include_all_helpers = false のため、ここで明示的に読み込む。
+  helper Gws::Tabular::FilesHelper
+
   navi_view "gws/tabular/main/navi"
 
   before_action :set_trash

--- a/app/helpers/gws/tabular/files_helper.rb
+++ b/app/helpers/gws/tabular/files_helper.rb
@@ -1,7 +1,11 @@
 module Gws::Tabular::FilesHelper
   # 適用中の検索条件を「チップ」表示するための要素を列挙する。
   # search: 検索パラメータ（OpenStruct もしくは Hash）、model: ファイルモデル
-  # 返り値: [{ label:, url: }, ...]（url はその条件を外した一覧 URL）
+  ##
+  # 適用中の検索条件をチップ形式の配列として返す。
+  # @param [Hash, nil] search - 検索条件ハッシュ（`nil` の場合は空配列を返す）
+  # @param [Class, Object] model - 検索カラム候補を提供するモデル（`search_column_candidates` を利用可能であることを想定）
+  # @return [Array<Hash>] 各要素は `{ label: String, url: String }` のハッシュ。`url` は該当の条件を除外した一覧へのリンク。
   def gws_tabular_applied_search_filters(search, model)
     return [] if search.nil?
 
@@ -9,13 +13,20 @@ module Gws::Tabular::FilesHelper
     gws_tabular_keyword_chips(search, base) + gws_tabular_column_chips(search, model, base)
   end
 
-  # すべての検索条件を外した一覧 URL（「すべてクリア」用）。
+  ##
+  # すべての検索条件を外した一覧ページのURLを返す。
+  # @return [String] 検索条件を含まない一覧ページのURL。
   def gws_tabular_clear_search_url
     url_for(action: :index)
   end
 
   private
 
+  ##
+  # Builds a sanitized search base hash containing only present search fields.
+  # The resulting hash may include :keyword, :act and a deep-duplicated :col.
+  # @param [Hash] search - The original search parameters.
+  # @return [Hash] A hash with only the present keys from `search` (`:keyword`, `:act`, and `:col` where `:col` is deep-duplicated).
   def gws_tabular_search_base(search)
     base = {}
     base[:keyword] = search[:keyword] if search[:keyword].present?
@@ -24,6 +35,11 @@ module Gws::Tabular::FilesHelper
     base
   end
 
+  ##
+  # Builds an array with a single chip representing the keyword filter and a URL that removes that keyword from the search.
+  # @param [Hash] search - Current search parameters (may include :keyword).
+  # @param [Hash] base - Sanitized base search hash used as the starting point for the removal URL.
+  # @return [Array<Hash>] An array containing one chip hash with keys `:label` and `:url`; returns an empty array if no keyword is present.
   def gws_tabular_keyword_chips(search, base)
     return [] if search[:keyword].blank?
 
@@ -32,6 +48,14 @@ module Gws::Tabular::FilesHelper
     [{ label: "#{t('ss.keyword')}: #{search[:keyword]}", url: gws_tabular_search_url(new_search) }]
   end
 
+  ##
+  # Builds filter chips for column-based search conditions.
+  # For each column candidate with a present value and a `search_filter_chips` implementation,
+  # produces one or more chip hashes that remove or adjust that column's filter when visited.
+  # @param [Hash] search - The raw search parameters; expected to contain a `:col` hash keyed by column id strings.
+  # @param [Class, Object] model - The model or class that may respond to `:search_column_candidates`.
+  # @param [Hash] base - A sanitized base search hash (typically produced by `gws_tabular_search_base`) used as the starting point for generated URLs.
+  # @return [Array<Hash>] Array of chips; each chip is a hash with `:label` (String) and `:url` (String). Empty array if there are no column filters.
   def gws_tabular_column_chips(search, model, base)
     col = search[:col]
     return [] if col.blank?
@@ -48,6 +72,12 @@ module Gws::Tabular::FilesHelper
     end
   end
 
+  ##
+  # Build a new search hash with the specified column filter updated or removed.
+  # @param [Hash] base - The original search hash to duplicate; may include a `:col` sub-hash.
+  # @param [String] column_id - The column identifier whose filter should be changed or removed.
+  # @param [Object] remaining - The remaining value for the column filter; if blank, the column filter is removed.
+  # @return [Hash] A new search hash reflecting the updated `:col` state; if no column filters remain, the `:col` key is omitted.
   def gws_tabular_remove_col(base, column_id, remaining)
     new_search = base.deep_dup
     new_search[:col] ||= {}
@@ -60,6 +90,10 @@ module Gws::Tabular::FilesHelper
     new_search
   end
 
+  ##
+  # Builds the index URL applying the given search parameters when present.
+  # @param [Hash, nil] new_search - Search parameters to include as the `s` query parameter; if `nil` or empty, no search parameters are included.
+  # @return [String] The URL for the index action with `s` set to `new_search` when present, otherwise the index URL without search parameters.
   def gws_tabular_search_url(new_search)
     new_search.present? ? url_for(action: :index, s: new_search) : url_for(action: :index)
   end

--- a/app/helpers/gws/tabular/files_helper.rb
+++ b/app/helpers/gws/tabular/files_helper.rb
@@ -26,7 +26,8 @@ module Gws::Tabular::FilesHelper
   # Builds a sanitized search base hash containing only present search fields.
   # The resulting hash may include :keyword, :act and a deep-duplicated :col.
   # @param [Hash] search - The original search parameters.
-  # @return [Hash] A hash with only the present keys from `search` (`:keyword`, `:act`, and `:col` where `:col` is deep-duplicated).
+  # @return [Hash] A hash with only the present keys from `search` (`:keyword`, `:act`, and `:col`
+  #   where `:col` is deep-duplicated).
   def gws_tabular_search_base(search)
     base = {}
     base[:keyword] = search[:keyword] if search[:keyword].present?
@@ -36,10 +37,12 @@ module Gws::Tabular::FilesHelper
   end
 
   ##
-  # Builds an array with a single chip representing the keyword filter and a URL that removes that keyword from the search.
+  # Builds an array with a single chip representing the keyword filter and a URL that removes
+  # that keyword from the search.
   # @param [Hash] search - Current search parameters (may include :keyword).
   # @param [Hash] base - Sanitized base search hash used as the starting point for the removal URL.
-  # @return [Array<Hash>] An array containing one chip hash with keys `:label` and `:url`; returns an empty array if no keyword is present.
+  # @return [Array<Hash>] An array containing one chip hash with keys `:label` and `:url`;
+  #   returns an empty array if no keyword is present.
   def gws_tabular_keyword_chips(search, base)
     return [] if search[:keyword].blank?
 
@@ -54,8 +57,10 @@ module Gws::Tabular::FilesHelper
   # produces one or more chip hashes that remove or adjust that column's filter when visited.
   # @param [Hash] search - The raw search parameters; expected to contain a `:col` hash keyed by column id strings.
   # @param [Class, Object] model - The model or class that may respond to `:search_column_candidates`.
-  # @param [Hash] base - A sanitized base search hash (typically produced by `gws_tabular_search_base`) used as the starting point for generated URLs.
-  # @return [Array<Hash>] Array of chips; each chip is a hash with `:label` (String) and `:url` (String). Empty array if there are no column filters.
+  # @param [Hash] base - A sanitized base search hash (typically produced by `gws_tabular_search_base`)
+  #   used as the starting point for generated URLs.
+  # @return [Array<Hash>] Array of chips; each chip is a hash with `:label` (String) and `:url` (String).
+  #   Empty array if there are no column filters.
   def gws_tabular_column_chips(search, model, base)
     col = search[:col]
     return [] if col.blank?
@@ -77,7 +82,8 @@ module Gws::Tabular::FilesHelper
   # @param [Hash] base - The original search hash to duplicate; may include a `:col` sub-hash.
   # @param [String] column_id - The column identifier whose filter should be changed or removed.
   # @param [Object] remaining - The remaining value for the column filter; if blank, the column filter is removed.
-  # @return [Hash] A new search hash reflecting the updated `:col` state; if no column filters remain, the `:col` key is omitted.
+  # @return [Hash] A new search hash reflecting the updated `:col` state; if no column filters remain,
+  #   the `:col` key is omitted.
   def gws_tabular_remove_col(base, column_id, remaining)
     new_search = base.deep_dup
     new_search[:col] ||= {}
@@ -92,8 +98,10 @@ module Gws::Tabular::FilesHelper
 
   ##
   # Builds the index URL applying the given search parameters when present.
-  # @param [Hash, nil] new_search - Search parameters to include as the `s` query parameter; if `nil` or empty, no search parameters are included.
-  # @return [String] The URL for the index action with `s` set to `new_search` when present, otherwise the index URL without search parameters.
+  # @param [Hash, nil] new_search - Search parameters to include as the `s` query parameter;
+  #   if `nil` or empty, no search parameters are included.
+  # @return [String] The URL for the index action with `s` set to `new_search` when present,
+  #   otherwise the index URL without search parameters.
   def gws_tabular_search_url(new_search)
     new_search.present? ? url_for(action: :index, s: new_search) : url_for(action: :index)
   end

--- a/app/helpers/gws/tabular/files_helper.rb
+++ b/app/helpers/gws/tabular/files_helper.rb
@@ -1,0 +1,66 @@
+module Gws::Tabular::FilesHelper
+  # 適用中の検索条件を「チップ」表示するための要素を列挙する。
+  # search: 検索パラメータ（OpenStruct もしくは Hash）、model: ファイルモデル
+  # 返り値: [{ label:, url: }, ...]（url はその条件を外した一覧 URL）
+  def gws_tabular_applied_search_filters(search, model)
+    return [] if search.nil?
+
+    base = gws_tabular_search_base(search)
+    gws_tabular_keyword_chips(search, base) + gws_tabular_column_chips(search, model, base)
+  end
+
+  # すべての検索条件を外した一覧 URL（「すべてクリア」用）。
+  def gws_tabular_clear_search_url
+    url_for(action: :index)
+  end
+
+  private
+
+  def gws_tabular_search_base(search)
+    base = {}
+    base[:keyword] = search[:keyword] if search[:keyword].present?
+    base[:act] = search[:act] if search[:act].present?
+    base[:col] = search[:col].deep_dup if search[:col].present?
+    base
+  end
+
+  def gws_tabular_keyword_chips(search, base)
+    return [] if search[:keyword].blank?
+
+    new_search = base.deep_dup
+    new_search.delete(:keyword)
+    [{ label: "#{t('ss.keyword')}: #{search[:keyword]}", url: gws_tabular_search_url(new_search) }]
+  end
+
+  def gws_tabular_column_chips(search, model, base)
+    col = search[:col]
+    return [] if col.blank?
+
+    candidates = model.respond_to?(:search_column_candidates) ? model.search_column_candidates : []
+    candidates.flat_map do |column|
+      value = col[column.id.to_s]
+      next [] if value.blank? || !column.respond_to?(:search_filter_chips)
+
+      column.search_filter_chips(value).map do |chip|
+        new_search = gws_tabular_remove_col(base, column.id.to_s, chip[:remaining])
+        { label: chip[:label], url: gws_tabular_search_url(new_search) }
+      end
+    end
+  end
+
+  def gws_tabular_remove_col(base, column_id, remaining)
+    new_search = base.deep_dup
+    new_search[:col] ||= {}
+    if remaining.present?
+      new_search[:col][column_id] = remaining
+    else
+      new_search[:col].delete(column_id)
+    end
+    new_search.delete(:col) if new_search[:col].blank?
+    new_search
+  end
+
+  def gws_tabular_search_url(new_search)
+    new_search.present? ? url_for(action: :index, s: new_search) : url_for(action: :index)
+  end
+end

--- a/app/models/concerns/gws/tabular/file/search.rb
+++ b/app/models/concerns/gws/tabular/file/search.rb
@@ -19,7 +19,8 @@ module Gws::Tabular::File::Search
     # Filters records by `params[:keyword]` across the configured `keyword_fields`.
     # If `params[:keyword]` is blank, returns the unfiltered relation.
     # @param [Hash] params - Parameters hash that may include :keyword.
-    # @return [ActiveRecord::Relation] Relation matching the keyword in `keyword_fields`, or the original relation when no keyword is provided.
+    # @return [ActiveRecord::Relation] Relation matching the keyword in `keyword_fields`,
+    #   or the original relation when no keyword is provided.
     def search_keyword(params)
       return all if params[:keyword].blank?
       all.keyword_in(params[:keyword], *keyword_fields)
@@ -62,7 +63,8 @@ module Gws::Tabular::File::Search
     ##
     # Filters records by the requested action context.
     #
-    # @param [Hash, ActionController::Parameters] params - Parameters containing the action filter and current site, user, and form context.
+    # @param [Hash, ActionController::Parameters] params - Parameters containing the action filter
+    #   and current site, user, and form context.
     # @return [Mongoid::Criteria] The filtered search criteria.
     def search_act(params)
       Gws::Tabular::File::ActQuery.call(self, all, **params.to_h.slice(:cur_site, :cur_user, :cur_form, :act))

--- a/app/models/concerns/gws/tabular/file/search.rb
+++ b/app/models/concerns/gws/tabular/file/search.rb
@@ -20,6 +20,33 @@ module Gws::Tabular::File::Search
       all.keyword_in(params[:keyword], *keyword_fields)
     end
 
+    # 検索ボックス右レールに表示する、絞り込み可能な項目（列挙型・日付型など）を返す。
+    def search_column_candidates
+      return [] if released_columns.blank?
+      released_columns.select do |column|
+        column.respond_to?(:search_input_type) && column.search_input_type.present?
+      end
+    end
+
+    # 右レールで選択された項目（params[:s][:col]）を使って一覧を絞り込む。
+    # 列挙型は完全一致（$in）、日付型は from / to の範囲で絞り込む。
+    def search_columns(params)
+      col_params = params[:col]
+      return all if col_params.blank?
+
+      criteria = all
+      search_column_candidates.each do |column|
+        value = col_params[column.id.to_s]
+        next if value.blank?
+
+        selector = column.search_file_criteria(value)
+        next if selector.blank?
+
+        criteria = criteria.where(selector)
+      end
+      criteria
+    end
+
     def search_act(params)
       Gws::Tabular::File::ActQuery.call(self, all, **params.to_h.slice(:cur_site, :cur_user, :cur_form, :act))
     end

--- a/app/models/concerns/gws/tabular/file/search.rb
+++ b/app/models/concerns/gws/tabular/file/search.rb
@@ -15,12 +15,20 @@ module Gws::Tabular::File::Search
       criteria
     end
 
+    ##
+    # Filters records by `params[:keyword]` across the configured `keyword_fields`.
+    # If `params[:keyword]` is blank, returns the unfiltered relation.
+    # @param [Hash] params - Parameters hash that may include :keyword.
+    # @return [ActiveRecord::Relation] Relation matching the keyword in `keyword_fields`, or the original relation when no keyword is provided.
     def search_keyword(params)
       return all if params[:keyword].blank?
       all.keyword_in(params[:keyword], *keyword_fields)
     end
 
-    # 検索ボックス右レールに表示する、絞り込み可能な項目（列挙型・日付型など）を返す。
+    ##
+    # 検索ボックス右レールに表示する絞り込み可能な列を返す。
+    # released_columns のうち `search_input_type` を持ち、その値が設定されている列だけを返す。
+    # @return [Array] 絞り込み候補となる列オブジェクトの配列。
     def search_column_candidates
       return [] if released_columns.blank?
       released_columns.select do |column|
@@ -29,7 +37,11 @@ module Gws::Tabular::File::Search
     end
 
     # 右レールで選択された項目（params[:s][:col]）を使って一覧を絞り込む。
-    # 列挙型は完全一致（$in）、日付型は from / to の範囲で絞り込む。
+    ##
+    # 指定されたカラム選択値(params[:col])に基づいてファイル検索の絞り込みを順次適用する。
+    # 列挙型は完全一致（$in）、日付型は from/to の範囲で絞り込む。
+    # @param [Hash] params - 検索パラメータ。キー `:col` にカラムID文字列をキー、選択値を値とするハッシュを含むことを期待する。
+    # @return [Object] カラム条件を順次適用した検索用の criteria（元の `all` を基に絞り込みを行ったオブジェクト）。
     def search_columns(params)
       col_params = params[:col]
       return all if col_params.blank?
@@ -47,6 +59,11 @@ module Gws::Tabular::File::Search
       criteria
     end
 
+    ##
+    # Filters records by the requested action context.
+    #
+    # @param [Hash, ActionController::Parameters] params - Parameters containing the action filter and current site, user, and form context.
+    # @return [Mongoid::Criteria] The filtered search criteria.
     def search_act(params)
       Gws::Tabular::File::ActQuery.call(self, all, **params.to_h.slice(:cur_site, :cur_user, :cur_form, :act))
     end

--- a/app/models/gws/tabular/column/date_time_field.rb
+++ b/app/models/gws/tabular/column/date_time_field.rb
@@ -20,15 +20,19 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
 
   ##
   # Selects the search UI input type for this column to use a from/to date range layout.
-  # @return [String] The input type identifier "date_range", indicating the search box should render two fields for start and end timestamps.
+  # @return [String] The input type identifier "date_range", indicating the search box should render
+  #   two fields for start and end timestamps.
   def search_input_type
     "date_range"
   end
 
   ##
-  # Builds query criteria to filter records within the range specified by `from`/`to`, treating date inputs as inclusive of the whole day.
-  # @param [Object] value - A hash-like object (responds to `#key?`) that may contain `:from`/`"from"` and `:to`/`"to"` entries.
-  # @return [Hash, nil] A hash mapping the stored file field name to a conditions hash containing `$gte` and/or `$lte` as applicable, or `nil` when no valid boundaries are present.
+  # Builds query criteria to filter records within the range specified by `from`/`to`,
+  # treating date inputs as inclusive of the whole day.
+  # @param [Object] value - A hash-like object (responds to `#key?`) that may contain
+  #   `:from`/`"from"` and `:to`/`"to"` entries.
+  # @return [Hash, nil] A hash mapping the stored file field name to a conditions hash containing
+  #   `$gte` and/or `$lte` as applicable, or `nil` when no valid boundaries are present.
   def search_file_criteria(value)
     return unless value.respond_to?(:key?)
 
@@ -48,7 +52,8 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
   ##
   # Builds a single search filter chip representing a from–to date range when `value` contains `from` or `to`.
   # @param [Hash, #key?] value - A hash-like object that may contain `:from`/"from" and `:to`/"to" string values.
-  # @return [Array<Hash>] An array with one chip hash `{ label: "...", remaining: nil }` when at least one boundary is present, or an empty array when both are blank.
+  # @return [Array<Hash>] An array with one chip hash `{ label: "...", remaining: nil }` when at least
+  #   one boundary is present, or an empty array when both are blank.
   def search_filter_chips(value)
     return [] unless value.respond_to?(:key?)
 
@@ -113,7 +118,8 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
   ##
   # Format the stored date or datetime value for CSV export.
   #
-  # Converts `db_value` to a locale-aware CSV string; when `input_type` is `"date"` the value is converted to a Date before formatting.
+  # Converts `db_value` to a locale-aware CSV string; when `input_type` is `"date"` the value is
+  # converted to a Date before formatting.
   # Returns nil if `db_value` is blank.
   # @param [Object] db_value - The stored value (Time/Date/DateTime or parsable value) to format.
   # @return [String, nil] The localized CSV-formatted representation of the value, or `nil` when `db_value` is blank.

--- a/app/models/gws/tabular/column/date_time_field.rb
+++ b/app/models/gws/tabular/column/date_time_field.rb
@@ -8,18 +8,27 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
 
   validates :input_type, presence: true, inclusion: { in: %w(date datetime), allow_blank: true }
 
+  ##
+  # Available input type options for the column as `[label, value]` pairs.
+  # The label for each value is localized via I18n.t("gws/column.options.date_input_type.<value>").
+  # @return [Array<Array<String,String>>] Array containing `[label, value]` for "date" and "datetime".
   def input_type_options
     %w(date datetime).map do |v|
       [ I18n.t("gws/column.options.date_input_type.#{v}"), v ]
     end
   end
 
-  # 検索ボックス右レールでは、from / to の2欄（日付範囲）として表示する。
+  ##
+  # Selects the search UI input type for this column to use a from/to date range layout.
+  # @return [String] The input type identifier "date_range", indicating the search box should render two fields for start and end timestamps.
   def search_input_type
     "date_range"
   end
 
-  # from / to で指定された範囲（当日を含む範囲）に一致するレコードを絞り込む条件を返す。
+  ##
+  # Builds query criteria to filter records within the range specified by `from`/`to`, treating date inputs as inclusive of the whole day.
+  # @param [Object] value - A hash-like object (responds to `#key?`) that may contain `:from`/`"from"` and `:to`/`"to"` entries.
+  # @return [Hash, nil] A hash mapping the stored file field name to a conditions hash containing `$gte` and/or `$lte` as applicable, or `nil` when no valid boundaries are present.
   def search_file_criteria(value)
     return unless value.respond_to?(:key?)
 
@@ -36,7 +45,10 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
   end
 
   # 適用中の絞り込み条件を「チップ」表示するための要素を返す。
-  # 日付範囲は from〜to を1チップにまとめ、解除すると範囲全体を外す（remaining: nil）。
+  ##
+  # Builds a single search filter chip representing a from–to date range when `value` contains `from` or `to`.
+  # @param [Hash, #key?] value - A hash-like object that may contain `:from`/"from" and `:to`/"to" string values.
+  # @return [Array<Hash>] An array with one chip hash `{ label: "...", remaining: nil }` when at least one boundary is present, or an empty array when both are blank.
   def search_filter_chips(value)
     return [] unless value.respond_to?(:key?)
 
@@ -47,6 +59,16 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
     [{ label: "#{name}: #{from}〜#{to}", remaining: nil }]
   end
 
+  ##
+  # Configure the given file model with the field, permitted params, validations, index and renderer mapping for this column.
+  #
+  # The configuration uses this column's `input_type`, `required?`, `unique_state` and `index_state` to:
+  # - add a field of `Date` or `DateTime`,
+  # - permit the field in params,
+  # - add appropriate date/datetime and presence/uniqueness validations,
+  # - create an index with ordering and uniqueness options when requested,
+  # - register the column's value renderer in the model's renderer factory map.
+  # @param [Class] file_model - The file model class or model-like object to be configured.
   def configure_file(file_model)
     field_name = store_as_in_file
     if input_type == 'date'
@@ -88,6 +110,13 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
     Gws::Tabular::Column::DateTimeFieldComponent.new(value: value, type: type, column: self, **options)
   end
 
+  ##
+  # Format the stored date or datetime value for CSV export.
+  #
+  # Converts `db_value` to a locale-aware CSV string; when `input_type` is `"date"` the value is converted to a Date before formatting.
+  # Returns nil if `db_value` is blank.
+  # @param [Object] db_value - The stored value (Time/Date/DateTime or parsable value) to format.
+  # @return [String, nil] The localized CSV-formatted representation of the value, or `nil` when `db_value` is blank.
   def to_csv_value(_item, db_value, **_options)
     return if db_value.blank?
 
@@ -102,7 +131,12 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
   private
 
   # 検索フォームから渡された日付文字列を、絞り込みに使える境界値へ正規化する。
-  # 日付型は日付（当日を含む）として、日時型は当日の開始/終了時刻として扱う。
+  ##
+  # 指定した文字列を検索境界の値（date または time の境界）に正規化する。
+  # パースできないか空の場合は `nil` を返す。
+  # @param [String, nil] str - 日付/日時を表す文字列
+  # @param [Symbol] boundary - 境界種別。`:beginning` は日の開始、その他は日の終了として扱う
+  # @return [Date, Time, nil] `input_type` が `"date"` の場合は Date（その日全体を表す）、それ以外では境界に応じた Time（当日の開始時刻または終了時刻）。パース失敗または入力空の場合は `nil`
   def normalize_search_boundary(str, boundary)
     return if str.blank?
 

--- a/app/models/gws/tabular/column/date_time_field.rb
+++ b/app/models/gws/tabular/column/date_time_field.rb
@@ -14,6 +14,27 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
     end
   end
 
+  # 検索ボックス右レールでは、from / to の2欄（日付範囲）として表示する。
+  def search_input_type
+    "date_range"
+  end
+
+  # from / to で指定された範囲（当日を含む範囲）に一致するレコードを絞り込む条件を返す。
+  def search_file_criteria(value)
+    return unless value.respond_to?(:key?)
+
+    conditions = {}
+    if (from_value = normalize_search_boundary(value[:from] || value["from"], :beginning))
+      conditions["$gte"] = from_value
+    end
+    if (to_value = normalize_search_boundary(value[:to] || value["to"], :end))
+      conditions["$lte"] = to_value
+    end
+    return if conditions.blank?
+
+    { store_as_in_file => conditions }
+  end
+
   def configure_file(file_model)
     field_name = store_as_in_file
     if input_type == 'date'
@@ -63,6 +84,30 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
       I18n.l(db_value.to_date, format: :csv)
     else # "datetime"
       I18n.l(db_value, format: :csv)
+    end
+  end
+
+  private
+
+  # 検索フォームから渡された日付文字列を、絞り込みに使える境界値へ正規化する。
+  # 日付型は日付（当日を含む）として、日時型は当日の開始/終了時刻として扱う。
+  def normalize_search_boundary(str, boundary)
+    return if str.blank?
+
+    time =
+      begin
+        Time.zone.parse(str.to_s)
+      rescue ArgumentError, TypeError
+        nil
+      end
+    return if time.blank?
+
+    if input_type == "date"
+      time.to_date
+    elsif boundary == :beginning
+      time.beginning_of_day
+    else
+      time.end_of_day
     end
   end
 end

--- a/app/models/gws/tabular/column/date_time_field.rb
+++ b/app/models/gws/tabular/column/date_time_field.rb
@@ -141,7 +141,8 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
   # 指定した文字列を検索境界の値（date または time の境界）に正規化する。
   # パースできないか空の場合は `nil` を返す。
   # @param [String, nil] str - 日付/日時を表す文字列
-  # @param [Symbol] boundary - 境界種別。`:beginning` は日の開始、その他は日の終了として扱う
+  # @param [Symbol] boundary - 境界種別。`:beginning` の場合は日の開始時刻、`:end` の場合は日の終了時刻として扱う
+  #   （`input_type` が `"date"` の場合は無視される）
   # @return [Date, Time, nil] `input_type` が `"date"` の場合は Date（その日全体を表す）、それ以外では境界に応じた Time（当日の開始時刻または終了時刻）。パース失敗または入力空の場合は `nil`
   def normalize_search_boundary(str, boundary)
     return if str.blank?

--- a/app/models/gws/tabular/column/date_time_field.rb
+++ b/app/models/gws/tabular/column/date_time_field.rb
@@ -35,6 +35,18 @@ class Gws::Tabular::Column::DateTimeField < Gws::Column::Base
     { store_as_in_file => conditions }
   end
 
+  # 適用中の絞り込み条件を「チップ」表示するための要素を返す。
+  # 日付範囲は from〜to を1チップにまとめ、解除すると範囲全体を外す（remaining: nil）。
+  def search_filter_chips(value)
+    return [] unless value.respond_to?(:key?)
+
+    from = (value[:from] || value["from"]).to_s.strip
+    to = (value[:to] || value["to"]).to_s.strip
+    return [] if from.blank? && to.blank?
+
+    [{ label: "#{name}: #{from}〜#{to}", remaining: nil }]
+  end
+
   def configure_file(file_model)
     field_name = store_as_in_file
     if input_type == 'date'

--- a/app/models/gws/tabular/column/enum_field.rb
+++ b/app/models/gws/tabular/column/enum_field.rb
@@ -22,18 +22,28 @@ class Gws::Tabular::Column::EnumField < Gws::Column::Base
     end
   end
 
+  ##
+  # Returns the available input type choices for the column as translated label/value pairs.
+  # @return [Array] An array of [label, value] pairs where `label` is the translated name and `value` is one of "radio", "checkbox", or "select".
   def input_type_options
     %w(radio checkbox select).map do |v|
       [ I18n.t("gws/tabular.options.enum_input_type.#{v}"), v ]
     end
   end
 
-  # 検索ボックス右レールでは、選択肢のチェックボックス一覧として表示する。
+  ##
+  # 検索ボックス右レールで選択肢をチェックボックス一覧として表示する。
+  # @return [String] "checkbox"（右レール用の入力種別）
   def search_input_type
     "checkbox"
   end
 
-  # 選択された選択肢に完全一致（$in）するレコードを絞り込む条件を返す。
+  ##
+  # Builds a MongoDB `$in` query criteria for the file-stored field from the given filter value(s).
+  # The input is normalized to an array of non-blank strings, restricted to the column's `select_options`,
+  # and if any values remain returns `{ store_as_in_file => { "$in" => values } }`; returns `nil` when no valid values.
+  # @param [Object] value - A single value or an array of values to filter by.
+  # @return [Hash, nil] The criteria hash for matching stored file values, or `nil` if there are no valid values.
   def search_file_criteria(value)
     values = Array(value).flatten.map { |v| v.to_s.strip }.select(&:present?)
     values &= select_options.to_a
@@ -43,7 +53,12 @@ class Gws::Tabular::Column::EnumField < Gws::Column::Base
   end
 
   # 適用中の絞り込み条件を「チップ」表示するための要素を返す。
-  # 選択値ごとに1チップを作り、remaining はその値を外した残りの選択値（空なら nil）。
+  ##
+  # Builds an array of filter "chips" for each selected enum value.
+  # @param [Array, String, nil] value - Input value or values to normalize and filter against the column's select options.
+  # @return [Array<Hash>] Array of hashes for each selected value. Each hash contains:
+  #   - :label => "#{name}: <value>"
+  #   - :remaining => an array of the other selected values, or nil if none remain.
   def search_filter_chips(value)
     values = Array(value).flatten.map { |v| v.to_s.strip }.select(&:present?)
     values &= select_options.to_a
@@ -52,6 +67,14 @@ class Gws::Tabular::Column::EnumField < Gws::Column::Base
     end
   end
 
+  ##
+  # Configure the given file model to persist and render this enum column.
+  #
+  # Adds a field named by `store_as_in_file` (type `SS::Extensions::Words`), permits it for mass assignment,
+  # normalizes its values before validation (strip + remove blanks), enforces inclusion in `select_options`,
+  # requires presence when the column is required, constrains length to 1 for `radio`/`select` input types,
+  # creates a DB index according to `index_state`, and registers renderer and Liquid factories for the field.
+  # @param [Class] file_model - The file model class to modify; the field name is derived from `store_as_in_file`.
   def configure_file(file_model)
     field_name = store_as_in_file
     file_model.field field_name, type: SS::Extensions::Words

--- a/app/models/gws/tabular/column/enum_field.rb
+++ b/app/models/gws/tabular/column/enum_field.rb
@@ -28,6 +28,20 @@ class Gws::Tabular::Column::EnumField < Gws::Column::Base
     end
   end
 
+  # 検索ボックス右レールでは、選択肢のチェックボックス一覧として表示する。
+  def search_input_type
+    "checkbox"
+  end
+
+  # 選択された選択肢に完全一致（$in）するレコードを絞り込む条件を返す。
+  def search_file_criteria(value)
+    values = Array(value).flatten.map { |v| v.to_s.strip }.select(&:present?)
+    values &= select_options.to_a
+    return if values.blank?
+
+    { store_as_in_file => { "$in" => values } }
+  end
+
   def configure_file(file_model)
     field_name = store_as_in_file
     file_model.field field_name, type: SS::Extensions::Words

--- a/app/models/gws/tabular/column/enum_field.rb
+++ b/app/models/gws/tabular/column/enum_field.rb
@@ -42,6 +42,16 @@ class Gws::Tabular::Column::EnumField < Gws::Column::Base
     { store_as_in_file => { "$in" => values } }
   end
 
+  # 適用中の絞り込み条件を「チップ」表示するための要素を返す。
+  # 選択値ごとに1チップを作り、remaining はその値を外した残りの選択値（空なら nil）。
+  def search_filter_chips(value)
+    values = Array(value).flatten.map { |v| v.to_s.strip }.select(&:present?)
+    values &= select_options.to_a
+    values.map do |v|
+      { label: "#{name}: #{v}", remaining: (values - [v]).presence }
+    end
+  end
+
   def configure_file(file_model)
     field_name = store_as_in_file
     file_model.field field_name, type: SS::Extensions::Words

--- a/app/models/gws/tabular/column/enum_field.rb
+++ b/app/models/gws/tabular/column/enum_field.rb
@@ -24,7 +24,8 @@ class Gws::Tabular::Column::EnumField < Gws::Column::Base
 
   ##
   # Returns the available input type choices for the column as translated label/value pairs.
-  # @return [Array] An array of [label, value] pairs where `label` is the translated name and `value` is one of "radio", "checkbox", or "select".
+  # @return [Array] An array of [label, value] pairs where `label` is the translated name and `value`
+  #   is one of "radio", "checkbox", or "select".
   def input_type_options
     %w(radio checkbox select).map do |v|
       [ I18n.t("gws/tabular.options.enum_input_type.#{v}"), v ]

--- a/app/models/gws/tabular/file.rb
+++ b/app/models/gws/tabular/file.rb
@@ -21,7 +21,7 @@ module Gws::Tabular::File
     cattr_accessor(:display_order_hash, instance_accessor: false)
     self.display_order_hash = {}
     cattr_accessor(:search_handlers, instance_accessor: false)
-    self.search_handlers = %i[search_keyword search_act]
+    self.search_handlers = %i[search_keyword search_columns search_act]
 
     field :migration_errors, type: Array
 

--- a/app/views/gws/tabular/files/_applied_filters.html.erb
+++ b/app/views/gws/tabular/files/_applied_filters.html.erb
@@ -3,7 +3,10 @@
   return if filters.blank?
 %>
 <div class="gws-tabular-applied-filters">
-  <span class="gws-tabular-applied-filters-label"><%= t("gws/tabular.search.applied_filters") %></span>
+  <span class="gws-tabular-applied-filters-label">
+    <span class="material-icons-outlined md-15" aria-hidden="true">filter_alt</span>
+    <span><%= t("gws/tabular.search.applied_filters") %></span>
+  </span>
   <ul class="gws-tabular-applied-filters-list">
     <% filters.each do |filter| %>
       <li class="gws-tabular-applied-filter">

--- a/app/views/gws/tabular/files/_applied_filters.html.erb
+++ b/app/views/gws/tabular/files/_applied_filters.html.erb
@@ -1,0 +1,18 @@
+<%
+  filters = gws_tabular_applied_search_filters(@s, @model)
+  return if filters.blank?
+%>
+<div class="gws-tabular-applied-filters">
+  <span class="gws-tabular-applied-filters-label"><%= t("gws/tabular.search.applied_filters") %></span>
+  <ul class="gws-tabular-applied-filters-list">
+    <% filters.each do |filter| %>
+      <li class="gws-tabular-applied-filter">
+        <span class="gws-tabular-applied-filter-text"><%= filter[:label] %></span>
+        <%= link_to filter[:url], class: "gws-tabular-applied-filter-remove", title: t("gws/tabular.search.remove_filter") do %>
+          <span class="material-icons-outlined md-15">close</span>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+  <%= link_to t("gws/tabular.search.clear_all"), gws_tabular_clear_search_url, class: "gws-tabular-applied-filters-clear" %>
+</div>

--- a/app/views/gws/tabular/files/_applied_filters.html.erb
+++ b/app/views/gws/tabular/files/_applied_filters.html.erb
@@ -8,8 +8,9 @@
     <% filters.each do |filter| %>
       <li class="gws-tabular-applied-filter">
         <span class="gws-tabular-applied-filter-text"><%= filter[:label] %></span>
-        <%= link_to filter[:url], class: "gws-tabular-applied-filter-remove", title: t("gws/tabular.search.remove_filter") do %>
-          <span class="material-icons-outlined md-15">close</span>
+        <%= link_to filter[:url], class: "gws-tabular-applied-filter-remove",
+          title: t("gws/tabular.search.remove_filter"), aria: { label: t("gws/tabular.search.remove_filter") } do %>
+          <span class="material-icons-outlined md-15" aria-hidden="true">close</span>
         <% end %>
       </li>
     <% end %>

--- a/app/views/gws/tabular/files/_applied_filters.html.erb
+++ b/app/views/gws/tabular/files/_applied_filters.html.erb
@@ -3,23 +3,15 @@
   return if filters.blank?
 %>
 <div class="gws-tabular-applied-filters">
-  <span class="gws-tabular-applied-filters-label">
-    <span class="material-icons-outlined md-15" aria-hidden="true">filter_alt</span>
-    <span><%= t("gws/tabular.search.applied_filters") %></span>
-  </span>
+  <span class="gws-tabular-applied-filters-label"><%= t("gws/tabular.search.applied_filters") %></span>
   <ul class="gws-tabular-applied-filters-list">
     <% filters.each do |filter| %>
       <li class="gws-tabular-applied-filter">
         <span class="gws-tabular-applied-filter-text"><%= filter[:label] %></span>
-        <%= link_to filter[:url], class: "gws-tabular-applied-filter-remove",
-          title: t("gws/tabular.search.remove_filter"), aria: { label: t("gws/tabular.search.remove_filter") } do %>
-          <span class="material-icons-outlined md-15" aria-hidden="true">close</span>
-        <% end %>
+        <%= link_to "", filter[:url], class: "gws-tabular-applied-filter-remove",
+          title: t("gws/tabular.search.remove_filter"), aria: { label: t("gws/tabular.search.remove_filter") } %>
       </li>
     <% end %>
   </ul>
-  <%= link_to gws_tabular_clear_search_url, class: "gws-tabular-applied-filters-clear" do %>
-    <span class="material-icons-outlined md-15" aria-hidden="true">filter_alt_off</span>
-    <span><%= t("gws/tabular.search.clear_all") %></span>
-  <% end %>
+  <%= link_to t("gws/tabular.search.clear_all"), gws_tabular_clear_search_url, class: "gws-tabular-applied-filters-clear" %>
 </div>

--- a/app/views/gws/tabular/files/_applied_filters.html.erb
+++ b/app/views/gws/tabular/files/_applied_filters.html.erb
@@ -15,5 +15,8 @@
       </li>
     <% end %>
   </ul>
-  <%= link_to t("gws/tabular.search.clear_all"), gws_tabular_clear_search_url, class: "gws-tabular-applied-filters-clear" %>
+  <%= link_to gws_tabular_clear_search_url, class: "gws-tabular-applied-filters-clear" do %>
+    <span class="material-icons-outlined md-15" aria-hidden="true">filter_alt_off</span>
+    <span><%= t("gws/tabular.search.clear_all") %></span>
+  <% end %>
 </div>

--- a/app/views/gws/tabular/files/_list_head.html.erb
+++ b/app/views/gws/tabular/files/_list_head.html.erb
@@ -38,5 +38,7 @@
     </div>
   <% end %>
 
-  <%= render template: "_search" %>
+  <% unless @gws_tabular_search_rail %>
+    <%= render template: "_search" %>
+  <% end %>
 </div>

--- a/app/views/gws/tabular/files/_search.html.erb
+++ b/app/views/gws/tabular/files/_search.html.erb
@@ -58,6 +58,7 @@
     <% if search_rail %>
       <div class="gws-tabular-file-search-actions">
         <%= f.submit t('ss.buttons.search'), class: "btn", name: nil %>
+        <%= link_to t('ss.buttons.reset'), { action: :index }, class: "btn" %>
       </div>
     <% else %>
       <%= f.submit t('ss.buttons.search'), class: "btn", name: nil %>

--- a/app/views/gws/tabular/files/_search.html.erb
+++ b/app/views/gws/tabular/files/_search.html.erb
@@ -1,11 +1,66 @@
 <%
-  return if @model.keyword_fields.blank?
+  search_rail = local_assigns[:search_rail]
+  has_keyword = @model.keyword_fields.present?
+  search_columns =
+    if search_rail && @model.respond_to?(:search_column_candidates)
+      @model.search_column_candidates
+    else
+      []
+    end
+  return if !has_keyword && search_columns.blank?
 
   @s ||= OpenStruct.new params[:s]
+  col_params = @s[:col].presence || {}
 %>
-<div class="list-head-search">
+<div class="list-head-search<%= search_rail ? " gws-tabular-file-search" : "" %>">
   <%= form_with scope: :s, url: "", class: "index-search", method: :get do |f| %>
-    <%= f.text_field :keyword, placeholder: t('ss.keyword'), style: "width: 300px;", id: nil %>
-    <%= f.submit t('ss.buttons.search'), class: "btn", name: nil %>
+    <% if has_keyword %>
+      <% if search_rail %>
+        <div class="gws-tabular-file-search-keyword">
+          <%= f.text_field :keyword, placeholder: t('ss.keyword'), id: nil %>
+        </div>
+      <% else %>
+        <%= f.text_field :keyword, placeholder: t('ss.keyword'), style: "width: 300px;", id: nil %>
+      <% end %>
+    <% end %>
+
+    <% search_columns.each do |column| %>
+      <% selected = col_params[column.id.to_s] %>
+      <div class="gws-tabular-file-search-section" data-column-id="<%= column.id %>">
+        <h3 class="gws-tabular-file-search-section-head"><%= column.name %></h3>
+        <% case column.search_input_type %>
+        <% when "checkbox" %>
+          <% selected_values = Array(selected).map(&:to_s) %>
+          <ul class="gws-tabular-file-search-options">
+            <% column.select_options.to_a.each do |option| %>
+              <li class="gws-tabular-file-search-option">
+                <label>
+                  <%= check_box_tag "s[col][#{column.id}][]", option, selected_values.include?(option.to_s), id: nil %>
+                  <span><%= option %></span>
+                </label>
+              </li>
+            <% end %>
+          </ul>
+        <% when "date_range" %>
+          <%
+            from_value = selected.respond_to?(:key?) ? (selected["from"] || selected[:from]) : nil
+            to_value = selected.respond_to?(:key?) ? (selected["to"] || selected[:to]) : nil
+          %>
+          <div class="gws-tabular-file-search-date-range">
+            <%= ss_date_field_tag "s[col][#{column.id}][from]", from_value, {}, class: "gws-tabular-file-search-date", title: t("gws/tabular.search.date_from") %>
+            <span class="gws-tabular-file-search-date-sep">〜</span>
+            <%= ss_date_field_tag "s[col][#{column.id}][to]", to_value, {}, class: "gws-tabular-file-search-date", title: t("gws/tabular.search.date_to") %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if search_rail %>
+      <div class="gws-tabular-file-search-actions">
+        <%= f.submit t('ss.buttons.search'), class: "btn", name: nil %>
+      </div>
+    <% else %>
+      <%= f.submit t('ss.buttons.search'), class: "btn", name: nil %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/gws/tabular/files/_search.html.erb
+++ b/app/views/gws/tabular/files/_search.html.erb
@@ -24,6 +24,13 @@
       <% end %>
     <% end %>
 
+    <% if search_rail && search_columns.present? %>
+      <%# 絞り込み項目が多いと末尾の検索ボタンが下方に離れるため、上部にも検索ボタンを置く %>
+      <div class="gws-tabular-file-search-actions gws-tabular-file-search-actions-top">
+        <%= f.submit t('ss.buttons.search'), class: "btn", name: nil %>
+      </div>
+    <% end %>
+
     <% search_columns.each do |column| %>
       <% selected = col_params[column.id.to_s] %>
       <div class="gws-tabular-file-search-section" data-column-id="<%= column.id %>">

--- a/app/views/gws/tabular/files/default_view/index.html.erb
+++ b/app/views/gws/tabular/files/default_view/index.html.erb
@@ -35,7 +35,7 @@
 <%= tag.div class: "gws-tabular-views-main-box", data: { controller: "ss--list-action-enabler" } do %>
   <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
     <div class="gws-tabular-file-index-list">
-      <%= render "applied_filters" %>
+      <%= render "gws/tabular/files/applied_filters" %>
       <%= render template: "gws/crud/index" %>
     </div>
     <% if show_search_rail %>

--- a/app/views/gws/tabular/files/default_view/index.html.erb
+++ b/app/views/gws/tabular/files/default_view/index.html.erb
@@ -35,6 +35,7 @@
 <%= tag.div class: "gws-tabular-views-main-box", data: { controller: "ss--list-action-enabler" } do %>
   <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
     <div class="gws-tabular-file-index-list">
+      <%= render "applied_filters" %>
       <%= render template: "gws/crud/index" %>
     </div>
     <% if show_search_rail %>

--- a/app/views/gws/tabular/files/default_view/index.html.erb
+++ b/app/views/gws/tabular/files/default_view/index.html.erb
@@ -1,7 +1,8 @@
 <%
   columns = cur_form.columns.reorder(order: 1, id: 1).to_a
   search_columns = @model.respond_to?(:search_column_candidates) ? @model.search_column_candidates : []
-  show_search_rail = !@trash && (@model.keyword_fields.present? || search_columns.present?)
+  # 絞り込み項目（タクソノミー）があるときだけ右レールを表示し、キーワードのみのときは従来の検索ボックスを表示する
+  show_search_rail = !@trash && search_columns.present?
   # 右レールにキーワード欄をまとめるため、一覧ヘッダー側の検索ボックスは抑制する
   @gws_tabular_search_rail = show_search_rail
 %>

--- a/app/views/gws/tabular/files/default_view/index.html.erb
+++ b/app/views/gws/tabular/files/default_view/index.html.erb
@@ -1,5 +1,9 @@
 <%
   columns = cur_form.columns.reorder(order: 1, id: 1).to_a
+  search_columns = @model.respond_to?(:search_column_candidates) ? @model.search_column_candidates : []
+  show_search_rail = !@trash && (@model.keyword_fields.present? || search_columns.present?)
+  # 右レールにキーワード欄をまとめるため、一覧ヘッダー側の検索ボックスは抑制する
+  @gws_tabular_search_rail = show_search_rail
 %>
 <% @tap_menu = proc do |item| %>
   <%= link_to t('ss.links.show'), url_for(action: :show, id: item) if item.allowed?(:read, @cur_user, site: @cur_site) %>
@@ -28,5 +32,14 @@
 <% end %>
 
 <%= tag.div class: "gws-tabular-views-main-box", data: { controller: "ss--list-action-enabler" } do %>
-  <%= render template: "gws/crud/index" %>
+  <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
+    <div class="gws-tabular-file-index-list">
+      <%= render template: "gws/crud/index" %>
+    </div>
+    <% if show_search_rail %>
+      <aside class="gws-tabular-file-index-rail">
+        <%= render template: "_search", locals: { search_rail: true } %>
+      </aside>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/gws/tabular/files/index.html.erb
+++ b/app/views/gws/tabular/files/index.html.erb
@@ -1,7 +1,5 @@
 <%
   columns = cur_form.columns.reorder(order: 1, id: 1).to_a
-  search_columns = @model.respond_to?(:search_column_candidates) ? @model.search_column_candidates : []
-  show_search_rail = @model.keyword_fields.present? || search_columns.present?
 %>
 
 <%= tag.div class: "main-box gws-tabular-file-main-box", data: { controller: "ss--list-action-enabler" } do %>
@@ -14,61 +12,54 @@
         <% end %>
       </div>
     </div>
-  </div>
-  <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
-    <div class="gws-tabular-file-index-list">
-      <table class="index">
-        <thead class="list-head">
-        <tr>
-          <th><input type="checkbox" /></th>
-          <% columns.each do |column| %>
-            <th><%= column.name %></th>
-          <% end %>
-          <% if cur_form.workflow_enabled? %>
-            <th><%= @model.t :workflow_state %></th>
-            <th><%= @model.t :destination_treat_state %></th>
-          <% end %>
-          <th><%= @model.t :updated %></th>
-          <th></th>
-        </tr>
-        </thead>
-        <tbody>
-        <% @items.each do |item| %>
-        <tr class="list-item" data-id="<%= item.id %>">
-          <td><input type="checkbox" name="ids[]" value="<%= item.id %>" /></td>
-          <% columns.each do |column| %>
-            <% column_value = item.column_values.where(column_id: column.id).first %>
-            <td><%= column_value.to_html %></td>
-          <% end %>
-          <% if cur_form.workflow_enabled? %>
-            <td><%= t("workflow.state.#{item.workflow_state.presence || "draft"}") %></td>
-            <td><%= item.label(:destination_treat_state) %></td>
-          <% end %>
-          <td><%= ss_time_tag item.updated %></td>
-          <td>
-            <%= link_to t('ss.links.show'), url_for(action: :show, id: item), class: 'btn primary' if item.allowed?(:read, @cur_user, site: @cur_site) %>
-            <%=
-              if item.allowed?(:edit, @cur_user, site: @cur_site)
-                link_to tag.span("edit", class: "material-icons-outlined md-15"), url_for(action: :edit, id: item), class: 'btn', title: t('ss.links.edit') rescue nil
-              end
-            %>
-            <%=
-              if item.allowed?(:delete, @cur_user, site: @cur_site)
-                link_to tag.span("delete", class: "material-icons-outlined md-15"), url_for(action: :destroy, id: item), class: 'btn', title: t('ss.links.delete'), method: "delete", data: { confirm: t('ss.confirm.delete') } rescue nil
-              end
-            %>
-          </td>
-        </tr>
-        <% end %>
-        </tbody>
-      </table>
 
-      <%= paginate @items if @items.try(:current_page) %>
-    </div>
-    <% if show_search_rail %>
-      <aside class="gws-tabular-file-index-rail">
-        <%= render template: "_search", locals: { search_rail: true } %>
-      </aside>
-    <% end %>
+    <%= render template: "_search" %>
   </div>
+  <table class="index">
+    <thead class="list-head">
+    <tr>
+      <th><input type="checkbox" /></th>
+      <% columns.each do |column| %>
+        <th><%= column.name %></th>
+      <% end %>
+      <% if cur_form.workflow_enabled? %>
+        <th><%= @model.t :workflow_state %></th>
+        <th><%= @model.t :destination_treat_state %></th>
+      <% end %>
+      <th><%= @model.t :updated %></th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @items.each do |item| %>
+    <tr class="list-item" data-id="<%= item.id %>">
+      <td><input type="checkbox" name="ids[]" value="<%= item.id %>" /></td>
+      <% columns.each do |column| %>
+        <% column_value = item.column_values.where(column_id: column.id).first %>
+        <td><%= column_value.to_html %></td>
+      <% end %>
+      <% if cur_form.workflow_enabled? %>
+        <td><%= t("workflow.state.#{item.workflow_state.presence || "draft"}") %></td>
+        <td><%= item.label(:destination_treat_state) %></td>
+      <% end %>
+      <td><%= ss_time_tag item.updated %></td>
+      <td>
+        <%= link_to t('ss.links.show'), url_for(action: :show, id: item), class: 'btn primary' if item.allowed?(:read, @cur_user, site: @cur_site) %>
+        <%=
+          if item.allowed?(:edit, @cur_user, site: @cur_site)
+            link_to tag.span("edit", class: "material-icons-outlined md-15"), url_for(action: :edit, id: item), class: 'btn', title: t('ss.links.edit') rescue nil
+          end
+        %>
+        <%=
+          if item.allowed?(:delete, @cur_user, site: @cur_site)
+            link_to tag.span("delete", class: "material-icons-outlined md-15"), url_for(action: :destroy, id: item), class: 'btn', title: t('ss.links.delete'), method: "delete", data: { confirm: t('ss.confirm.delete') } rescue nil
+          end
+        %>
+      </td>
+    </tr>
+    <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @items if @items.try(:current_page) %>
 <% end %>

--- a/app/views/gws/tabular/files/index.html.erb
+++ b/app/views/gws/tabular/files/index.html.erb
@@ -1,5 +1,7 @@
 <%
   columns = cur_form.columns.reorder(order: 1, id: 1).to_a
+  search_columns = @model.respond_to?(:search_column_candidates) ? @model.search_column_candidates : []
+  show_search_rail = @model.keyword_fields.present? || search_columns.present?
 %>
 
 <%= tag.div class: "main-box gws-tabular-file-main-box", data: { controller: "ss--list-action-enabler" } do %>
@@ -12,54 +14,61 @@
         <% end %>
       </div>
     </div>
-
-    <%= render template: "_search" %>
   </div>
-  <table class="index">
-    <thead class="list-head">
-    <tr>
-      <th><input type="checkbox" /></th>
-      <% columns.each do |column| %>
-        <th><%= column.name %></th>
-      <% end %>
-      <% if cur_form.workflow_enabled? %>
-        <th><%= @model.t :workflow_state %></th>
-        <th><%= @model.t :destination_treat_state %></th>
-      <% end %>
-      <th><%= @model.t :updated %></th>
-      <th></th>
-    </tr>
-    </thead>
-    <tbody>
-    <% @items.each do |item| %>
-    <tr class="list-item" data-id="<%= item.id %>">
-      <td><input type="checkbox" name="ids[]" value="<%= item.id %>" /></td>
-      <% columns.each do |column| %>
-        <% column_value = item.column_values.where(column_id: column.id).first %>
-        <td><%= column_value.to_html %></td>
-      <% end %>
-      <% if cur_form.workflow_enabled? %>
-        <td><%= t("workflow.state.#{item.workflow_state.presence || "draft"}") %></td>
-        <td><%= item.label(:destination_treat_state) %></td>
-      <% end %>
-      <td><%= ss_time_tag item.updated %></td>
-      <td>
-        <%= link_to t('ss.links.show'), url_for(action: :show, id: item), class: 'btn primary' if item.allowed?(:read, @cur_user, site: @cur_site) %>
-        <%=
-          if item.allowed?(:edit, @cur_user, site: @cur_site)
-            link_to tag.span("edit", class: "material-icons-outlined md-15"), url_for(action: :edit, id: item), class: 'btn', title: t('ss.links.edit') rescue nil
-          end
-        %>
-        <%=
-          if item.allowed?(:delete, @cur_user, site: @cur_site)
-            link_to tag.span("delete", class: "material-icons-outlined md-15"), url_for(action: :destroy, id: item), class: 'btn', title: t('ss.links.delete'), method: "delete", data: { confirm: t('ss.confirm.delete') } rescue nil
-          end
-        %>
-      </td>
-    </tr>
-    <% end %>
-    </tbody>
-  </table>
+  <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
+    <div class="gws-tabular-file-index-list">
+      <table class="index">
+        <thead class="list-head">
+        <tr>
+          <th><input type="checkbox" /></th>
+          <% columns.each do |column| %>
+            <th><%= column.name %></th>
+          <% end %>
+          <% if cur_form.workflow_enabled? %>
+            <th><%= @model.t :workflow_state %></th>
+            <th><%= @model.t :destination_treat_state %></th>
+          <% end %>
+          <th><%= @model.t :updated %></th>
+          <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <% @items.each do |item| %>
+        <tr class="list-item" data-id="<%= item.id %>">
+          <td><input type="checkbox" name="ids[]" value="<%= item.id %>" /></td>
+          <% columns.each do |column| %>
+            <% column_value = item.column_values.where(column_id: column.id).first %>
+            <td><%= column_value.to_html %></td>
+          <% end %>
+          <% if cur_form.workflow_enabled? %>
+            <td><%= t("workflow.state.#{item.workflow_state.presence || "draft"}") %></td>
+            <td><%= item.label(:destination_treat_state) %></td>
+          <% end %>
+          <td><%= ss_time_tag item.updated %></td>
+          <td>
+            <%= link_to t('ss.links.show'), url_for(action: :show, id: item), class: 'btn primary' if item.allowed?(:read, @cur_user, site: @cur_site) %>
+            <%=
+              if item.allowed?(:edit, @cur_user, site: @cur_site)
+                link_to tag.span("edit", class: "material-icons-outlined md-15"), url_for(action: :edit, id: item), class: 'btn', title: t('ss.links.edit') rescue nil
+              end
+            %>
+            <%=
+              if item.allowed?(:delete, @cur_user, site: @cur_site)
+                link_to tag.span("delete", class: "material-icons-outlined md-15"), url_for(action: :destroy, id: item), class: 'btn', title: t('ss.links.delete'), method: "delete", data: { confirm: t('ss.confirm.delete') } rescue nil
+              end
+            %>
+          </td>
+        </tr>
+        <% end %>
+        </tbody>
+      </table>
 
-  <%= paginate @items if @items.try(:current_page) %>
+      <%= paginate @items if @items.try(:current_page) %>
+    </div>
+    <% if show_search_rail %>
+      <aside class="gws-tabular-file-index-rail">
+        <%= render template: "_search", locals: { search_rail: true } %>
+      </aside>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/gws/tabular/files/liquid/index.html.erb
+++ b/app/views/gws/tabular/files/liquid/index.html.erb
@@ -1,9 +1,25 @@
+<%
+  search_columns = @model.respond_to?(:search_column_candidates) ? @model.search_column_candidates : []
+  # 絞り込み項目（タクソノミー）があるときだけ右レールを表示し、キーワードのみのときは従来の検索ボックスを表示する
+  show_search_rail = !@trash && search_columns.present?
+%>
 <div class="gws-tabular-views-main-box">
-  <div class="index">
-    <div class="list-head">
-      <%= render template: "_search" %>
-    </div>
+  <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
+    <div class="gws-tabular-file-index-list">
+      <div class="index">
+        <% unless show_search_rail %>
+          <div class="list-head">
+            <%= render template: "_search" %>
+          </div>
+        <% end %>
 
-    <%= render Gws::Tabular::View::LiquidComponent.new(cur_site: @cur_site, cur_space: cur_space, cur_form: cur_form, cur_view: cur_view, items: @items) %>
+        <%= render Gws::Tabular::View::LiquidComponent.new(cur_site: @cur_site, cur_space: cur_space, cur_form: cur_form, cur_view: cur_view, items: @items) %>
+      </div>
+    </div>
+    <% if show_search_rail %>
+      <aside class="gws-tabular-file-index-rail">
+        <%= render template: "_search", locals: { search_rail: true } %>
+      </aside>
+    <% end %>
   </div>
 </div>

--- a/app/views/gws/tabular/files/liquid/index.html.erb
+++ b/app/views/gws/tabular/files/liquid/index.html.erb
@@ -6,6 +6,7 @@
 <div class="gws-tabular-views-main-box">
   <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
     <div class="gws-tabular-file-index-list">
+      <%= render "applied_filters" %>
       <div class="index">
         <% unless show_search_rail %>
           <div class="list-head">

--- a/app/views/gws/tabular/files/liquid/index.html.erb
+++ b/app/views/gws/tabular/files/liquid/index.html.erb
@@ -6,7 +6,7 @@
 <div class="gws-tabular-views-main-box">
   <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
     <div class="gws-tabular-file-index-list">
-      <%= render "applied_filters" %>
+      <%= render "gws/tabular/files/applied_filters" %>
       <div class="index">
         <% unless show_search_rail %>
           <div class="list-head">

--- a/app/views/gws/tabular/files/list/index.html.erb
+++ b/app/views/gws/tabular/files/list/index.html.erb
@@ -1,6 +1,11 @@
 <%
   columns = nil
   id_column_map = nil
+  search_columns = @model.respond_to?(:search_column_candidates) ? @model.search_column_candidates : []
+  # 絞り込み項目（タクソノミー）があるときだけ右レールを表示し、キーワードのみのときは従来の検索ボックスを表示する
+  show_search_rail = !@trash && search_columns.present?
+  # 右レールにキーワード欄をまとめるため、一覧ヘッダー側の検索ボックスは抑制する
+  @gws_tabular_search_rail = show_search_rail
 %>
 <% @tap_menu = proc do |item| %>
   <%= link_to t('ss.links.show'), url_for(action: :show, id: item) if item.allowed?(:read, @cur_user, site: @cur_site) %>
@@ -41,5 +46,14 @@
 <% end %>
 
 <%= tag.div class: "gws-tabular-views-main-box", data: { controller: "ss--list-action-enabler" } do %>
-  <%= render template: "gws/crud/index" %>
+  <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
+    <div class="gws-tabular-file-index-list">
+      <%= render template: "gws/crud/index" %>
+    </div>
+    <% if show_search_rail %>
+      <aside class="gws-tabular-file-index-rail">
+        <%= render template: "_search", locals: { search_rail: true } %>
+      </aside>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/gws/tabular/files/list/index.html.erb
+++ b/app/views/gws/tabular/files/list/index.html.erb
@@ -48,6 +48,7 @@
 <%= tag.div class: "gws-tabular-views-main-box", data: { controller: "ss--list-action-enabler" } do %>
   <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
     <div class="gws-tabular-file-index-list">
+      <%= render "applied_filters" %>
       <%= render template: "gws/crud/index" %>
     </div>
     <% if show_search_rail %>

--- a/app/views/gws/tabular/files/list/index.html.erb
+++ b/app/views/gws/tabular/files/list/index.html.erb
@@ -48,7 +48,7 @@
 <%= tag.div class: "gws-tabular-views-main-box", data: { controller: "ss--list-action-enabler" } do %>
   <div class="gws-tabular-file-index-columns<%= show_search_rail ? "" : " gws-tabular-file-index-columns-no-rail" %>">
     <div class="gws-tabular-file-index-list">
-      <%= render "applied_filters" %>
+      <%= render "gws/tabular/files/applied_filters" %>
       <%= render template: "gws/crud/index" %>
     </div>
     <% if show_search_rail %>

--- a/config/locales/gws/tabular/en.yml
+++ b/config/locales/gws/tabular/en.yml
@@ -54,6 +54,9 @@ en:
         index: Select form
     buttons:
       manage_space: Space Management
+    search:
+      date_from: Date From
+      date_to: Date To
     notice:
       delay_download_with_message: |-
         Prepare files in the background.

--- a/config/locales/gws/tabular/en.yml
+++ b/config/locales/gws/tabular/en.yml
@@ -57,6 +57,9 @@ en:
     search:
       date_from: Date From
       date_to: Date To
+      applied_filters: "Applied filters"
+      clear_all: "Clear all"
+      remove_filter: "Remove this filter"
     notice:
       delay_download_with_message: |-
         Prepare files in the background.

--- a/config/locales/gws/tabular/ja.yml
+++ b/config/locales/gws/tabular/ja.yml
@@ -54,6 +54,9 @@ ja:
         index: 定義を選択する
     buttons:
       manage_space: スペース管理
+    search:
+      date_from: 開始日
+      date_to: 終了日
     notice:
       delay_download_with_message: |-
         バックグランドでファイルを準備します。

--- a/config/locales/gws/tabular/ja.yml
+++ b/config/locales/gws/tabular/ja.yml
@@ -57,6 +57,9 @@ ja:
     search:
       date_from: 開始日
       date_to: 終了日
+      applied_filters: 適用中の条件
+      clear_all: すべてクリア
+      remove_filter: この条件を外す
     notice:
       delay_download_with_message: |-
         バックグランドでファイルを準備します。

--- a/spec/features/gws/tabular/files/search_with_taxonomy_spec.rb
+++ b/spec/features/gws/tabular/files/search_with_taxonomy_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+# 検索ボックス右レール（タクソノミー）で一覧を絞り込む
+describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:admin) { gws_user }
+
+  let!(:permissions) { %w(use_gws_tabular read_gws_tabular_files edit_gws_tabular_files) }
+  let!(:role) { create :gws_role, cur_site: site, permissions: permissions }
+  let!(:user1) { create :gws_user, :gws_tabular_notice, group_ids: admin.group_ids, gws_role_ids: [ role.id ] }
+
+  let!(:space) { create :gws_tabular_space, cur_site: site, cur_user: admin, state: "public", readable_setting_range: "public" }
+  let!(:form) do
+    create(
+      :gws_tabular_form, cur_site: site, cur_space: space, cur_user: admin, state: 'publishing', revision: 1,
+      workflow_state: 'disabled', readable_setting_range: "public"
+    )
+  end
+  let(:select_options) { %w(alpha bravo charlie) }
+  let!(:name_column) do
+    create(
+      :gws_tabular_column_text_field, cur_site: site, cur_form: form, order: 10, required: "required",
+      name: "name", input_type: "single", validation_type: "none", i18n_state: "disabled", unique_state: "enabled")
+  end
+  let!(:enum_column) do
+    create(
+      :gws_tabular_column_enum_field, cur_site: site, cur_form: form, order: 20, required: "optional",
+      name: "category", select_options: select_options, input_type: "checkbox", index_state: 'asc')
+  end
+
+  before do
+    site.path_id = unique_id
+    site.canonical_scheme = %w(http https).sample
+    site.canonical_domain = "#{unique_id}.example.jp"
+    site.save!
+
+    Gws::Tabular::FormPublishJob.bind(site_id: site, user_id: admin).perform_now(form.id.to_s)
+
+    expect(Gws::Job::Log.count).to eq 1
+    Gws::Job::Log.all.each do |log|
+      expect(log.logs).to include(/INFO -- : .* Started Job/)
+      expect(log.logs).to include(/INFO -- : .* Completed Job/)
+    end
+    form.reload
+  end
+
+  context "filter by enum (category) checkbox" do
+    let(:file_model) { Gws::Tabular::File[form.current_release] }
+    let(:name_a) { "apple-#{unique_id}" }
+    let(:name_b) { "banana-#{unique_id}" }
+    let(:name_c) { "cherry-#{unique_id}" }
+    let!(:file_a) do
+      file_model.create!(
+        cur_user: user1, cur_site: site, cur_space: space, cur_form: form,
+        "col_#{name_column.id}" => name_a, "col_#{enum_column.id}" => %w(alpha))
+    end
+    let!(:file_b) do
+      file_model.create!(
+        cur_user: user1, cur_site: site, cur_space: space, cur_form: form,
+        "col_#{name_column.id}" => name_b, "col_#{enum_column.id}" => %w(bravo))
+    end
+    let!(:file_c) do
+      file_model.create!(
+        cur_user: user1, cur_site: site, cur_space: space, cur_form: form,
+        "col_#{name_column.id}" => name_c, "col_#{enum_column.id}" => %w(alpha))
+    end
+
+    it do
+      login_user user1, to: gws_tabular_files_path(site: site, space: space, form: form, view: "-")
+      wait_for_js_ready
+
+      within ".list-items" do
+        expect(page).to have_css(".list-item", count: 3)
+      end
+
+      expect(page).to have_css(".gws-tabular-file-index-rail")
+
+      within ".gws-tabular-file-index-rail" do
+        within ".gws-tabular-file-search-section[data-column-id='#{enum_column.id}']" do
+          find(".gws-tabular-file-search-option label", text: "alpha").click
+        end
+        click_on I18n.t("ss.buttons.search")
+      end
+      wait_for_js_ready
+
+      within ".list-items" do
+        expect(page).to have_css(".list-item", count: 2)
+        expect(page).to have_content(name_a)
+        expect(page).to have_content(name_c)
+        expect(page).to have_no_content(name_b)
+      end
+    end
+  end
+end

--- a/spec/features/gws/tabular/files/search_with_taxonomy_spec.rb
+++ b/spec/features/gws/tabular/files/search_with_taxonomy_spec.rb
@@ -79,7 +79,10 @@ describe Gws::Tabular::FilesController, type: :feature, dbscope: :example, js: t
         within ".gws-tabular-file-search-section[data-column-id='#{enum_column.id}']" do
           find(".gws-tabular-file-search-option label", text: "alpha").click
         end
-        click_on I18n.t("ss.buttons.search")
+        # キーワード直下とフォーム末尾の2か所に検索ボタンがあるため、上部のボタンを明示的に押す
+        within ".gws-tabular-file-search-actions-top" do
+          click_on I18n.t("ss.buttons.search")
+        end
       end
       wait_for_js_ready
 

--- a/spec/models/gws/tabular/file/search_columns_spec.rb
+++ b/spec/models/gws/tabular/file/search_columns_spec.rb
@@ -30,6 +30,11 @@ describe Gws::Tabular::File, type: :model, dbscope: :example do
     expect(form.state).to eq 'public'
   end
 
+  ##
+  # Creates and saves a file record for the form's current release and assigns optional column values.
+  # @param [Array<String>, nil] enum_values - Values to set on the enum column, or `nil` to leave unset.
+  # @param [Date, Time, String, nil] date_value - Value to set on the date/datetime column, or `nil` to leave unset.
+  # @return [Gws::Tabular::File] The saved file record.
   def create_file(enum_values: nil, date_value: nil)
     file = file_model.new(cur_site: site, cur_space: space, cur_form: form)
     file.send("#{enum_field}=", enum_values) if enum_values

--- a/spec/models/gws/tabular/file/search_columns_spec.rb
+++ b/spec/models/gws/tabular/file/search_columns_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe Gws::Tabular::File, type: :model, dbscope: :example do
+  let!(:site) { gws_site }
+  let!(:user) { gws_user }
+  let!(:space) { create :gws_tabular_space, cur_site: site }
+  let!(:form) { create :gws_tabular_form, cur_site: site, cur_space: space, state: 'publishing', revision: 1 }
+
+  let(:select_options) { %w(alpha bravo charlie) }
+  let!(:enum_column) do
+    create(
+      :gws_tabular_column_enum_field, cur_site: site, cur_form: form, order: 10,
+      required: "optional", select_options: select_options, input_type: "checkbox", index_state: 'asc'
+    )
+  end
+  let!(:date_column) do
+    create(
+      :gws_tabular_column_date_time_field, cur_site: site, cur_form: form, order: 20,
+      required: "optional", input_type: input_type, index_state: 'asc', unique_state: 'disabled'
+    )
+  end
+
+  let(:file_model) { Gws::Tabular::File[form.current_release] }
+  let(:enum_field) { "col_#{enum_column.id}" }
+  let(:date_field) { "col_#{date_column.id}" }
+
+  before do
+    Gws::Tabular::FormPublishJob.bind(site_id: site, user_id: user).perform_now(form.id.to_s)
+    form.reload
+    expect(form.state).to eq 'public'
+  end
+
+  def create_file(enum_values: nil, date_value: nil)
+    file = file_model.new(cur_site: site, cur_space: space, cur_form: form)
+    file.send("#{enum_field}=", enum_values) if enum_values
+    file.send("#{date_field}=", date_value) if date_value
+    file.save!
+    file
+  end
+
+  context "with date input_type" do
+    let(:input_type) { "date" }
+
+    let!(:file_alpha) { create_file(enum_values: %w(alpha), date_value: Date.new(2026, 6, 1)) }
+    let!(:file_bravo) { create_file(enum_values: %w(bravo), date_value: Date.new(2026, 6, 10)) }
+    let!(:file_charlie) { create_file(enum_values: %w(charlie), date_value: Date.new(2026, 6, 20)) }
+
+    it "filters by enum column ($in / exact match)" do
+      result = file_model.search(col: { enum_column.id.to_s => %w(alpha) }).to_a
+      expect(result.map(&:id)).to contain_exactly(file_alpha.id)
+    end
+
+    it "filters by multiple enum values" do
+      result = file_model.search(col: { enum_column.id.to_s => %w(alpha charlie) }).to_a
+      expect(result.map(&:id)).to contain_exactly(file_alpha.id, file_charlie.id)
+    end
+
+    it "ignores blank enum selection" do
+      result = file_model.search(col: { enum_column.id.to_s => [ "" ] }).to_a
+      expect(result.map(&:id)).to contain_exactly(file_alpha.id, file_bravo.id, file_charlie.id)
+    end
+
+    it "filters by date range (from / to, inclusive of boundary days)" do
+      result = file_model.search(col: { date_column.id.to_s => { "from" => "2026/06/05", "to" => "2026/06/20" } }).to_a
+      expect(result.map(&:id)).to contain_exactly(file_bravo.id, file_charlie.id)
+    end
+
+    it "filters by date range with only from" do
+      result = file_model.search(col: { date_column.id.to_s => { "from" => "2026/06/10" } }).to_a
+      expect(result.map(&:id)).to contain_exactly(file_bravo.id, file_charlie.id)
+    end
+
+    it "filters by date range with only to" do
+      result = file_model.search(col: { date_column.id.to_s => { "to" => "2026/06/10" } }).to_a
+      expect(result.map(&:id)).to contain_exactly(file_alpha.id, file_bravo.id)
+    end
+
+    it "combines enum and date conditions (AND)" do
+      result = file_model.search(
+        col: { enum_column.id.to_s => %w(bravo charlie), date_column.id.to_s => { "to" => "2026/06/10" } }
+      ).to_a
+      expect(result.map(&:id)).to contain_exactly(file_bravo.id)
+    end
+  end
+
+  context "with datetime input_type" do
+    let(:input_type) { "datetime" }
+
+    let!(:file_morning) { create_file(date_value: Time.zone.local(2026, 6, 10, 9, 0, 0)) }
+    let!(:file_night) { create_file(date_value: Time.zone.local(2026, 6, 10, 23, 30, 0)) }
+    let!(:file_next_day) { create_file(date_value: Time.zone.local(2026, 6, 11, 0, 30, 0)) }
+
+    it "treats from / to as the whole-day range" do
+      result = file_model.search(col: { date_column.id.to_s => { "from" => "2026/06/10", "to" => "2026/06/10" } }).to_a
+      expect(result.map(&:id)).to contain_exactly(file_morning.id, file_night.id)
+    end
+  end
+
+  context "search_column_candidates" do
+    let(:input_type) { "date" }
+
+    it "includes enum and date columns" do
+      candidates = file_model.search_column_candidates
+      expect(candidates.map(&:id)).to contain_exactly(enum_column.id, date_column.id)
+    end
+  end
+end

--- a/spec/models/gws/tabular/file/search_filter_chips_spec.rb
+++ b/spec/models/gws/tabular/file/search_filter_chips_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe "Gws::Tabular search_filter_chips", type: :model, dbscope: :example do
+  let!(:site) { gws_site }
+  let!(:space) { create :gws_tabular_space, cur_site: site }
+  let!(:form) { create :gws_tabular_form, cur_site: site, cur_space: space, state: 'publishing', revision: 1 }
+
+  context "with enum_field" do
+    let!(:column) do
+      create(
+        :gws_tabular_column_enum_field, cur_site: site, cur_form: form,
+        name: "分類", select_options: %w[alpha bravo charlie], input_type: "checkbox")
+    end
+
+    it "returns one chip per selected value with the remaining values" do
+      expect(column.search_filter_chips(%w[alpha charlie])).to eq(
+        [
+          { label: "分類: alpha", remaining: %w[charlie] },
+          { label: "分類: charlie", remaining: %w[alpha] }
+        ]
+      )
+    end
+
+    it "sets remaining to nil when removing the only selected value" do
+      expect(column.search_filter_chips(%w[alpha])).to eq([{ label: "分類: alpha", remaining: nil }])
+    end
+
+    it "ignores blanks and values not in the options" do
+      expect(column.search_filter_chips(["", "unknown"])).to eq([])
+    end
+  end
+
+  context "with date_time_field" do
+    let!(:column) do
+      create(
+        :gws_tabular_column_date_time_field, cur_site: site, cur_form: form,
+        name: "使用日", input_type: "date", unique_state: "disabled")
+    end
+
+    it "returns a single range chip that clears the whole range" do
+      expect(column.search_filter_chips("from" => "2026/01/01", "to" => "2026/03/31")).to eq(
+        [{ label: "使用日: 2026/01/01〜2026/03/31", remaining: nil }]
+      )
+    end
+
+    it "supports a one-sided range" do
+      expect(column.search_filter_chips("from" => "2026/01/01")).to eq(
+        [{ label: "使用日: 2026/01/01〜", remaining: nil }]
+      )
+    end
+
+    it "returns empty when no range is given" do
+      expect(column.search_filter_chips({})).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## 概要

汎用DB（GWS Tabular）のデータ一覧画面に、検索ボックスから下の**右側レール**として**タクソノミー（分類・使用日など）**を縦置きで表示し、クリックで一覧を絞り込めるようにしました。

- **分類（列挙型）** → チェックボックス一覧（選択肢に完全一致：`$in`）
- **使用日（日付型）** → from / to の2欄（当日を含む範囲、既存 `ss_date_field` を流用）
- **使用目的・製品名・備考（テキスト型/参照型）** → 従来どおりキーワード欄
- 件数表示なし（クリックで一覧を絞るのみ）

<img width="1440" height="900" alt="shiyou_rireki_使用履歴" src="https://github.com/user-attachments/assets/56988545-a49d-40e5-b18c-1def4e1e2a34" />


## 変更内容

| ファイル | 変更 |
|---|---|
| `models/concerns/gws/tabular/file/search.rb` ・ `models/gws/tabular/file.rb` | `search_columns` / `search_column_candidates` を追加し、`search_handlers` に `search_columns` を組み込み（enum=完全一致 `$in` / date=from-to 範囲） |
| `models/gws/tabular/column/enum_field.rb` ・ `date_time_field.rb` | 型別の検索条件メソッド（`search_input_type` / `search_file_criteria`）を追加。日付は当日を含む範囲へ正規化 |
| `views/.../files/_search.html.erb` ＋ `default_view/index.html.erb` ＋ `_list_head.html.erb` ＋ `files/index.html.erb` | 右レール描画（選択肢チェックボックス・日付欄・選択状態・絞り込みボタン）と2カラム化。レール表示時は一覧ヘッダーの検索欄をレール側へ統合 |
| `assets/stylesheets/gws/tabular/_gws.scss` | 左:一覧／右:絞り込みレールの2カラムレイアウト（モバイルは縦積み・レールを上に） |
| `controllers/gws/tabular/files_controller.rb` | `params[:s][:col]` を正規化して受け渡し |
| `config/locales/gws/tabular/{ja,en}.yml` | 開始日/終了日ラベルを追加 |
| `spec/models/.../search_columns_spec.rb` ・ `spec/features/.../search_with_taxonomy_spec.rb` | モデルspec＋featurespecを追加 |

## 設計上の補足

- 実際にレンダリングされる既定の一覧テンプレートは `files/index.html.erb` ではなく、ナビが `view: "-"`（DefaultView）でリンクする **`default_view/index.html.erb`（crudベース）** だったため、右レールはそちらにも実装しています。`_list_head` のキーワード欄はレール側へ統合し二重表示を防いでいます（プランで挙げられていた `files/index.html.erb` も整合性のため更新）。
- レールは既定ビューのみに表示します（リスト型/Liquid型ビューは従来どおりキーワード欄のまま）。
- 日付型の「当日範囲」は from/to の両端を当日含む範囲（日付型は日付一致、日時型は当日 00:00:00〜23:59:59）として実装しています。

## レイアウトプレビュー

実アプリ（MongoDB）が起動できない環境のため、追加したマークアップ＋SCSSを反映した静的プレビューを Playwright で撮影し、2カラム／モバイル縦積みのレイアウトを確認済みです。絞り込みの実挙動は追加した model spec / feature spec（CI）で担保します。

<img width="390" height="1100" alt="mb_390_使用履歴" src="https://github.com/user-attachments/assets/4385c79c-ebc8-40e1-be5b-1d10fb9373c4" />

<img width="600" height="1100" alt="mb_600_使用履歴" src="https://github.com/user-attachments/assets/ee3bba8b-05a4-40ae-924e-ce9cc308bbbc" />

## テスト

- `spec/models/gws/tabular/file/search_columns_spec.rb`（enum=`$in`完全一致 / date=from-to当日含む範囲 / AND結合）
- `spec/features/gws/tabular/files/search_with_taxonomy_spec.rb`（実ブラウザでチェックボックス絞り込み）

---
_Generated by [Claude Code](https://claude.ai/code/session_013ecmpzpNLB23nkcMXv22ya)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 表形式一覧に右側の「検索レール」を導入（チェックボックス／日付レンジ等のカラム絞り込みを複数組合せ可）。
  * 適用中フィルターをチップ表示し、個別解除・全クリアが可能（チップは各列の形式に応じて生成）。

* **改善**
  * 一覧と検索レールを分離するレスポンシブレイアウト（PCは2カラム、モバイルはレール上部へ移動）。
  * キーワード／カラム絞り込みの入力・復元・送信／リセット動作を整理。

* **テスト**
  * 絞り込み挙動を検証する機能／モデルの自動テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->