### PR TITLE
[add] cms node destroy_job

### DIFF
--- a/app/controllers/cms/agents/tasks/nodes_controller.rb
+++ b/app/controllers/cms/agents/tasks/nodes_controller.rb
@@ -177,4 +177,27 @@ class Cms::Agents::Tasks::NodesController < ApplicationController
       end
     end
   end
+
+  def destroy
+    return if @selected_ids.blank?
+
+    @task.log "# #{@site.name}"
+
+    nodes = Cms::Node.site(@site).in(id: @selected_ids)
+
+    ids   = nodes.pluck(:id)
+    @task.total_count = ids.size
+
+    ids.each do |id|
+      rescue_with(rescue_p: rescue_p) do
+        @task.count
+        node = nodes.where(id: id).first
+        next unless node
+        next if @user.present? && !node.allowed?(:delete, @user, site: @site, node: @node)
+
+        @task.log "delete #{node.name} "
+        node.destroy
+      end
+    end
+  end
 end

--- a/app/controllers/cms/agents/tasks/nodes_controller.rb
+++ b/app/controllers/cms/agents/tasks/nodes_controller.rb
@@ -177,32 +177,4 @@ class Cms::Agents::Tasks::NodesController < ApplicationController
       end
     end
   end
-
-  def destroy
-    return if @selected_ids.blank?
-
-    @task.log "# #{@site.name}"
-
-    nodes = Cms::Node.site(@site).in(id: @selected_ids)
-
-    ids   = nodes.pluck(:id)
-    @task.total_count = ids.size
-
-    ids.each do |id|
-      rescue_with(rescue_p: rescue_p) do
-        @task.count
-        node = nodes.where(id: id).first
-        node.cur_user = @cur_user if node.respond_to?(:cur_user)
-        next unless node
-
-        if @user.present? && !node.allowed?(:delete, @user, site: @site, node: @node)
-          @task.log "skip delete #{node.name}: permission denied"
-          next
-        end
-
-        @task.log "delete #{node.name}"
-        node.destroy
-      end
-    end
-  end
 end

--- a/app/controllers/cms/agents/tasks/nodes_controller.rb
+++ b/app/controllers/cms/agents/tasks/nodes_controller.rb
@@ -192,10 +192,15 @@ class Cms::Agents::Tasks::NodesController < ApplicationController
       rescue_with(rescue_p: rescue_p) do
         @task.count
         node = nodes.where(id: id).first
+        node.cur_user = @cur_user if node.respond_to?(:cur_user)
         next unless node
-        next if @user.present? && !node.allowed?(:delete, @user, site: @site, node: @node)
 
-        @task.log "delete #{node.name} "
+        if @user.present? && !node.allowed?(:delete, @user, site: @site, node: @node)
+          @task.log "skip delete #{node.name}: permission denied"
+          next
+        end
+
+        @task.log "delete #{node.name}"
         node.destroy
       end
     end

--- a/app/controllers/cms/node/confs_controller.rb
+++ b/app/controllers/cms/node/confs_controller.rb
@@ -31,9 +31,9 @@ class Cms::Node::ConfsController < ApplicationController
     raise "403" unless @item.allowed?(:delete, @cur_user)
 
     if SS.config.cms.node_destroy_job.try(:[], 'enable').present?
-      result = Cms::Node::DestroyJob.bind(site_id: @cur_site.id, node_id: @cur_node.id, user_id: @cur_user.id).
+      Cms::Node::DestroyJob.bind(site_id: @cur_site.id, node_id: @cur_node.id, user_id: @cur_user.id).
         perform_later([@item.id])
-      render_destroy result, location: redirect_url_on_destroy, notice: t('ss.notice.started_purge')
+      render_destroy true, location: redirect_url_on_destroy, notice: t('ss.notice.started_purge')
       return
     end
 

--- a/app/controllers/cms/node/confs_controller.rb
+++ b/app/controllers/cms/node/confs_controller.rb
@@ -29,6 +29,14 @@ class Cms::Node::ConfsController < ApplicationController
 
   def destroy
     raise "403" unless @item.allowed?(:delete, @cur_user)
+
+    if SS.config.cms.node_destroy_job.try(:[], 'enable').present?
+      result = Cms::Node::DestroyJob.bind(site_id: @cur_site.id, node_id: @cur_node.id, user_id: @cur_user.id).
+        perform_later([@item.id])
+      render_destroy result, location: redirect_url_on_destroy, notice: t('ss.notice.started_purge')
+      return
+    end
+
     render_destroy @item.destroy, location: redirect_url_on_destroy
   end
 

