### PR TITLE
[modify][gws]共有ファイルに選択ファイルの一括移動機能を追加

### DIFF
--- a/app/assets/javascripts/gws/script.js
+++ b/app/assets/javascripts/gws/script.js
@@ -28,6 +28,7 @@
 //= require gws/attendance/portlet
 //= require gws/presence/user
 //= require gws/share/folder_toolbar
+//= require gws/share/file
 //= require gws/affair/menu
 //= require gws/affair/overtime_file
 //= require gws/affair/shift_records

--- a/app/assets/javascripts/gws/share/file.js
+++ b/app/assets/javascripts/gws/share/file.js
@@ -1,0 +1,25 @@
+this.Gws_Share_File = (function () {
+  function Gws_Share_File() {}
+
+  // チェックされたファイルの ids[] を載せた一括操作用フォームを生成する。
+  // チェックが無い場合は false を返す。
+  Gws_Share_File.buildForm = function (action, confirm) {
+    var checked = $(".list-item input:checkbox:checked").map(function () {
+      return $(this).val();
+    });
+    if (checked.length === 0) {
+      return false;
+    }
+
+    var token = $('meta[name="csrf-token"]').attr("content");
+    var form = $("<form/>", { action: action, method: "post", data: { confirm: confirm } });
+    form.append($("<input/>", { name: "authenticity_token", value: token, type: "hidden" }));
+
+    for (var i = 0, len = checked.length; i < len; i++) {
+      form.append($("<input/>", { name: "ids[]", value: checked[i], type: "hidden" }));
+    }
+    return form;
+  };
+
+  return Gws_Share_File;
+})();

--- a/app/assets/stylesheets/gws/share/_gws.scss
+++ b/app/assets/stylesheets/gws/share/_gws.scss
@@ -38,6 +38,51 @@
     top: 4px;
     right: 4px;
   }
