### PR TITLE
汎用DB(gws/tabular)のインポートにひな形ダウンロードを追加

### DIFF
--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -341,14 +341,23 @@ class Gws::Tabular::FilesController < ApplicationController
     set_model
     raise "403" unless policy_class.import?(@cur_site, @cur_user, @model)
 
-    encoding = params[:encoding].to_s
-    encoding = "UTF-8" unless %w(UTF-8 Shift_JIS).include?(encoding)
+    @item = Gws::Tabular::File::DownloadParam.new(cur_site: @cur_site, cur_user: @cur_user)
+    if request.get? || request.head?
+      render
+      return
+    end
+
+    @item.attributes = params.expect(item: [:encoding])
+    if @item.invalid?
+      render
+      return
+    end
 
     exporter = Gws::Tabular::File::CsvExporter.new(
       site: @cur_site, user: @cur_user, space: cur_space, form: cur_form, release: cur_release, criteria: @model.none)
 
     filename = "gws_tabular_files_#{cur_form.i18n_name}_template.csv"
-    send_enum exporter.enum_csv(encoding: encoding), filename: filename
+    send_enum exporter.enum_csv(encoding: @item.encoding), filename: filename
   end
 
   def copy

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -334,6 +334,20 @@ class Gws::Tabular::FilesController < ApplicationController
     redirect_to url_for(action: :index), notice: t('ss.notice.started_import')
   end
 
+  def download_template
+    raise "404" if cur_release.blank?
+    raise "404" unless cur_view.authoring_allowed?("import")
+
+    set_model
+    raise "403" unless policy_class.import?(@cur_site, @cur_user, @model)
+
+    exporter = Gws::Tabular::File::CsvExporter.new(
+      site: @cur_site, user: @cur_user, space: cur_space, form: cur_form, release: cur_release, criteria: @model.none)
+
+    filename = "gws_tabular_files_#{cur_form.i18n_name}_template.csv"
+    send_enum exporter.enum_csv(encoding: "UTF-8"), filename: filename
+  end
+
   def copy
     raise "404" if cur_release.blank?
     raise "404" unless cur_view.authoring_allowed?("edit")

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -341,11 +341,14 @@ class Gws::Tabular::FilesController < ApplicationController
     set_model
     raise "403" unless policy_class.import?(@cur_site, @cur_user, @model)
 
+    encoding = params[:encoding].to_s
+    encoding = "UTF-8" unless %w(UTF-8 Shift_JIS).include?(encoding)
+
     exporter = Gws::Tabular::File::CsvExporter.new(
       site: @cur_site, user: @cur_user, space: cur_space, form: cur_form, release: cur_release, criteria: @model.none)
 
     filename = "gws_tabular_files_#{cur_form.i18n_name}_template.csv"
-    send_enum exporter.enum_csv(encoding: "UTF-8"), filename: filename
+    send_enum exporter.enum_csv(encoding: encoding), filename: filename
   end
 
   def copy

--- a/app/views/gws/tabular/files/download_template.html.erb
+++ b/app/views/gws/tabular/files/download_template.html.erb
@@ -1,0 +1,27 @@
+<%= form_for :item, url: { action: :download_template }, html: { id: "item-form", method: :post } do |f| %>
+  <%= error_messages_for :item %>
+
+  <div class="addon-views">
+    <div class="addon-view" id="addon-basic">
+      <div class="addon-head"><h2><%= t('ss.links.download_template') %></h2></div>
+      <div class="addon-body">
+        <dl class="see">
+          <dt><%= t('ss.encoding') %></dt>
+          <dd>
+            <% %w(UTF-8 Shift_JIS).each do |encoding| %>
+              <label>
+                <%= radio_button_tag "item[encoding]", encoding, encoding == 'UTF-8', { id: nil } %>
+                <%= t("ss.options.csv_encoding.#{encoding}") %>
+              </label>
+            <% end %>
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+
+  <footer class="send ss-sticky ss-sticky-bottom">
+    <%= f.submit t('ss.buttons.download'), class: 'btn-primary save' %>
+    <%= link_to t('ss.buttons.cancel'), { action: :import }, { class: 'btn-default' } %>
+  </footer>
+<% end %>

--- a/app/views/gws/tabular/files/import.html.erb
+++ b/app/views/gws/tabular/files/import.html.erb
@@ -13,7 +13,12 @@
           </dd>
           <% download_template_path = url_for(action: :download_template) rescue nil %>
           <% if download_template_path.present? %>
-            <dd><%= link_to t('ss.links.download_template'), download_template_path %></dd>
+            <% %w(UTF-8 Shift_JIS).each do |encoding| %>
+              <dd>
+                <%= link_to "#{t('ss.links.download_template')} (#{t("ss.options.csv_encoding.#{encoding}")})",
+                      url_for(action: :download_template, encoding: encoding) %>
+              </dd>
+            <% end %>
           <% end %>
           <dd>
             <div class="body markdown-body">

