### PR TITLE
[fix][cms] liquidループHTMLでループ設定が無い場合に入力できない不具合を修正

### DIFF
--- a/app/views/cms/agents/addons/page_list/_form.html.erb
+++ b/app/views/cms/agents/addons/page_list/_form.html.erb
@@ -10,10 +10,14 @@
     Cms_Editor_CodeMirror.lock('#item_loop_setting_id', '#item_loop_html');
 
     <% if @model.use_liquid %>
-    Cms_Editor_CodeMirror.lock('#item_loop_setting_id_liquid', '#item_loop_liquid');
-
     var $loopSettingSelectShirasagi = $('#item_loop_setting_id');
     var $loopSettingSelectLiquid = $('#item_loop_setting_id_liquid');
+
+    // liquid のループ設定が無いと select 自体が描画されない。
+    // 存在する時だけロックする（無い場合は直接入力で編集可のままにする）。
+    if ($loopSettingSelectLiquid.length) {
+      Cms_Editor_CodeMirror.lock('#item_loop_setting_id_liquid', '#item_loop_liquid');
+    }
 
     var changeLoopFormat = function() {
       var format = $loopFormatSelect.val();

--- a/spec/features/cms/node/liquid_snippet_spec.rb
+++ b/spec/features/cms/node/liquid_snippet_spec.rb
@@ -220,6 +220,43 @@ describe "cms node liquid snippets", type: :feature, dbscope: :example, js: true
   end
 
   #
+  # liquid のループ設定 (テンプレート/スニペット) が 1 件も無いと、テンプレート選択用
+  # select (#item_loop_setting_id_liquid) 自体が描画されない。この select を無条件に
+  # lock 対象にしていたため、val() が undefined となり editor が readOnly になって、
+  # liquid 入力欄に何も入力できなくなっていた (K03012-1911)。select が無い場合は
+  # 直接入力で編集可のままになることを回帰防止としてテストする。
+  #
+  it "keeps the loop_liquid editor editable when no liquid loop setting exists" do
+    # liquid のループ設定を全て削除し、テンプレート/スニペットが何も無い状態にする
+    Cms::LoopSetting.where(html_format: "liquid").destroy_all
+
+    visit edit_node_conf_path(site.id, node)
+    ensure_addon_opened('#addon-event-agents-addons-page_list')
+
+    loop_liquid_readonly = -> do
+      page.evaluate_script(<<~JS)
+        (function() {
+          var ta = document.getElementById('item_loop_liquid');
+          var wrapper = ta && $(ta).next('.CodeMirror')[0];
+          return !!(wrapper && wrapper.CodeMirror && wrapper.CodeMirror.getOption('readOnly'));
+        })();
+      JS
+    end
+
+    within '#addon-event-agents-addons-page_list' do
+      select('Liquid', from: 'item[loop_format]') if page.has_select?('item[loop_format]')
+      wait_for_js_ready
+
+      # ループ設定が無いため、テンプレート選択 select は描画されない (バグ条件)
+      expect(page).to have_no_css('#item_loop_setting_id_liquid', visible: :all)
+
+      # select が無くても editor は readOnly にならず、直接入力で編集できる
+      # (修正前は lock が undefined の select で readOnly=true にしていた)
+      expect(loop_liquid_readonly.call).to eq false
+    end
+  end
+
+  #
   # テンプレート選択時、textarea は readOnly になるが editor.replaceSelection で
   # スニペットが挿入できてしまっていた (利用者には反映されないテンプレート内容に
   # 上書きされ、混乱を招いた)。回帰防止のため、テンプレート選択中はスニペット


### PR DESCRIPTION
- [x] 動作確認をしたか？（RSpec system spec / Playwright で確認）
- [x] ドキュメントやコメントを書いたか？（コミットメッセージ・コード意図・テストコメントを明記）

## 概要

記事/記事リストの「ループHTML」を **liquid 形式** にしたとき、liquid のループ設定（テンプレート/スニペット）が1件も無いと、liquid 入力欄に**何も入力できなくなる**不具合を修正します。

報告: 「ループHTML をliquid入力に指定した際に文字入力ができない」（v1.21.0 リリース対応）

## 変更内容

### 修正: `app/views/cms/agents/addons/page_list/_form.html.erb`

**原因**: liquid のループ設定が0件だと、ロック対象の select `#item_loop_setting_id_liquid` が描画されない。にもかかわらず `Cms_Editor_CodeMirror.lock('#item_loop_setting_id_liquid', ...)` を無条件に呼んでいたため、`$(selector).val()` が `undefined` となり editor が `readOnly` になって入力不能になっていた。

**修正**: 兄弟アドオン（`layout_html` / `column-layout`）が既に行っているのと同じく、**select が存在する時だけ lock を呼ぶ**ガードを追加。ループ設定が無い場合は直接入力で編集可のままにする。

```diff
     <% if @model.use_liquid %>
-    Cms_Editor_CodeMirror.lock('#item_loop_setting_id_liquid', '#item_loop_liquid');
-
     var $loopSettingSelectShirasagi = $('#item_loop_setting_id');
     var $loopSettingSelectLiquid = $('#item_loop_setting_id_liquid');
+
+    // liquid のループ設定が無いと select 自体が描画されない。
+    // 存在する時だけロックする（無い場合は直接入力で編集可のままにする）。
+    if ($loopSettingSelectLiquid.length) {
+      Cms_Editor_CodeMirror.lock('#item_loop_setting_id_liquid', '#item_loop_liquid');
+    }
```

### テスト: `spec/features/cms/node/liquid_snippet_spec.rb`

liquid のループ設定が無い状態で `#item_loop_setting_id_liquid` が描画されず、かつ `loop_liquid` エディタが `readOnly` にならない（直接入力で編集可）ことを検証する system spec（`js: true`）を1件追加。

- 修正前: 当該テストは `readOnly == true` となり **失敗**（バグ再現を確認済み）。
- 修正後: **合格**。

**補足（#6032 との関係）**: #6032 はスニペットセレクタ（`.loop-snippet-selector`）の初期値を「直接入力」にする等の改善ですが、対象は**スニペット挿入用 select** です。本 PR が直すのは**テンプレート選択用 select (`#item_loop_setting_id_liquid`) の lock** で、別のセレクタを扱うため衝突しません。両者を合わせて「ループ設定が無い liquid 状態でも直接入力できる」挙動になります。

**影響範囲**: page_list アドオンの liquid 形式時の lock 呼び出しのみ。select が存在する場合の挙動（テンプレート選択→readOnly）は不変。

## その他

- ローカルで `bundle exec rspec spec/features/cms/node/liquid_snippet_spec.rb`（追加テスト）の合格、および修正なしでの失敗（回帰再現）を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 管理画面のノード編集で、ループ設定がない場合でもテンプレートエディタが誤って読み取り専用になる問題を修正しました。選択要素が存在する場合のみ編集ロックが適用されます。

* **Tests**
  * ループ設定が存在しない状況でもエディタが編集可能であることを検証する機能テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->