--- a/app/controllers/concerns/cms/node_filter.rb
+++ b/app/controllers/concerns/cms/node_filter.rb
@@ -36,9 +36,9 @@ module Cms::NodeFilter
     end
 
     if SS.config.cms.node_destroy_job.try(:[], 'enable').present? && @items.present?
-      result = Cms::Node::DestroyJob.bind(site_id: @cur_site.id, user_id: @cur_user.id).
+      Cms::Node::DestroyJob.bind(site_id: @cur_site.id, user_id: @cur_user.id).
         perform_later(@items.collect(&:id))
-      return result
+      return true
     end
 
     @items.size < entries.size
@@ -93,9 +93,9 @@ module Cms::NodeFilter
     @item.cur_user = @cur_user if @item.respond_to?(:cur_user)
 
     if SS.config.cms.node_destroy_job.try(:[], 'enable').present?
-      result = Cms::Node::DestroyJob.bind(site_id: @cur_site.id, user_id: @cur_user.id).
+      Cms::Node::DestroyJob.bind(site_id: @cur_site.id, user_id: @cur_user.id).
         perform_later([@item.id])
-      render_destroy result, notice: t('ss.notice.started_purge')
+      render_destroy true, notice: t('ss.notice.started_purge')
       return
     end
 

--- a/app/controllers/concerns/cms/node_filter.rb
+++ b/app/controllers/concerns/cms/node_filter.rb
@@ -18,6 +18,32 @@ module Cms::NodeFilter
     end
   end
 
+  def destroy_items
+    return super if SS.config.cms.node_destroy_job.try(:[], 'enable').blank?
+
+    raise "400" if @selected_items.blank?
+
+    entries = @selected_items.entries
+    @items = []
+
+    entries.each do |item|
+      if item.allowed?(:delete, @cur_user, site: @cur_site, node: @cur_node)
+        item.cur_user = @cur_user if item.respond_to?(:cur_user)
+      else
+        item.errors.add :base, :auth_error
+      end
+      @items << item
+    end
+
+    if SS.config.cms.node_destroy_job.try(:[], 'enable').present? && @items.present?
+      result = Cms::Node::DestroyJob.bind(site_id: @cur_site.id, user_id: @cur_user.id).
+        perform_later(@items.collect(&:id))
+      return result
+    end
+
+    entries.size != @items.size
+  end
+
   def change_item_class
     @item.route = params[:route] if params[:route]
     @item = @item.becomes_with_route(@item.route) rescue @item
@@ -60,6 +86,31 @@ module Cms::NodeFilter
     @item.in_updated = params[:_updated] if @item.respond_to?(:in_updated)
     raise "403" unless @item.allowed?(:edit, @cur_user, site: @cur_site, node: @cur_node)
     render_update @item.update, location: redirect_url
+  end
+
+  def destroy
+    raise "403" unless @item.allowed?(:delete, @cur_user, site: @cur_site, node: @cur_node)
+    @item.cur_user = @cur_user if @item.respond_to?(:cur_user)
+
+    if SS.config.cms.node_destroy_job.try(:[], 'enable').present?
+      result = Cms::Node::DestroyJob.bind(site_id: @cur_site.id, user_id: @cur_user.id).
+        perform_later([@item.id])
+      render_destroy result, notice: t('ss.notice.started_purge')
+      return
+    end
+
+    super
+  end
+
+  def destroy_all
+    raise "400" if @selected_items.blank?
+
+    if params[:destroy_all].present? && SS.config.cms.node_destroy_job.try(:[], 'enable').present?
+      render_confirmed_all(destroy_items, location: SS.request_path(request), notice: t('ss.notice.started_purge'))
+      return
+    end
+
+    super
   end
 
   def move

--- a/app/controllers/concerns/cms/node_filter.rb
+++ b/app/controllers/concerns/cms/node_filter.rb
@@ -29,10 +29,10 @@ module Cms::NodeFilter
     entries.each do |item|
       if item.allowed?(:delete, @cur_user, site: @cur_site, node: @cur_node)
         item.cur_user = @cur_user if item.respond_to?(:cur_user)
+        @items << item
       else
         item.errors.add :base, :auth_error
       end
-      @items << item
     end
 
     if SS.config.cms.node_destroy_job.try(:[], 'enable').present? && @items.present?
