### PR TITLE
[fix] gws/memo/notification : ensure actually destroyed items in destroy_all

### DIFF
--- a/app/controllers/concerns/gws/memo/notification_filter.rb
+++ b/app/controllers/concerns/gws/memo/notification_filter.rb
@@ -82,6 +82,7 @@ module Gws::Memo::NotificationFilter
 
     @destroyed_items ||= []
     @destroyed_items << @destroyed_item if @destroyed_item
+    ensure_destroyed_items if @ensure_destroyed_items
     return if @destroyed_items.blank?
 
     check = []
@@ -132,7 +133,14 @@ module Gws::Memo::NotificationFilter
           @destroyed_items << [copy, item.subscribed_users]
         end
       end
+      @ensure_destroyed_items = true
     end
+  end
+
+  def ensure_destroyed_items
+    # 削除できなかったものが @items に残る
+    item_ids = @items.pluck(:id)
+    @destroyed_items.select! { |item, _| !item_ids.include?(item.id) }
   end
 
   def item_notify_enabled?(item)

--- a/app/controllers/concerns/ss/crud_filter.rb
+++ b/app/controllers/concerns/ss/crud_filter.rb
@@ -178,11 +178,11 @@ module SS::CrudFilter
   end
 
   def render_confirmed_all(result, opts = {})
-    action = if %w(close_all change_state_all).include?(params[:action])
-               'change'
-             else
-               'delete'
-             end
+    if %w(close_all change_state_all).include?(params[:action])
+      action = 'change'
+    else
+      action = 'delete'
+    end
 
     location = opts[:location].presence || crud_redirect_url || { action: :index }
     if result

