### PR TITLE
[feat][gws][tabular] 汎用DBの検索フォームにリセットボタンを追加

### DIFF
--- a/app/views/gws/tabular/files/_search.html.erb
+++ b/app/views/gws/tabular/files/_search.html.erb
@@ -28,6 +28,7 @@
       <%# 絞り込み項目が多いと末尾の検索ボタンが下方に離れるため、上部にも検索ボタンを置く %>
       <div class="gws-tabular-file-search-actions gws-tabular-file-search-actions-top">
         <%= f.submit t('ss.buttons.search'), class: "btn", name: nil %>
+        <%= link_to t('ss.buttons.reset'), { action: :index }, class: "btn" %>
       </div>
     <% end %>
 


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [ ] ドキュメントやコメントを書いたか？

## 概要
表形式ファイル検索フォームにリセットボタンを追加しました。

## 変更内容
`app/views/gws/tabular/files/_search.html.erb`の検索ボタン下部に、検索条件をリセットするボタンを追加しました。

- 検索フォームの上部アクションエリアに「リセット」ボタンを配置
- クリックするとindexアクションにリダイレクトして検索条件をクリア
- 既存の検索ボタンと同じスタイルクラス（`btn`）を適用

## その他
検索条件が多い場合、ユーザーが簡単に検索をリセットできるようになります。

関連PR：[feat][gws][tabular]: 汎用DBの一覧に絞り込みレール（タクソノミー）を追加 (#6073)

https://claude.ai/code/session_01DeYtQxDwJiX4K2FJcPGAJ4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 検索フォームの上部にリセットボタンを追加しました。フィルタ項目が多い場合でも、上部からすぐに検索をリセットしてインデックス画面へ戻ることができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->