+
+  // ドラッグ&ドロップによる一括移動
+  .tree-item.gws-share-drop-hover {
+    background-color: init.$gray1;
+  }
+
+  .tree-item.gws-share-drop-invalid {
+    opacity: 0.4;
+
+    .item-name {
+      cursor: not-allowed;
+    }
+  }
+}
+
+// 一括移動の「移動」ドロップダウン
+.gws-share-dropdown {
+  display: inline-block;
+  font-weight: normal;
+  vertical-align: middle;
+
+  .dropdown-menu {
+    left: 0;
+    margin: 0;
+    padding: 5px 0;
+    border: 1px solid #ccc;
+    background: #fff;
+    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+    text-align: left;
+    max-height: 320px;
+    overflow-y: auto;
+
+    a {
+      display: block;
+      padding: 5px 10px;
+      color: init.$black;
+      white-space: nowrap;
+    }
+
+    a:hover {
+      background-color: init.$gray1;
+      color: init.$orange;
+      text-decoration: none;
+    }
+  }
 }
 
 .gws-share-apis-folder_crud {

--- a/app/assets/stylesheets/gws/share/_gws.scss
+++ b/app/assets/stylesheets/gws/share/_gws.scss
@@ -61,14 +61,14 @@
 
   .dropdown-menu {
     left: 0;
+    max-height: 320px;
     margin: 0;
     padding: 5px 0;
+    overflow-y: auto;
     border: 1px solid #ccc;
     background: #fff;
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
     text-align: left;
-    max-height: 320px;
-    overflow-y: auto;
 
     a {
       display: block;

--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -339,6 +339,9 @@ class Gws::Share::FilesController < ApplicationController
   def move_all
     folder = Gws::Share::Folder.site(@cur_site).where(id: params[:folder_id]).first
     raise "404" if folder.blank?
+    # 移動先候補（set_destination_folders）と同じ read ゲートを課し、
+    # 候補に出ないフォルダーへ細工した POST で移動されるのを防ぐ。
+    raise "403" unless folder.readable?(@cur_user) || folder.allowed?(:read, @cur_user, site: @cur_site)
     raise "403" unless folder.uploadable?(@cur_user)
 
     affected_folder_ids = [ folder.id ]
@@ -351,15 +354,22 @@ class Gws::Share::FilesController < ApplicationController
         next
       end
 
-      next if item.folder_id == folder.id
+      source_folder_id = item.folder_id
+      next if source_folder_id == folder.id
 
-      affected_folder_ids << item.folder_id if item.folder_id
+      affected_folder_ids << source_folder_id if source_folder_id
       item.folder_id = folder.id
       item.save
     end
 
-    # 移動元・移動先フォルダーの容量・ファイル数の集計を更新する
-    Gws::Share::Folder.site(@cur_site).in(id: affected_folder_ids.uniq).each(&:update_folder_descendants_file_info)
+    # 移動元・移動先フォルダーの容量・ファイル数の集計を更新する。
+    # update_folder_descendants_file_info は delta+inc 方式のため、入れ子フォルダー
+    # （移動元が移動先の子孫／祖先など）では更新順による stale 値で集計がズレる。
+    # 各フォルダーを更新直前に最新状態で読み直すことで、先行更新の inc を取り込む。
+    affected_folder_ids.uniq.each do |folder_id|
+      target = Gws::Share::Folder.site(@cur_site).where(id: folder_id).first
+      target&.update_folder_descendants_file_info
+    end
 
     render_change_all(location: { action: :index, folder: params[:folder], category: params[:category] })
   end

--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -6,11 +6,12 @@ class Gws::Share::FilesController < ApplicationController
   model Gws::Share::File
 
   before_action :set_item, only: [:show, :edit, :update, :delete, :destroy, :delete, :lock, :disable]
-  before_action :set_selected_items, only: [:disable_all, :download_all]
+  before_action :set_selected_items, only: [:disable_all, :download_all, :move_all]
   before_action :set_categories, only: [:index]
   before_action :set_category
   before_action :set_folder
   before_action :set_tree_navi, only: [:index]
+  before_action :set_destination_folders, only: [:index]
   before_action :set_default_readable_setting, only: [:new]
 
   # テスト時 unlock 実行前に database cleaner が実行されてしまい、
@@ -56,6 +57,37 @@ class Gws::Share::FilesController < ApplicationController
 
     @folder ||= Gws::Share::Folder.site(@cur_site).find(params[:folder])
     raise "403" unless @folder.readable?(@cur_user) || @folder.allowed?(:read, @cur_user, site: @cur_site)
+  end
+
+  # 一括移動の移動先候補（アップロード可能なフォルダー一覧）。
+  # フォルダー内を表示している場合は、同一ライブラリー（最上位フォルダー）内に絞り込む。
+  def set_destination_folders
+    folders = Gws::Share::Folder.site(@cur_site).
+      allow(:read, @cur_user, site: @cur_site).
+      tree_sort.
+      select { |folder| folder.uploadable?(@cur_user) }
+
+    if @folder
+      library = @folder.name.to_s.split("/").first
+      folders = folders.select { |folder| folder.name.to_s.split("/").first == library }
+    end
+
+    @destination_folders = folders
+  end
+
+  # ドラッグ&ドロップでの移動先制限用に、各ファイルが属するライブラリー（最上位フォルダー名）を求める
+  def set_file_libraries
+    @file_libraries = {}
+    items = @items.to_a
+    return if items.blank?
+
+    folder_ids = items.map(&:folder_id).compact.uniq
+    folder_names = Gws::Share::Folder.site(@cur_site).in(id: folder_ids).pluck(:id, :name).to_h
+    items.each do |item|
+      name = folder_names[item.folder_id]
+      next if name.blank?
+      @file_libraries[item.id.to_s] = name.split("/").first
+    end
   end
 
   def fix_params
@@ -154,6 +186,8 @@ class Gws::Share::FilesController < ApplicationController
       search(params[:s]).
       custom_order(@sort).
       page(params[:page]).per(50)
+
+    set_file_libraries
   end
 
   def show
@@ -323,6 +357,59 @@ class Gws::Share::FilesController < ApplicationController
       raise '500' unless zip.save
 
       send_file(zip.path, type: zip.type, filename: zip.name, disposition: 'attachment', x_sendfile: true)
+    end
+  end
+
+  def move_all
+    folder = Gws::Share::Folder.site(@cur_site).where(id: params[:folder_id]).first
+    raise "404" if folder.blank?
+    raise "403" unless folder.uploadable?(@cur_user)
+
+    dest_library = folder.name.to_s.split("/").first
+    affected_folder_ids = [ folder.id ]
+
+    # 再描画時に再クエリされてエラー情報が失われないよう、配列として保持する
+    @items = @items.to_a
+    @items.each do |item|
+      unless item.allowed?(:edit, @cur_user, site: @cur_site)
+        item.errors.add :base, :auth_error
+        next
+      end
+
+      src_library = item.folder.try(:name).to_s.split("/").first
+      if src_library != dest_library
+        # 別ライブラリー（最上位フォルダー）へは移動できない
+        item.errors.add :base, t("gws/share.errors.different_library")
+        next
+      end
+
+      next if item.folder_id == folder.id
+
+      affected_folder_ids << item.folder_id if item.folder_id
+      item.folder_id = folder.id
+      item.save
+    end
+
+    # 移動元・移動先フォルダーの容量・ファイル数の集計を更新する
+    Gws::Share::Folder.site(@cur_site).in(id: affected_folder_ids.uniq).each(&:update_folder_descendants_file_info)
+
+    render_change_all(location: { action: :index, folder: params[:folder], category: params[:category] })
+  end
+
+  def render_change_all(opts = {})
+    location = opts[:location].presence || crud_redirect_url || { action: :index }
+    failed = @items.select { |item| item.errors.present? }
+
+    if failed.present?
+      notice = { notice: t("gws/share.notice.move_failed", names: failed.map(&:name).join("、")) }
+    else
+      notice = { notice: t("ss.notice.saved") }
+    end
+    errors = failed.map { |item| [item.id, item.errors.full_messages] }
+
+    respond_to do |format|
+      format.html { redirect_to location, notice }
+      format.json { head json: errors }
     end
   end
 

--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -409,7 +409,7 @@ class Gws::Share::FilesController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to location, notice }
-      format.json { head json: errors }
+      format.json { render json: errors }
     end
   end
 

--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -59,35 +59,13 @@ class Gws::Share::FilesController < ApplicationController
     raise "403" unless @folder.readable?(@cur_user) || @folder.allowed?(:read, @cur_user, site: @cur_site)
   end
 
-  # 一括移動の移動先候補（アップロード可能なフォルダー一覧）。
-  # フォルダー内を表示している場合は、同一ライブラリー（最上位フォルダー）内に絞り込む。
+  # 一括移動・ドラッグ&ドロップの移動先候補（アップロード可能なフォルダー一覧）。
+  # 部署（最上位フォルダー）をまたいだ移動を許可するため、ライブラリーでの絞り込みは行わない。
   def set_destination_folders
-    folders = Gws::Share::Folder.site(@cur_site).
+    @destination_folders = Gws::Share::Folder.site(@cur_site).
       allow(:read, @cur_user, site: @cur_site).
       tree_sort.
       select { |folder| folder.uploadable?(@cur_user) }
-
-    if @folder
-      library = @folder.name.to_s.split("/").first
-      folders = folders.select { |folder| folder.name.to_s.split("/").first == library }
-    end
-
-    @destination_folders = folders
-  end
-
-  # ドラッグ&ドロップでの移動先制限用に、各ファイルが属するライブラリー（最上位フォルダー名）を求める
-  def set_file_libraries
-    @file_libraries = {}
-    items = @items.to_a
-    return if items.blank?
-
-    folder_ids = items.map(&:folder_id).compact.uniq
-    folder_names = Gws::Share::Folder.site(@cur_site).in(id: folder_ids).pluck(:id, :name).to_h
-    items.each do |item|
-      name = folder_names[item.folder_id]
-      next if name.blank?
-      @file_libraries[item.id.to_s] = name.split("/").first
-    end
   end
 
   def fix_params
@@ -186,8 +164,6 @@ class Gws::Share::FilesController < ApplicationController
       search(params[:s]).
       custom_order(@sort).
       page(params[:page]).per(50)
-
-    set_file_libraries
   end
 
   def show
@@ -365,7 +341,6 @@ class Gws::Share::FilesController < ApplicationController
     raise "404" if folder.blank?
     raise "403" unless folder.uploadable?(@cur_user)
 
-    dest_library = folder.name.to_s.split("/").first
     affected_folder_ids = [ folder.id ]
 
     # 再描画時に再クエリされてエラー情報が失われないよう、配列として保持する
@@ -373,13 +348,6 @@ class Gws::Share::FilesController < ApplicationController
     @items.each do |item|
       unless item.allowed?(:edit, @cur_user, site: @cur_site)
         item.errors.add :base, :auth_error
-        next
-      end
-
-      src_library = item.folder.try(:name).to_s.split("/").first
-      if src_library != dest_library
-        # 別ライブラリー（最上位フォルダー）へは移動できない
-        item.errors.add :base, t("gws/share.errors.different_library")
         next
       end
 

--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -345,6 +345,7 @@ class Gws::Share::FilesController < ApplicationController
     raise "403" unless folder.uploadable?(@cur_user)
 
     affected_folder_ids = [ folder.id ]
+    moved = []
 
     # 再描画時に再クエリされてエラー情報が失われないよう、配列として保持する
     @items = @items.to_a
@@ -357,9 +358,11 @@ class Gws::Share::FilesController < ApplicationController
       source_folder_id = item.folder_id
       next if source_folder_id == folder.id
 
-      affected_folder_ids << source_folder_id if source_folder_id
       item.folder_id = folder.id
-      item.save
+      next unless item.save
+
+      affected_folder_ids << source_folder_id if source_folder_id
+      moved << item
     end
 
     # 移動元・移動先フォルダーの容量・ファイル数の集計を更新する。
@@ -371,24 +374,25 @@ class Gws::Share::FilesController < ApplicationController
       target&.update_folder_descendants_file_info
     end
 
-    render_change_all(location: { action: :index, folder: params[:folder], category: params[:category] })
+    render_change_all(moved: moved, location: { action: :index, folder: params[:folder], category: params[:category] })
   end
 
   def render_change_all(opts = {})
     location = opts[:location].presence || crud_redirect_url || { action: :index }
     failed = @items.select { |item| item.errors.present? }
 
-    if failed.present?
-      notice = { notice: t("gws/share.notice.move_failed", names: failed.map(&:name).join("、")) }
-    else
-      notice = { notice: t("ss.notice.saved") }
-    end
-    errors = failed.map { |item| [item.id, item.errors.full_messages] }
+    notice =
+      if failed.present?
+        t("gws/share.notice.move_failed", names: failed.map(&:name).join("、"))
+      elsif opts[:moved].blank?
+        # 全件が移動先と同一フォルダーにあった等、実際には何も移動しなかった場合
+        t("gws/share.notice.move_none")
+      else
+        t("ss.notice.saved")
+      end
 
-    respond_to do |format|
-      format.html { redirect_to location, notice }
-      format.json { render json: errors }
-    end
+    # 一括移動はフォーム送信（HTML）のみで呼ばれるため、リダイレクトで応答する
+    redirect_to location, notice: notice
   end
 
   def render_destroy_all(result)

--- a/app/views/gws/share/files/_list_head.html.erb
+++ b/app/views/gws/share/files/_list_head.html.erb
@@ -1,5 +1,24 @@
 <%= jquery do %>
-  $(".move-menu li a").on("click", function() {
+  // ドロップダウンの項目は開いた時に初めて生成する。
+  // 一覧ページには同名のフォルダーリンク（ツリーナビ）が存在し、テスト環境では
+  // ignore_hidden_elements = false のため、常時 DOM に項目があると click_on が
+  // 曖昧マッチになってしまう。これを避けるため遅延生成する。
+  $(".move-menu").each(function() {
+    var $menu = $(this);
+    var $list = $menu.find(".dropdown-menu");
+    $menu.on("ss:dropdownOpened", function() {
+      if ($list.data("populated")) { return; }
+      $list.data("populated", true);
+
+      var folders = $menu.data("folders") || [];
+      $.each(folders, function(_i, folder) {
+        var $a = $("<a/>", { href: "#", role: "menuitem", "data-folder-id": folder.id, text: folder.name });
+        $list.append($("<li/>", { role: "none" }).append($a));
+      });
+    });
+  });
+
+  $(".move-menu").on("click", ".dropdown-menu a", function() {
     var folderId = $(this).attr("data-folder-id");
     var form = Gws_Share_File.buildForm("<%= url_for(action: :move_all) %>", "<%= t('gws/share.links.confirm.move') %>");
     if (!form) { return false; }
@@ -16,15 +35,12 @@
     <%= ss_button_to t("gws/share.links.file_download"), url_for(action: :download_all), class: "download-all btn btn-list-head-action", method: "post", confirm: t('gws/share.links.confirm.download_all') %>
 
     <% if @destination_folders.present? %>
-      <div class="dropdown dropdown-toggle gws-share-dropdown move-menu ml-2">
+      <div class="dropdown dropdown-toggle gws-share-dropdown move-menu ml-2"
+           data-folders="<%= @destination_folders.map { |folder| { id: folder.id, name: folder.name } }.to_json %>">
         <button type="button" class="btn" aria-haspopup="true" aria-expanded="false">
           <%= t('gws/share.links.move') %> <i class="material-icons md-13">keyboard_arrow_down</i>
         </button>
-        <ul class="dropdown-menu" role="menu">
-          <% @destination_folders.each do |folder| %>
-            <li role="none"><a href="#" role="menuitem" data-folder-id="<%= folder.id %>"><%= folder.name %></a></li>
-          <% end %>
-        </ul>
+        <ul class="dropdown-menu" role="menu"></ul>
       </div>
     <% end %>
 

--- a/app/views/gws/share/files/_list_head.html.erb
+++ b/app/views/gws/share/files/_list_head.html.erb
@@ -1,8 +1,33 @@
+<%= jquery do %>
+  $(".move-menu li a").on("click", function() {
+    var folderId = $(this).attr("data-folder-id");
+    var form = Gws_Share_File.buildForm("<%= url_for(action: :move_all) %>", "<%= t('gws/share.links.confirm.move') %>");
+    if (!form) { return false; }
+    form.append($("<input/>", { name: "folder_id", value: folderId, type: "hidden" }));
+    form.appendTo(document.body)[0].requestSubmit();
+    return false;
+  });
+<% end %>
+
 <div class="list-head">
   <label class="check"><input type="checkbox" /></label>
 
   <div class="list-head-action">
     <%= ss_button_to t("gws/share.links.file_download"), url_for(action: :download_all), class: "download-all btn btn-list-head-action", method: "post", confirm: t('gws/share.links.confirm.download_all') %>
+
+    <% if @destination_folders.present? %>
+      <div class="dropdown dropdown-toggle gws-share-dropdown move-menu ml-2">
+        <button type="button" class="btn">
+          <%= t('gws/share.links.move') %> <i class="material-icons md-13">keyboard_arrow_down</i>
+        </button>
+        <ul class="dropdown-menu">
+          <% @destination_folders.each do |folder| %>
+            <li><a href="#" data-folder-id="<%= folder.id %>"><%= folder.name %></a></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <%=
       if @deletable
         ss_button_to t("ss.links.delete"), url_for(action: :disable_all), class: "disable-all btn btn-red ml-2 btn-list-head-action", method: "post", confirm: t('ss.confirm.soft_delete')

--- a/app/views/gws/share/files/_list_head.html.erb
+++ b/app/views/gws/share/files/_list_head.html.erb
@@ -17,12 +17,12 @@
 
     <% if @destination_folders.present? %>
       <div class="dropdown dropdown-toggle gws-share-dropdown move-menu ml-2">
-        <button type="button" class="btn">
+        <button type="button" class="btn" aria-haspopup="true" aria-expanded="false">
           <%= t('gws/share.links.move') %> <i class="material-icons md-13">keyboard_arrow_down</i>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu" role="menu">
           <% @destination_folders.each do |folder| %>
-            <li><a href="#" data-folder-id="<%= folder.id %>"><%= folder.name %></a></li>
+            <li role="none"><a href="#" role="menuitem" data-folder-id="<%= folder.id %>"><%= folder.name %></a></li>
           <% end %>
         </ul>
       </div>

--- a/app/views/gws/share/files/_list_head.html.erb
+++ b/app/views/gws/share/files/_list_head.html.erb
@@ -1,8 +1,10 @@
 <%= jquery do %>
   // ドロップダウンの項目は開いた時に初めて生成する。
-  // 一覧ページには同名のフォルダーリンク（ツリーナビ）が存在し、テスト環境では
-  // ignore_hidden_elements = false のため、常時 DOM に項目があると click_on が
-  // 曖昧マッチになってしまう。これを避けるため遅延生成する。
+  // 一覧ページにはツリーナビに同名のフォルダーリンクが既に存在するため、移動先項目を
+  // 常時サーバー描画するとフォルダー名のクリック対象が二重化する。共有ファイル系の
+  // feature spec は多くがスコープ無しの click_on folder.name でツリーナビを操作しており
+  // （ignore_hidden_elements = false 環境では非表示の項目も照合対象）、常設すると広範な
+  // 曖昧マッチを招く。バインドは DOM ready 時・生成はユーザーが開いた後のため本番でも安全。
   $(".move-menu").each(function() {
     var $menu = $(this);
     var $list = $menu.find(".dropdown-menu");

--- a/app/views/gws/share/files/index.html.erb
+++ b/app/views/gws/share/files/index.html.erb
@@ -54,10 +54,11 @@
 
 <%= jquery do %>
   var moveAllUrl = "<%= url_for(action: :move_all) %>";
-  // アップロード可能なフォルダー（＝移動先として許可されるフォルダー）のIDの集合
+  // 移動先候補は移動ドロップダウン（.move-menu[data-folders]）を唯一の出所とし、
+  // ドロップダウンとD&Dで集合がズレないよう同じデータからIDの集合を作る。
   var validFolderIds = {};
-  $.each(<%== @destination_folders.map(&:id).to_json.html_safe %>, function(_i, id) {
-    validFolderIds[id] = true;
+  $.each($(".move-menu").data("folders") || [], function(_i, folder) {
+    validFolderIds[folder.id] = true;
   });
 
   function gwsShareIsValidTarget($node) {

--- a/app/views/gws/share/files/index.html.erb
+++ b/app/views/gws/share/files/index.html.erb
@@ -54,16 +54,14 @@
 
 <%= jquery do %>
   var moveAllUrl = "<%= url_for(action: :move_all) %>";
-  var fileLibraries = <%== @file_libraries.to_json.html_safe %>;
+  // アップロード可能なフォルダー（＝移動先として許可されるフォルダー）のIDの集合
+  var validFolderIds = {};
+  $.each(<%== @destination_folders.map(&:id).to_json.html_safe %>, function(_i, id) {
+    validFolderIds[id] = true;
+  });
 
-  // ドラッグ中のファイルが属するライブラリー（最上位フォルダー名）の一覧を返す
-  function gwsShareDraggedLibraries() {
-    var libs = {};
-    $(".gws-schedule-file-main .list-item input:checkbox:checked").each(function() {
-      var lib = fileLibraries[$(this).val()];
-      if (lib) { libs[lib] = true; }
-    });
-    return Object.keys(libs);
+  function gwsShareIsValidTarget($node) {
+    return !!validFolderIds[$node.data("id")];
   }
 
   // フォルダーノードをドロップ先として有効化する（既に初期化済みならスキップ）
@@ -76,7 +74,7 @@
         tolerance: "pointer",
         hoverClass: "gws-share-drop-hover",
         drop: function() {
-          if ($node.hasClass("gws-share-drop-invalid")) { return; }
+          if (!gwsShareIsValidTarget($node)) { return; }
 
           var folderId = $node.data("id");
           var folderName = $node.find("a.item-name").text();
@@ -107,27 +105,15 @@
       return helper;
     },
     start: function() {
-      // 別ライブラリー（移動不可）のフォルダーをグレーアウトしてドロップ無効化する
-      var libs = gwsShareDraggedLibraries();
+      // アップロード権限が無いフォルダーはグレーアウトしてドロップ不可を明示する
       $(".gws-share-file-folder-navi .tree-item[data-id]").each(function() {
         var $node = $(this);
-        if (!$node.data("ssDroppable")) { return; }
-
-        var nodeLib = String($node.data("filename") || "").split("/")[0];
-        var valid = (libs.length === 1 && libs[0] === nodeLib);
-        if (valid) {
-          $node.removeClass("gws-share-drop-invalid").droppable("enable");
-        } else {
-          $node.addClass("gws-share-drop-invalid").droppable("disable");
-        }
+        if (gwsShareIsValidTarget($node)) { return; }
+        $node.addClass("gws-share-drop-invalid");
       });
     },
     stop: function() {
-      $(".gws-share-file-folder-navi .tree-item[data-id]").each(function() {
-        var $node = $(this);
-        if (!$node.data("ssDroppable")) { return; }
-        $node.removeClass("gws-share-drop-invalid").droppable("enable");
-      });
+      $(".gws-share-file-folder-navi .tree-item.gws-share-drop-invalid").removeClass("gws-share-drop-invalid");
     }
   });
 

--- a/app/views/gws/share/files/index.html.erb
+++ b/app/views/gws/share/files/index.html.erb
@@ -51,3 +51,97 @@
     <%= render template: "gws/crud/index" %>
   </div>
 </div>
+
+<%= jquery do %>
+  var moveAllUrl = "<%= url_for(action: :move_all) %>";
+  var fileLibraries = <%== @file_libraries.to_json.html_safe %>;
+
+  // ドラッグ中のファイルが属するライブラリー（最上位フォルダー名）の一覧を返す
+  function gwsShareDraggedLibraries() {
+    var libs = {};
+    $(".gws-schedule-file-main .list-item input:checkbox:checked").each(function() {
+      var lib = fileLibraries[$(this).val()];
+      if (lib) { libs[lib] = true; }
+    });
+    return Object.keys(libs);
+  }
+
+  // フォルダーノードをドロップ先として有効化する（既に初期化済みならスキップ）
+  function gwsShareMakeDroppable($nodes) {
+    $nodes.filter(".tree-item[data-id]").each(function() {
+      var $node = $(this);
+      if ($node.data("ssDroppable")) { return; }
+      $node.data("ssDroppable", true);
+      $node.droppable({
+        tolerance: "pointer",
+        hoverClass: "gws-share-drop-hover",
+        drop: function() {
+          if ($node.hasClass("gws-share-drop-invalid")) { return; }
+
+          var folderId = $node.data("id");
+          var folderName = $node.find("a.item-name").text();
+          var confirmMsg = "<%= t('gws/share.links.confirm.move_drop.head') %>" +
+            " \"" + folderName + "\" " + "<%= t('gws/share.links.confirm.move_drop.tail') %>";
+
+          var form = Gws_Share_File.buildForm(moveAllUrl, confirmMsg);
+          if (!form) { return; }
+          form.append($("<input/>", { name: "folder_id", value: folderId, type: "hidden" }));
+          form.appendTo(document.body)[0].requestSubmit();
+        }
+      });
+    });
+  }
+
+  // 一覧のファイル行をドラッグ可能にする
+  $(".gws-schedule-file-main .list-item").draggable({
+    zIndex: 100,
+    opacity: 0.75,
+    cursorAt: { top: 16, left: 5 },
+    helper: function() {
+      var checkbox = $(this).find("label.check input[name='ids[]']");
+      if (!checkbox.prop("checked")) { checkbox.prop("checked", true); }
+
+      var checked = $(".gws-schedule-file-main .list-item input:checkbox:checked");
+      var helper = $('<div style="background-color: lightgreen; padding: 2px 10px;"></div>');
+      helper.text(checked.length + "<%= t('gws/share.select_check') %>");
+      return helper;
+    },
+    start: function() {
+      // 別ライブラリー（移動不可）のフォルダーをグレーアウトしてドロップ無効化する
+      var libs = gwsShareDraggedLibraries();
+      $(".gws-share-file-folder-navi .tree-item[data-id]").each(function() {
+        var $node = $(this);
+        if (!$node.data("ssDroppable")) { return; }
+
+        var nodeLib = String($node.data("filename") || "").split("/")[0];
+        var valid = (libs.length === 1 && libs[0] === nodeLib);
+        if (valid) {
+          $node.removeClass("gws-share-drop-invalid").droppable("enable");
+        } else {
+          $node.addClass("gws-share-drop-invalid").droppable("disable");
+        }
+      });
+    },
+    stop: function() {
+      $(".gws-share-file-folder-navi .tree-item[data-id]").each(function() {
+        var $node = $(this);
+        if (!$node.data("ssDroppable")) { return; }
+        $node.removeClass("gws-share-drop-invalid").droppable("enable");
+      });
+    }
+  });
+
+  // ツリーは非同期・遅延描画されるため、追加されたノードに順次ドロップ先を適用する
+  var treeContainer = $("#gws-share-file-folder-list .tree-navi").get(0);
+  if (treeContainer) {
+    gwsShareMakeDroppable($(treeContainer).find(".tree-item"));
+    var observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        $(mutation.addedNodes).each(function() {
+          gwsShareMakeDroppable($(this).find(".tree-item").addBack(".tree-item"));
+        });
+      });
+    });
+    observer.observe(treeContainer, { childList: true, subtree: true });
+  }
+<% end %>

--- a/config/locales/gws/share/en.yml
+++ b/config/locales/gws/share/en.yml
@@ -23,6 +23,7 @@ en:
     select_check: " file(s) selected"
     notice:
       move_failed: "Some items could not be moved: %{names}"
+      move_none: No items were moved.
     mailers:
       compressed:
         subject: Your download is now ready

--- a/config/locales/gws/share/en.yml
+++ b/config/locales/gws/share/en.yml
@@ -23,8 +23,6 @@ en:
     select_check: " file(s) selected"
     notice:
       move_failed: "Some items could not be moved: %{names}"
-    errors:
-      different_library: Files cannot be moved to a different library.
     mailers:
       compressed:
         subject: Your download is now ready

--- a/config/locales/gws/share/en.yml
+++ b/config/locales/gws/share/en.yml
@@ -13,8 +13,18 @@ en:
     links:
       categories: Category
       file_download: Download
+      move: Move
       confirm:
         download_all: Do you want to download the selected items?
+        move: Do you want to move the selected items?
+        move_drop:
+          head: Move the selected files to
+          tail: "?"
+    select_check: " file(s) selected"
+    notice:
+      move_failed: "Some items could not be moved: %{names}"
+    errors:
+      different_library: Files cannot be moved to a different library.
     mailers:
       compressed:
         subject: Your download is now ready

--- a/config/locales/gws/share/ja.yml
+++ b/config/locales/gws/share/ja.yml
@@ -13,7 +13,7 @@ ja:
     links:
       categories: カテゴリー
       file_download: ダウンロード
-      move: 移動
+      move: 移動する
       confirm:
         download_all: 選択した項目をダウンロードしますか？
         move: 選択した項目を移動しますか？

--- a/config/locales/gws/share/ja.yml
+++ b/config/locales/gws/share/ja.yml
@@ -23,8 +23,6 @@ ja:
     select_check: 件のファイルを選択
     notice:
       move_failed: "移動できなかった項目があります：%{names}"
-    errors:
-      different_library: 別のライブラリーには移動できません。
     mailers:
       compressed:
         subject: ダウンロード準備完了のお知らせ

--- a/config/locales/gws/share/ja.yml
+++ b/config/locales/gws/share/ja.yml
@@ -13,8 +13,18 @@ ja:
     links:
       categories: カテゴリー
       file_download: ダウンロード
+      move: 移動
       confirm:
         download_all: 選択した項目をダウンロードしますか？
+        move: 選択した項目を移動しますか？
+        move_drop:
+          head: 選択したファイルを
+          tail: に移動しますか？
+    select_check: 件のファイルを選択
+    notice:
+      move_failed: "移動できなかった項目があります：%{names}"
+    errors:
+      different_library: 別のライブラリーには移動できません。
     mailers:
       compressed:
         subject: ダウンロード準備完了のお知らせ

--- a/config/locales/gws/share/ja.yml
+++ b/config/locales/gws/share/ja.yml
@@ -23,6 +23,7 @@ ja:
     select_check: 件のファイルを選択
     notice:
       move_failed: "移動できなかった項目があります：%{names}"
+      move_none: 移動する項目がありませんでした。
     mailers:
       compressed:
         subject: ダウンロード準備完了のお知らせ

--- a/config/routes/gws/share/routes.rb
+++ b/config/routes/gws/share/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
         post :disable, on: :member
         post :disable_all, on: :collection
         post :download_all, on: :collection
+        post :move_all, on: :collection
       end
 
       resources :folders, concerns: [:deletion, :export] do
@@ -51,6 +52,7 @@ Rails.application.routes.draw do
           post :disable, on: :member
           post :download_all, on: :collection
           post :disable_all, on: :collection
+          post :move_all, on: :collection
         end
       end
     end

--- a/spec/features/gws/share/files/move_all_drag_spec.rb
+++ b/spec/features/gws/share/files/move_all_drag_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+# ドラッグ＆ドロップ経路の試作 feature spec。
+#
+# 注意:
+# jQuery UI の draggable/droppable は mousedown → mousemove(閾値超え) → mouseup の
+# イベント列とタイミングに依存し、Selenium での再現は不安定（flaky）になりやすい。
+# shirasagi 全体でも D&D 操作そのものを駆動する feature spec の前例は無く、踏襲元の
+# gws/memo/messages/move_all_spec.rb もドロップダウン経路のみを検証している。
+# そのためサーバー側ロジック（認可・集計再計算など）の確定的な担保は
+# spec/requests/gws/share/files/move_all_spec.rb が担い、本 spec は D&D 経路の
+# クライアント側配線（draggable/droppable → buildForm → confirm → move_all 送信）が
+# 一通りつながっていることを確認する試作という位置づけ。
+describe "gws_share_files move_all (drag and drop)", type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:category) { create :gws_share_category, cur_site: site }
+
+  # ライブラリーA: 最上位 folder0 とその配下 folder1
+  let!(:folder0) { create :gws_share_folder, cur_site: site }
+  let!(:folder1) { create :gws_share_folder, cur_site: site, name: "#{folder0.name}/#{unique_id}" }
+
+  let!(:item1) { create :gws_share_file, cur_site: site, folder: folder1, category_ids: [ category.id ] }
+  let!(:item2) { create :gws_share_file, cur_site: site, folder: folder1, category_ids: [ category.id ] }
+
+  let(:index_path) { gws_share_folder_files_path site, folder1 }
+
+  # 一覧行 item を、フォルダーツリーの folder ノードへ jQuery UI の D&D で移動する。
+  # ドラッグ開始は行中央（ファイル名リンク付近）から行う。jQuery UI draggable は
+  # 既定で input 系を cancel するため、チェックボックスからは開始しないこと。
+  def drag_file_to_folder(item, folder)
+    source = find(".gws-schedule-file-main .list-item[data-id='#{item.id}']")
+    target = find("#gws-share-file-folder-list .tree-navi .tree-item[data-id='#{folder.id}']")
+
+    page.driver.browser.action
+      .move_to(source.native)
+      .click_and_hold(source.native)
+      .move_by(15, 15)        # 最初の mousemove で jQuery UI のドラッグを開始させる
+      .move_to(target.native) # ドロップ先ノードへ移動して droppable の hover を発火
+      .move_to(target.native)
+      .release
+      .perform
+  end
+
+  context "ファイル行をフォルダーツリーへドロップして移動できる" do
+    it do
+      login_gws_user to: index_path
+
+      # ツリーが描画され、移動先（親フォルダー folder0）が drop 先ノードとして現れるまで待つ
+      within ".tree-navi" do
+        expect(page).to have_css(".tree-item[data-id='#{folder0.id}'] .item-name", text: folder0.name)
+      end
+
+      expect(item1.folder_id).to eq folder1.id
+
+      # ドロップ時に確認ダイアログが出るので受け入れる
+      page.accept_confirm do
+        drag_file_to_folder(item1, folder0)
+      end
+
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      # ドラッグした item1 のみが folder0 へ移動し、未選択の item2 は folder1 に残る
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder0.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder1.id
+
+      # 子→親の入れ子移動でも集計がズレない:
+      # folder0 = item1(直下) + folder1 配下の item2 = 2 件
+      folder0.reload
+      expect(folder0.descendants_files_count).to eq 2
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 1
+    end
+  end
+end

--- a/spec/features/gws/share/files/move_all_spec.rb
+++ b/spec/features/gws/share/files/move_all_spec.rb
@@ -49,38 +49,8 @@ describe "gws_share_files move_all", type: :feature, dbscope: :example, js: true
     end
   end
 
-  context "入れ子フォルダー（子フォルダーからその親フォルダー）へ移動しても集計が壊れない" do
-    it do
-      # 初期状態: 親 folder0 の集計は配下 folder1 の2件を含む
-      folder0.reload
-      expect(folder0.descendants_files_count).to eq 2
-      folder1.reload
-      expect(folder1.descendants_files_count).to eq 2
-
-      login_gws_user to: index_path
-      wait_for_event_fired("ss:checked-all-list-items") { find('.list-head label.check input').set(true) }
-
-      within ".list-head-action .move-menu" do
-        find("button.btn", text: I18n.t("gws/share.links.move")).click
-        page.accept_confirm do
-          click_on folder0.name
-        end
-      end
-
-      wait_for_notice I18n.t('ss.notice.saved')
-
-      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder0.id
-      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder0.id
-
-      # 子→親の入れ子移動でも集計がズレないこと
-      folder0.reload
-      expect(folder0.descendants_files_count).to eq 2
-      expect(folder0.descendants_total_file_size).to eq(Gws::Share::File.in(id: [item1.id, item2.id]).pluck(:size).sum)
-      folder1.reload
-      expect(folder1.descendants_files_count).to eq 0
-      expect(folder1.descendants_total_file_size).to eq 0
-    end
-  end
+  # 入れ子フォルダー間の移動を含む集計再計算の検証は、ブラウザ非依存で決定的な
+  # spec/requests/gws/share/files/move_all_spec.rb に集約している。
 
   context "別ライブラリー（別の最上位フォルダー＝別部署）へも一括移動できる" do
     it do

--- a/spec/features/gws/share/files/move_all_spec.rb
+++ b/spec/features/gws/share/files/move_all_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe "gws_share_files move_all", type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:category) { create :gws_share_category, cur_site: site }
+
+  # ライブラリーA（最上位フォルダー folder0 とその配下 folder1 / folder2）
+  let!(:folder0) { create :gws_share_folder, cur_site: site }
+  let!(:folder1) { create :gws_share_folder, cur_site: site, name: "#{folder0.name}/#{unique_id}" }
+  let!(:folder2) { create :gws_share_folder, cur_site: site, name: "#{folder0.name}/#{unique_id}" }
+
+  # ライブラリーB（別の最上位フォルダー）
+  let!(:other_library) { create :gws_share_folder, cur_site: site }
+
+  let!(:item1) { create :gws_share_file, cur_site: site, folder: folder1, category_ids: [category.id] }
+  let!(:item2) { create :gws_share_file, cur_site: site, folder: folder1, category_ids: [category.id] }
+
+  let(:index_path) { gws_share_folder_files_path site, folder1 }
+
+  context "同一ライブラリー内の別フォルダーへ一括移動できる" do
+    it do
+      expect(item1.folder_id).to eq folder1.id
+      expect(item2.folder_id).to eq folder1.id
+
+      login_gws_user to: index_path
+      within ".tree-navi" do
+        expect(page).to have_css(".item-name", text: folder0.name)
+      end
+
+      wait_for_event_fired("ss:checked-all-list-items") { find('.list-head label.check input').set(true) }
+
+      within ".list-head-action .move-menu" do
+        find("button.btn", text: I18n.t("gws/share.links.move")).click
+        page.accept_confirm do
+          click_on folder2.name
+        end
+      end
+
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder2.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder2.id
+
+      # 移動元・移動先の集計が更新されていること
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 0
+      folder2.reload
+      expect(folder2.descendants_files_count).to eq 2
+    end
+  end
+
+  context "移動先候補は同一ライブラリー内に絞り込まれる" do
+    it do
+      login_gws_user to: index_path
+
+      within ".list-head-action .move-menu" do
+        find("button.btn", text: I18n.t("gws/share.links.move")).click
+        expect(page).to have_link folder2.name
+        # 別ライブラリーは候補に表示されない
+        expect(page).to have_no_link other_library.name
+      end
+    end
+  end
+end

--- a/spec/features/gws/share/files/move_all_spec.rb
+++ b/spec/features/gws/share/files/move_all_spec.rb
@@ -49,16 +49,33 @@ describe "gws_share_files move_all", type: :feature, dbscope: :example, js: true
     end
   end
 
-  context "移動先候補は同一ライブラリー内に絞り込まれる" do
+  context "別ライブラリー（別の最上位フォルダー＝別部署）へも一括移動できる" do
     it do
+      expect(item1.folder_id).to eq folder1.id
+      expect(item2.folder_id).to eq folder1.id
+
       login_gws_user to: index_path
+      wait_for_event_fired("ss:checked-all-list-items") { find('.list-head label.check input').set(true) }
 
       within ".list-head-action .move-menu" do
         find("button.btn", text: I18n.t("gws/share.links.move")).click
-        expect(page).to have_link folder2.name
-        # 別ライブラリーは候補に表示されない
-        expect(page).to have_no_link other_library.name
+        # 別ライブラリーも移動先候補に表示される
+        expect(page).to have_link other_library.name
+        page.accept_confirm do
+          click_on other_library.name
+        end
       end
+
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq other_library.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq other_library.id
+
+      # 移動元・移動先の集計が更新されていること
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 0
+      other_library.reload
+      expect(other_library.descendants_files_count).to eq 2
     end
   end
 end

--- a/spec/features/gws/share/files/move_all_spec.rb
+++ b/spec/features/gws/share/files/move_all_spec.rb
@@ -49,6 +49,39 @@ describe "gws_share_files move_all", type: :feature, dbscope: :example, js: true
     end
   end
 
+  context "入れ子フォルダー（子フォルダーからその親フォルダー）へ移動しても集計が壊れない" do
+    it do
+      # 初期状態: 親 folder0 の集計は配下 folder1 の2件を含む
+      folder0.reload
+      expect(folder0.descendants_files_count).to eq 2
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 2
+
+      login_gws_user to: index_path
+      wait_for_event_fired("ss:checked-all-list-items") { find('.list-head label.check input').set(true) }
+
+      within ".list-head-action .move-menu" do
+        find("button.btn", text: I18n.t("gws/share.links.move")).click
+        page.accept_confirm do
+          click_on folder0.name
+        end
+      end
+
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder0.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder0.id
+
+      # 子→親の入れ子移動でも集計がズレないこと
+      folder0.reload
+      expect(folder0.descendants_files_count).to eq 2
+      expect(folder0.descendants_total_file_size).to eq(Gws::Share::File.in(id: [item1.id, item2.id]).pluck(:size).sum)
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 0
+      expect(folder1.descendants_total_file_size).to eq 0
+    end
+  end
+
   context "別ライブラリー（別の最上位フォルダー＝別部署）へも一括移動できる" do
     it do
       expect(item1.folder_id).to eq folder1.id

--- a/spec/requests/gws/share/files/move_all_spec.rb
+++ b/spec/requests/gws/share/files/move_all_spec.rb
@@ -32,11 +32,19 @@ describe "gws_share_files move_all (request)", type: :request, dbscope: :example
     post move_all_gws_share_folder_files_path(site, folder1), params: { ids: ids, folder_id: folder.id }
   end
 
+  # flash の notice はコントローラがリクエスト時のロケールで翻訳して格納するため、
+  # spec 側の I18n.locale（locale.rb がランダムに選ぶ）と一致するとは限らない。
+  # ロケールに依存せず「どの notice キーが使われたか」を検証するため、
+  # 利用可能な全ロケールの翻訳のいずれかと一致することを確認する。
+  def notice_translations(key)
+    I18n.available_locales.map { |locale| I18n.t(key, locale: locale) }
+  end
+
   context "同一ライブラリー内の別フォルダーへ移動できる" do
     it do
       post_move_all(folder2)
       expect(response.status).to eq 302
-      expect(flash[:notice]).to eq I18n.t('ss.notice.saved')
+      expect(notice_translations('ss.notice.saved')).to include(flash[:notice])
 
       expect(Gws::Share::File.find(item1.id).folder_id).to eq folder2.id
       expect(Gws::Share::File.find(item2.id).folder_id).to eq folder2.id
@@ -102,7 +110,7 @@ describe "gws_share_files move_all (request)", type: :request, dbscope: :example
     it do
       post_move_all(folder1)
       expect(response.status).to eq 302
-      expect(flash[:notice]).to eq I18n.t('gws/share.notice.move_none')
+      expect(notice_translations('gws/share.notice.move_none')).to include(flash[:notice])
 
       expect(Gws::Share::File.find(item1.id).folder_id).to eq folder1.id
       expect(Gws::Share::File.find(item2.id).folder_id).to eq folder1.id

--- a/spec/requests/gws/share/files/move_all_spec.rb
+++ b/spec/requests/gws/share/files/move_all_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+# D&D・移動ドロップダウンはいずれも同一の move_all エンドポイントへ POST する UI 層に過ぎない。
+# jQuery UI の D&D は feature spec で再現しにくいため、ここでサーバー到達と
+# 認可・集計再計算のサーバーロジックを直接（かつ決定的・高速に）検証する。
+describe "gws_share_files move_all (request)", type: :request, dbscope: :example do
+  let!(:site) { gws_site }
+  let!(:user) { gws_user }
+  let!(:category) { create :gws_share_category, cur_site: site }
+
+  # ライブラリーA: 最上位 folder0 とその配下 folder1 / folder2
+  let!(:folder0) { create :gws_share_folder, cur_site: site }
+  let!(:folder1) { create :gws_share_folder, cur_site: site, name: "#{folder0.name}/#{unique_id}" }
+  let!(:folder2) { create :gws_share_folder, cur_site: site, name: "#{folder0.name}/#{unique_id}" }
+  # ライブラリーB（別の最上位フォルダー＝別部署）
+  let!(:other_library) { create :gws_share_folder, cur_site: site }
+
+  let!(:item1) { create :gws_share_file, cur_site: site, folder: folder1, category_ids: [category.id] }
+  let!(:item2) { create :gws_share_file, cur_site: site, folder: folder1, category_ids: [category.id] }
+
+  before do
+    get sns_auth_token_path(format: :json)
+    auth_token = JSON.parse(response.body)["auth_token"]
+    post sns_login_path(format: :json), params: {
+      'authenticity_token' => auth_token,
+      'item[email]' => user.email,
+      'item[password]' => ss_pass
+    }
+  end
+
+  def post_move_all(folder, ids: [ item1.id, item2.id ])
+    post move_all_gws_share_folder_files_path(site, folder1), params: { ids: ids, folder_id: folder.id }
+  end
+
+  context "同一ライブラリー内の別フォルダーへ移動できる" do
+    it do
+      post_move_all(folder2)
+      expect(response.status).to eq 302
+      expect(flash[:notice]).to eq I18n.t('ss.notice.saved')
+
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder2.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder2.id
+
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 0
+      folder2.reload
+      expect(folder2.descendants_files_count).to eq 2
+    end
+  end
+
+  context "入れ子フォルダー（子フォルダーからその親フォルダー）へ移動しても集計が壊れない" do
+    it do
+      folder0.reload
+      expect(folder0.descendants_files_count).to eq 2
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 2
+
+      post_move_all(folder0)
+      expect(response.status).to eq 302
+
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder0.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder0.id
+
+      # 子→親の入れ子移動でも集計（自フォルダー＋子孫）がズレないこと
+      folder0.reload
+      expect(folder0.descendants_files_count).to eq 2
+      expect(folder0.descendants_total_file_size).to eq(Gws::Share::File.in(id: [ item1.id, item2.id ]).pluck(:size).sum)
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 0
+      expect(folder1.descendants_total_file_size).to eq 0
+    end
+  end
+
+  context "別ライブラリー（別の最上位フォルダー＝別部署）へも移動できる" do
+    it do
+      post_move_all(other_library)
+      expect(response.status).to eq 302
+
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq other_library.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq other_library.id
+
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 0
+      other_library.reload
+      expect(other_library.descendants_files_count).to eq 2
+    end
+  end
+
+  context "移動先が現在のフォルダーと同一で、実際には何も移動しない場合" do
+    it do
+      post_move_all(folder1)
+      expect(response.status).to eq 302
+      expect(flash[:notice]).to eq I18n.t('gws/share.notice.move_none')
+
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder1.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder1.id
+
+      folder1.reload
+      expect(folder1.descendants_files_count).to eq 2
+    end
+  end
+
+  context "存在しない移動先フォルダーを指定した場合" do
+    it do
+      post move_all_gws_share_folder_files_path(site, folder1), params: { ids: [ item1.id, item2.id ], folder_id: 9_999_999 }
+      expect(response.status).to eq 404
+
+      # 何も移動していないこと
+      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder1.id
+      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder1.id
+    end
+  end
+end

--- a/spec/requests/gws/share/files/move_all_spec.rb
+++ b/spec/requests/gws/share/files/move_all_spec.rb
@@ -20,7 +20,7 @@ describe "gws_share_files move_all (request)", type: :request, dbscope: :example
 
   before do
     get sns_auth_token_path(format: :json)
-    auth_token = JSON.parse(response.body)["auth_token"]
+    auth_token = response.parsed_body["auth_token"]
     post sns_login_path(format: :json), params: {
       'authenticity_token' => auth_token,
       'item[email]' => user.email,
@@ -48,26 +48,38 @@ describe "gws_share_files move_all (request)", type: :request, dbscope: :example
     end
   end
 
-  context "入れ子フォルダー（子フォルダーからその親フォルダー）へ移動しても集計が壊れない" do
-    it do
-      folder0.reload
-      expect(folder0.descendants_files_count).to eq 2
-      folder1.reload
-      expect(folder1.descendants_files_count).to eq 2
+  # 入れ子（親子）フォルダー間の移動では、集計の delta+inc 伝播が更新順に依存する。
+  # move_all は移動先（dest）を先頭に集計するため、親→子の移動では子（dest）→親（source）
+  # の順で再計算され、各フォルダーを最新状態で読み直さないと親の集計が二重計上/欠落する。
+  # ここではその経路（reload による補正）を検証する。
+  context "入れ子フォルダー（親→子）へ移動しても親の集計が壊れない" do
+    let!(:parent_folder) { create :gws_share_folder, cur_site: site }
+    let!(:child_folder) { create :gws_share_folder, cur_site: site, name: "#{parent_folder.name}/#{unique_id}" }
+    let!(:nested_item1) { create :gws_share_file, cur_site: site, folder: parent_folder, category_ids: [ category.id ] }
+    let!(:nested_item2) { create :gws_share_file, cur_site: site, folder: parent_folder, category_ids: [ category.id ] }
 
-      post_move_all(folder0)
+    it do
+      # 本番ではアップロード等の操作時に集計が更新される。factory 経由では集計が
+      # 走らないため、移動前の正しいベースライン（親直下に2件）を作る。
+      parent_folder.update_folder_descendants_file_info
+      expect(parent_folder.reload.descendants_files_count).to eq 2
+      expect(child_folder.reload.descendants_files_count).to eq 0
+
+      # 親 parent_folder にいる状態で、子 child_folder へ一括移動する
+      post move_all_gws_share_folder_files_path(site, parent_folder),
+        params: { ids: [ nested_item1.id, nested_item2.id ], folder_id: child_folder.id }
       expect(response.status).to eq 302
 
-      expect(Gws::Share::File.find(item1.id).folder_id).to eq folder0.id
-      expect(Gws::Share::File.find(item2.id).folder_id).to eq folder0.id
+      expect(Gws::Share::File.find(nested_item1.id).folder_id).to eq child_folder.id
+      expect(Gws::Share::File.find(nested_item2.id).folder_id).to eq child_folder.id
 
-      # 子→親の入れ子移動でも集計（自フォルダー＋子孫）がズレないこと
-      folder0.reload
-      expect(folder0.descendants_files_count).to eq 2
-      expect(folder0.descendants_total_file_size).to eq(Gws::Share::File.in(id: [ item1.id, item2.id ]).pluck(:size).sum)
-      folder1.reload
-      expect(folder1.descendants_files_count).to eq 0
-      expect(folder1.descendants_total_file_size).to eq 0
+      # 子へ移動しても親の総集計（自フォルダー＋子孫）は2件のまま（二重計上/欠落しない）
+      total_size = Gws::Share::File.in(id: [ nested_item1.id, nested_item2.id ]).pluck(:size).sum
+      parent_folder.reload
+      expect(parent_folder.descendants_files_count).to eq 2
+      expect(parent_folder.descendants_total_file_size).to eq total_size
+      child_folder.reload
+      expect(child_folder.descendants_files_count).to eq 2
     end
   end
 


### PR DESCRIPTION
## 概要

GWS 共有ファイル（`/.gN/share/-/files`）に、選択したファイルを別フォルダーへ**一括移動**する機能を追加します。部署ごとに作成したフォルダー間（**最上位フォルダー＝部署をまたいだ移動も含む**）でファイルを渡せるようにします。メモ（メッセージ）機能の移動操作と同じ操作感です。

## 機能

- ファイル一覧の **削除ボタンの横に「移動」ドロップダウン** を追加し、チェックした複数ファイルを移動先フォルダーへ一括移動できます。
- ファイル一覧の行を **フォルダーツリーへドラッグ&ドロップ** して移動できます。
  - ドロップ時に **確認ダイアログ** を表示します。
  - **アップロード権限の無いフォルダーはグレーアウト** してドロップ不可にします。
  - ツリーは遅延描画されるため、`MutationObserver` で追加ノードにもドロップ先を適用します。

## 仕様

- **部署（最上位フォルダー＝ライブラリー）をまたいだ移動を許可**します（今回追加の一括移動・D&Dのみ。既存の単一ファイル編集フォームは従来どおり同一ライブラリー内）。
- 移動には対象ファイルの `:edit` 権限と、**移動先フォルダーへの `uploadable?`（「ファイルの編集（全て）」権限、またはフォルダー所有）** を要求します。権限の無い移動先はドロップダウンに出さず、D&Dではグレーアウトします。
- 移動後は **移動元・移動先フォルダーの容量・ファイル数の集計**（`update_folder_descendants_file_info`）を再計算します。
- ファイルの**閲覧範囲（公開範囲）はファイル個別の設定で決まる**ため、移動によって閲覧可否は変わりません。

## 主な変更

- ルート: `POST move_all`（カテゴリ／フォルダ両スコープ）
- コントローラ: `Gws::Share::FilesController#move_all` / `render_change_all` / 移動先候補（アップロード可能フォルダー）のセット
- ビュー: `_list_head`（移動ドロップダウン。項目は開いた時に遅延生成）/ `index`（D&D）
- JS: `gws/share/file.js`（選択 `ids[]` 収集フォーム生成。ドロップダウンの開閉は既存の `ss/lib/dropdown_toggle.js` を流用）
- CSS: ドロップダウン・ドロップ可ハイライト・グレーアウト
- i18n: 日本語/英語
- テスト: `spec/features/gws/share/files/move_all_spec.rb`（同一部署内・別部署への一括移動）

## テスト

- 新規 spec（同一フォルダー間／別部署への一括移動成功＋集計更新）: パス
- 既存の共有ファイル feature spec: 回帰なし（`edit_image_spec` の GraphicsMagick ケースのみローカルの MiniMagick5/GraphicsMagick 非互換で失敗。CI・本変更とは無関係）
- 当初CIで失敗した `upload_policy_spec` の曖昧マッチ（`ignore_hidden_elements=false` 環境で非表示のフォルダー名リンクが衝突）は、ドロップダウン項目の遅延生成で解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 共有ファイルの一括移動（移動メニュー／ドラッグ＆ドロップ）を追加。許可された移動先候補に絞り込み、確認後に反映されます。
  * 一括移動のフォーム生成、移動先選択、サーバー側の権限検証・移動結果通知、フォルダー配下の集計更新を実装。
  * 一括移動用エンドポイント（`move_all`）を追加。  
* **Style**
  * 一括移動のドラッグ状態および「移動」ドロップダウンUIのスタイルを追加。  
* **Tests**
  * 一括移動のE2E/リクエスト仕様と、ドラッグ＆ドロップ経路のJS feature spec を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->