--- a/spec/features/gws/board/topics/delete_notification_spec.rb
+++ b/spec/features/gws/board/topics/delete_notification_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:user) { gws_user }
+
+  let!(:permissions) do
+    Gws::Role.permission_names - %w(delete_other_gws_board_topics edit_other_gws_board_topics trash_other_gws_board_topics)
+  end
+  let!(:role) { create :gws_role, cur_site: site, permissions: permissions }
+
+  let!(:user1) { create :gws_user, group_ids: user.group_ids, gws_role_ids: [role.id] }
+  let!(:user2) { create :gws_user, group_ids: [group.id], gws_role_ids: [role.id] }
+
+  let!(:group) { create :gws_group, name: "#{site.name}/#{unique_id}" }
+  let!(:category) { create :gws_board_category, subscribed_group_ids: user.group_ids }
+
+  let!(:item1) { create :gws_board_topic, category_ids: [ category.id ], notify_state: "enabled", group_ids: user.group_ids }
+  let!(:item2) { create :gws_board_topic, category_ids: [ category.id ], notify_state: "enabled", group_ids: [group.id] }
+
+  context "soft_delete" do
+    it do
+      login_user(user)
+      visit gws_board_topic_path(site: site, mode: '-', category: '-', id: item2)
+
+      within "#menu" do
+        expect(page).to have_link I18n.t("ss.links.edit")
+        expect(page).to have_link I18n.t("ss.links.delete")
+        click_on I18n.t("ss.links.delete")
+      end
+      within "form#item-form" do
+        click_on I18n.t("ss.buttons.delete")
+      end
+      wait_for_notice I18n.t('ss.notice.deleted')
+
+      expect(SS::Notification.count).to eq 1
+      notification = SS::Notification.where(subject: /#{item2.name}/).first
+      expect(notification).to be_present
+      expect(notification.member_ids.include?(user.id)).to be_falsey
+      expect(notification.member_ids.include?(user1.id)).to be_truthy
+      expect(notification.member_ids.include?(user2.id)).to be_falsey
+    end
+  end
+
+  context "soft_delete with no permission case" do
+    it do
+      login_user(user1)
+      visit gws_board_topic_path(site: site, mode: '-', category: '-', id: item2)
+
+      within "#menu" do
+        expect(page).to have_no_link I18n.t("ss.links.edit")
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+      end
+    end
+  end
+
+  context "soft_delete_all" do
+    it do
+      login_user(user)
+      visit gws_board_topics_path(site: site, mode: '-', category: '-')
+
+      # check menu link
+      within ".list-items" do
+        expect(page).to have_selector(".list-item", count: 2)
+        expect(page).to have_link item1.name
+        expect(page).to have_link item2.name
+        click_link item1.name
+      end
+      within "#menu" do
+        expect(page).to have_link I18n.t("ss.links.edit")
+        expect(page).to have_link I18n.t("ss.links.delete")
+        click_on I18n.t("ss.links.back_to_index")
+      end
+      within ".list-items" do
+        click_link item2.name
+      end
+      within "#menu" do
+        expect(page).to have_link I18n.t("ss.links.edit")
+        expect(page).to have_link I18n.t("ss.links.delete")
+        click_on I18n.t("ss.links.back_to_index")
+      end
+
+      # check soft_destroy_all
+      wait_for_event_fired("ss:checked-all-list-items") { find('.list-head input[type="checkbox"]').set(true) }
+      within ".list-head-action" do
+        page.accept_alert(I18n.t("ss.confirm.delete")) do
+          click_button I18n.t('ss.buttons.delete')
+        end
+      end
+      wait_for_notice I18n.t('ss.notice.deleted')
+
+      within ".list-items" do
+        expect(page).to have_no_selector(".list-item")
+      end
+      expect(SS::Notification.count).to eq 2
+      notification = SS::Notification.where(subject: /#{item1.name}/).first
+      expect(notification).to be_present
+      expect(notification.member_ids.include?(user.id)).to be_falsey
+      expect(notification.member_ids.include?(user1.id)).to be_truthy
+      expect(notification.member_ids.include?(user2.id)).to be_falsey
+
+      notification = SS::Notification.where(subject: /#{item2.name}/).first
+      expect(notification).to be_present
+      expect(notification.member_ids.include?(user.id)).to be_falsey
+      expect(notification.member_ids.include?(user1.id)).to be_truthy
+      expect(notification.member_ids.include?(user2.id)).to be_falsey
+    end
+  end
+
+  context "soft_delete_all with no permission case" do
+    it do
+      login_user(user1)
+      visit gws_board_topics_path(site: site, mode: '-', category: '-')
+
+      # check menu link
+      within ".list-items" do
+        expect(page).to have_selector(".list-item", count: 2)
+        expect(page).to have_link item1.name
+        expect(page).to have_link item2.name
+        click_link item1.name
+      end
+      within "#menu" do
+        expect(page).to have_link I18n.t("ss.links.edit")
+        expect(page).to have_link I18n.t("ss.links.delete")
+        click_on I18n.t("ss.links.back_to_index")
+      end
+      within ".list-items" do
+        click_link item2.name
+      end
+      within "#menu" do
+        expect(page).to have_no_link I18n.t("ss.links.edit")
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+        click_on I18n.t("ss.links.back_to_index")
+      end
+
+      # check soft_destroy_all
+      wait_for_event_fired("ss:checked-all-list-items") { find('.list-head input[type="checkbox"]').set(true) }
+      within ".list-head-action" do
+        page.accept_alert(I18n.t("ss.confirm.delete")) do
+          click_button I18n.t('ss.buttons.delete')
+        end
+      end
+      wait_for_notice I18n.t('ss.notice.deleted')
+
+      within ".list-items" do
+        expect(page).to have_selector(".list-item", count: 1)
+        expect(page).to have_link item2.name
+      end
+      expect(SS::Notification.count).to eq 1
+      notification = SS::Notification.where(subject: /#{item1.name}/).first
+      expect(notification).to be_present
+      expect(notification.member_ids.include?(user.id)).to be_truthy
+      expect(notification.member_ids.include?(user1.id)).to be_falsey
+      expect(notification.member_ids.include?(user2.id)).to be_falsey
+
+      notification = SS::Notification.where(subject: /#{item2.name}/).first
+      expect(notification).to be_blank
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 削除に失敗したアイテムに対する通知送信を抑制するよう改善

* **リファクタリング**
  * CRUD操作のロジック構造を改善

* **テスト**
  * 掲示板トピック削除時の通知生成と対象メンバー制御に関するテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->