@@ -41,7 +41,7 @@ module Cms::NodeFilter
       return result
     end
 
-    entries.size != @items.size
+    @items.size < entries.size
   end
 
   def change_item_class

--- a/app/jobs/cms/node/destroy_job.rb
+++ b/app/jobs/cms/node/destroy_job.rb
@@ -1,0 +1,22 @@
+class Cms::Node::DestroyJob < Cms::ApplicationJob
+  include Job::Cms::GeneratorFilter
+
+  self.task_name = "cms:destroy_nodes"
+  self.controller = Cms::Agents::Tasks::NodesController
+  self.action = :destroy
+
+  def perform(*args)
+    options = args.extract_options!
+    options.symbolize_keys!
+    selected_ids = args.first
+
+    task.process self.class.controller, self.class.action, { site: site, node: node, user: user, selected_ids: selected_ids }
+  end
+
+  def task_cond
+    cond = { name: self.class.task_name }
+    cond[:site_id] = site_id
+    cond[:node_id] = node_id
+    cond
+  end
+end

--- a/app/jobs/cms/node/destroy_job.rb
+++ b/app/jobs/cms/node/destroy_job.rb
@@ -10,7 +10,7 @@ class Cms::Node::DestroyJob < Cms::ApplicationJob
 
     return if selected_ids.blank?
 
-    task.log "caution: user blank" if user.blank?
+    task.log "caution: user not found" if user.blank?
     task.log "# #{site.name}"
 
     items = Cms::Node.site(site).in(id: selected_ids).to_a
@@ -20,7 +20,7 @@ class Cms::Node::DestroyJob < Cms::ApplicationJob
       task.count
       item.cur_user = user if item.respond_to?(:cur_user)
 
-      if user.present? && item.allowed?(:delete, user, site: site, node: node)
+      if user.present? && !item.allowed?(:delete, user, site: site, node: node)
         task.log "skip delete #{item.name}: permission denied"
         next
       end

--- a/app/jobs/cms/node/destroy_job.rb
+++ b/app/jobs/cms/node/destroy_job.rb
@@ -2,21 +2,34 @@ class Cms::Node::DestroyJob < Cms::ApplicationJob
   include Job::Cms::GeneratorFilter
 
   self.task_name = "cms:destroy_nodes"
-  self.controller = Cms::Agents::Tasks::NodesController
-  self.action = :destroy
 
   def perform(*args)
     options = args.extract_options!
     options.symbolize_keys!
     selected_ids = args.first
 
-    task.process self.class.controller, self.class.action, { site: site, node: node, user: user, selected_ids: selected_ids }
-  end
+    return if selected_ids.blank?
 
-  def task_cond
-    cond = { name: self.class.task_name }
-    cond[:site_id] = site_id
-    cond[:node_id] = node_id
-    cond
+    task.log "# #{site.name}"
+
+    nodes = Cms::Node.site(site).in(id: selected_ids)
+
+    ids   = nodes.pluck(:id)
+    task.total_count = ids.size
+
+    ids.each do |id|
+      task.count
+      node = nodes.where(id: id).first
+      node.cur_user = user if node.respond_to?(:cur_user)
+      next unless node
+
+      if user.present? && !node.allowed?(:delete, user, site: site, node: node)
+        task.log "skip delete #{node.name}: permission denied"
+        next
+      end
+
+      task.log "delete #{node.name}"
+      node.destroy
+    end
   end
 end

--- a/app/jobs/cms/node/destroy_job.rb
+++ b/app/jobs/cms/node/destroy_job.rb
@@ -10,26 +10,23 @@ class Cms::Node::DestroyJob < Cms::ApplicationJob
 
     return if selected_ids.blank?
 
+    task.log "caution: user blank" if user.blank?
     task.log "# #{site.name}"
 
-    nodes = Cms::Node.site(site).in(id: selected_ids)
+    items = Cms::Node.site(site).in(id: selected_ids).to_a
 
-    ids   = nodes.pluck(:id)
-    task.total_count = ids.size
-
-    ids.each do |id|
+    task.total_count = items.count
+    items.each do |item|
       task.count
-      node = nodes.where(id: id).first
-      node.cur_user = user if node.respond_to?(:cur_user)
-      next unless node
+      item.cur_user = user if item.respond_to?(:cur_user)
 