--- a/app/views/gws/tabular/files/import.html.erb
+++ b/app/views/gws/tabular/files/import.html.erb
@@ -13,12 +13,7 @@
           </dd>
           <% download_template_path = url_for(action: :download_template) rescue nil %>
           <% if download_template_path.present? %>
-            <% %w(UTF-8 Shift_JIS).each do |encoding| %>
-              <dd>
-                <%= link_to "#{t('ss.links.download_template')} (#{t("ss.options.csv_encoding.#{encoding}")})",
-                      url_for(action: :download_template, encoding: encoding) %>
-              </dd>
-            <% end %>
+            <dd><%= link_to t('ss.links.download_template'), download_template_path %></dd>
           <% end %>
           <dd>
             <div class="body markdown-body">

--- a/config/routes/gws/tabular/routes.rb
+++ b/config/routes/gws/tabular/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         resources :files do
           match :download_all, on: :collection, via: %i[get post]
           match :import, on: :collection, via: %i[get post]
-          get :download_template, on: :collection
+          match :download_template, on: :collection, via: %i[get post]
           match :copy, on: :member, via: %i[get post]
         end
         resources :trash_files, only: %i[index show destroy] do

--- a/config/routes/gws/tabular/routes.rb
+++ b/config/routes/gws/tabular/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         resources :files do
           match :download_all, on: :collection, via: %i[get post]
           match :import, on: :collection, via: %i[get post]
+          get :download_template, on: :collection
           match :copy, on: :member, via: %i[get post]
         end
         resources :trash_files, only: %i[index show destroy] do


### PR DESCRIPTION
## 概要

GWS 汎用DB(`gws/tabular`)のインポート機能に、他のインポート機能(`gws/users` など)と同様の「ひな形ダウンロード」を追加します。

インポート画面のビューには既にひな形ダウンロードのリンク処理が用意されていましたが、対応するルートとコントローラのアクションが存在せず、リンクが表示されない状態でした(`url_for` が例外 → `rescue nil` で非表示)。本PRでルート・アクション・専用ビューを追加し、機能を有効化します。

## 変更内容

- **コントローラ** `app/controllers/gws/tabular/files_controller.rb`
  - `download_template` アクションを追加。インポートと同じ権限チェック(`authoring_allowed?("import")` / `policy_class.import?`)を行い、既存の `Gws::Tabular::File::CsvExporter` を空の絞り込み(`@model.none`)で利用してヘッダ行のみの CSV を出力します。
  - `download_all` と同様に GET でフォーム表示・POST でダウンロードする方式とし、`Gws::Tabular::File::DownloadParam` でエンコーディングを受け取ります。
- **ルート** `config/routes/gws/tabular/routes.rb`
  - `match :download_template, on: :collection, via: %i[get post]` を追加。
- **ビュー(新規)** `app/views/gws/tabular/files/download_template.html.erb`
  - `download_all` の共有テンプレート/`_download` パーシャルと同じ構造で、エンコーディング(UTF-8 / Shift_JIS)のラジオボタンとダウンロードボタンを配置。
- **ビュー** `app/views/gws/tabular/files/import.html.erb`
  - 既存のひな形ダウンロードのリンクが上記フォーム画面を開くように維持。

ロケール(`ss.links.download_template`、`ss.encoding`、`ss.options.csv_encoding.*`、`ss.buttons.download`)はすべて既存のものを利用しています。

## フロー

インポート画面の「雛形をダウンロード」リンク → エンコーディング選択フォーム(UTF-8 / Shift_JIS)→「ダウンロード」ボタンで、フォーム定義のカラムから生成されたヘッダのみの CSV を取得。CSV ダウンロード(`download_all`)と同じ操作感です。

## 補足・テスト

- 構文チェック(`ruby -c` / ERB)・ロケールキーの存在は確認済みです。
- 実行環境にネイティブの MeCab ライブラリが無く Rails が完全起動できないため、`rails` 起動を伴う動作確認・feature spec の実行は未実施です。実装は `download_all` の既存パターン(`DownloadParam` / `CsvExporter` / `_download` パーシャル / 共有テンプレート)をそのまま踏襲しています。

https://claude.ai/code/session_01SznUew958Xhv1Z7rvknUis

---
_Generated by [Claude Code](https://claude.ai/code/session_01SznUew958Xhv1Z7rvknUis)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CSVテンプレートのダウンロード機能を追加しました。タビュラーフォームのインポート時に使用可能なテンプレートファイルをダウンロードできます。
  * ダウンロード時にUTF-8またはShift_JISのエンコーディングを選択できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->