-      if user.present? && !node.allowed?(:delete, user, site: site, node: node)
-        task.log "skip delete #{node.name}: permission denied"
+      if user.present? && item.allowed?(:delete, user, site: site, node: node)
+        task.log "skip delete #{item.name}: permission denied"
         next
       end
 
-      task.log "delete #{node.name}"
-      node.destroy
+      task.log "delete #{item.name}"
+      item.destroy
     end
   end
 end

--- a/app/models/cms/import_job_file.rb
+++ b/app/models/cms/import_job_file.rb
@@ -58,7 +58,7 @@ class Cms::ImportJobFile
   end
 
   def save_import_node(filename)
-    item = Cms::Node::ImportNode.new
+    item = Cms::Node::ImportNode.find_or_initialize_by(site_id: site.id, filename: filename)
     item.filename = filename
     item.name = ::File.basename(filename)
     item.cur_site = site
@@ -79,7 +79,7 @@ class Cms::ImportJobFile
     import_html = file.read.force_encoding("utf-8").scrub
     import_html = modify_relative_paths(import_html)
 
-    item = Cms::ImportPage.new
+    item = Cms::ImportPage.find_or_initialize_by(site_id: site.id, filename: filename)
     item.filename = filename
     item.name = ::File.basename(filename)
     item.html = import_html

--- a/config/defaults/cms.yml
+++ b/config/defaults/cms.yml
@@ -223,6 +223,9 @@ production: &production
     external_block: "block_if_untrusted"
     trusted_urls: []
 
+  node_destroy_job:
+    enable: false
+
 test:
   <<: *production
 

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -3792,6 +3792,7 @@ ja:
       cms/node/generate_job: CMS/フォルダー書き出し
       cms/node/import_job: CMS/フォルダーインポート
       cms/node/release_job: CMS/フォルダー公開
+      cms/node/destroy_job: CMS/フォルダー削除
       cms/page/generate_job: CMS/ページ書き出し
       cms/page/release_job: CMS/ページ公開
       cms/page/remove_job: CMS/ページ削除

--- a/spec/jobs/cms/node/destroy_job/destroy_job_spec.rb
+++ b/spec/jobs/cms/node/destroy_job/destroy_job_spec.rb
@@ -12,12 +12,13 @@ describe Cms::Node::DestroyJob, dbscope: :example do
     end
 
     it do
-      log = Job::Log.first
+      expect(Job::Log.count).to eq 1
+      log = Job::Log.order_by(created: -1).first
       expect(log.logs).to include(/INFO -- : .* Started Job/)
       expect(log.logs).to include(/INFO -- : .* Completed Job/)
 
-      expect(Cms::Node.count).to eq 1
-      expect(Cms::Node.first.id).to eq node2.id
+      expect(Cms::Node.in(id: [node1.id, node2.id]).count).to eq 1
+      expect(Cms::Node.in(id: [node1.id, node2.id]).distinct(:id)).to eq [node2.id]
     end
   end
 end

--- a/spec/jobs/cms/node/destroy_job/destroy_job_spec.rb
+++ b/spec/jobs/cms/node/destroy_job/destroy_job_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Cms::Node::DestroyJob, dbscope: :example do
+  let!(:site) { cms_site }
+  let!(:node1) { create :cms_node_node, cur_site: site }
+  let!(:node2) { create :cms_node_node, cur_site: site }
+
+  describe "#perform" do
+    before do
+      job = described_class.bind(site_id: site.id, user_id: cms_user.id)
+      expect { ss_perform_now(job, [node1.id]) }.to output(include(node1.name)).to_stdout
+    end
+
+    it do
+      log = Job::Log.first
+      expect(log.logs).to include(/INFO -- : .* Started Job/)
+      expect(log.logs).to include(/INFO -- : .* Completed Job/)
+
+      expect(Cms::Node.count).to eq 1
+      expect(Cms::Node.first.id).to eq node2.id
+    end
+  end
+end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

大容量ファイルのフォルダー取り込み、削除対応。

## 変更内容

フォルダー削除のジョブ化。
フォルダー取り込みの処理を変更。

## その他

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ノード削除を非同期ジョブで処理可能に。削除開始時は通知を表示してリダイレクトし、単体・一括操作ともに権限判定を行う（権限なしは403）。
* **Bug Fixes**
  * インポート時の同一ファイルによる重複作成を防止（既存レコードを再利用）。
* **Chores**
  * ノード削除ジョブのデフォルト設定を追加（無効）。
* **Tests**
  * ノード削除ジョブの動作検証テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->