### PR TITLE
[modify][gws] ブックマークに選択ブックマークの一括移動機能を追加

### DIFF
--- a/app/assets/javascripts/gws/bookmark/item.js
+++ b/app/assets/javascripts/gws/bookmark/item.js
@@ -1,0 +1,25 @@
+this.Gws_Bookmark_Item = (function () {
+  function Gws_Bookmark_Item() {}
+
+  // チェックされたブックマークの ids[] を載せた一括操作用フォームを生成する。
+  // チェックが無い場合は false を返す。
+  Gws_Bookmark_Item.buildForm = function (action, confirm) {
+    var checked = $(".list-item input:checkbox:checked").map(function () {
+      return $(this).val();
+    });
+    if (checked.length === 0) {
+      return false;
+    }
+
+    var token = $('meta[name="csrf-token"]').attr("content");
+    var form = $("<form/>", { action: action, method: "post", data: { confirm: confirm } });
+    form.append($("<input/>", { name: "authenticity_token", value: token, type: "hidden" }));
+
+    for (var i = 0, len = checked.length; i < len; i++) {
+      form.append($("<input/>", { name: "ids[]", value: checked[i], type: "hidden" }));
+    }
+    return form;
+  };
+
+  return Gws_Bookmark_Item;
+})();

--- a/app/assets/javascripts/gws/script.js
+++ b/app/assets/javascripts/gws/script.js
@@ -28,6 +28,7 @@
 //= require gws/attendance/portlet
 //= require gws/presence/user
 //= require gws/share/folder_toolbar
+//= require gws/bookmark/item
 //= require gws/affair/menu
 //= require gws/affair/overtime_file
 //= require gws/affair/shift_records

--- a/app/assets/stylesheets/gws/bookmark/_gws.scss
+++ b/app/assets/stylesheets/gws/bookmark/_gws.scss
@@ -52,3 +52,41 @@
     }
   }
 }
+
+// ドラッグ&ドロップによる一括移動のドロップ先ハイライト
+#content-navi .tree-item.gws-bookmark-drop-hover {
+  background-color: init.$gray1;
+}
+
+// 一括移動の「移動する」ドロップダウン
+.gws-bookmark-dropdown {
+  display: inline-block;
+  margin-left: 8px;
+  font-weight: normal;
+  vertical-align: middle;
+
+  .dropdown-menu {
+    left: 0;
+    max-height: 320px;
+    margin: 0;
+    padding: 5px 0;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    background: #fff;
+    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+    text-align: left;
+
+    a {
+      display: block;
+      padding: 5px 10px;
+      color: init.$black;
+      white-space: nowrap;
+    }
+
+    a:hover {
+      background-color: init.$gray1;
+      color: init.$orange;
+      text-decoration: none;
+    }
+  }
+}

--- a/app/controllers/gws/bookmark/items_controller.rb
+++ b/app/controllers/gws/bookmark/items_controller.rb
@@ -87,7 +87,13 @@ class Gws::Bookmark::ItemsController < ApplicationController
 
     notice =
       if failed.present?
-        t("gws/bookmark.notice.move_failed", names: failed.map(&:name).join("、"))
+        # 権限エラーで弾いた項目がある場合は、細工された ids[] による他ユーザーの
+        # ブックマーク名の漏洩を防ぐため、名前を含めない汎用メッセージにフォールバックする。
+        if failed.any? { |item| item.errors.details[:base].any? { |detail| detail[:error] == :auth_error } }
+          t("errors.messages.auth_error")
+        else
+          t("gws/bookmark.notice.move_failed", names: failed.map(&:name).join("、"))
+        end
       elsif opts[:moved].blank?
         # 全件が移動先と同一フォルダーにあった等、実際には何も移動しなかった場合
         t("gws/bookmark.notice.move_none")

--- a/app/controllers/gws/bookmark/items_controller.rb
+++ b/app/controllers/gws/bookmark/items_controller.rb
@@ -5,7 +5,9 @@ class Gws::Bookmark::ItemsController < ApplicationController
 
   model Gws::Bookmark::Item
 
+  before_action :set_selected_items, only: [:move_all]
   before_action :set_tree_navi, only: [:index]
+  before_action :set_destination_folders, only: [:index]
 
   navi_view "gws/bookmark/main/navi"
 
@@ -34,6 +36,13 @@ class Gws::Bookmark::ItemsController < ApplicationController
     @tree_navi = gws_bookmark_apis_folder_list_path(folder_id: params[:folder_id], format: 'json')
   end
 
+  # 一括移動・ドラッグ&ドロップの移動先候補（ログインユーザーが所有する全フォルダー）。
+  def set_destination_folders
+    @destination_folders = @folders.
+      allow(:read, @cur_user, site: @cur_site).
+      tree_sort
+  end
+
   public
 
   def index
@@ -43,5 +52,50 @@ class Gws::Bookmark::ItemsController < ApplicationController
     @items = @items.and_folder(@folder) if @folder
     @items = @items.search(params[:s]).
       page(params[:page]).per(50)
+  end
+
+  def move_all
+    # 移動先フォルダー。ルートのパススコープ :folder_id（現在のフォルダー）と衝突するため、
+    # 移動先は dst_folder_id で受け取る。
+    folder = @folders.where(id: params[:dst_folder_id]).first
+    raise "404" if folder.blank?
+    raise "403" unless folder.allowed?(:read, @cur_user, site: @cur_site)
+
+    # 再描画時に再クエリされてエラー情報が失われないよう、配列として保持する
+    @items = @items.to_a
+    moved = []
+    @items.each do |item|
+      unless item.user_id == @cur_user.id && item.allowed?(:edit, @cur_user, site: @cur_site)
+        item.errors.add :base, :auth_error
+        next
+      end
+
+      next if item.folder_id == folder.id
+
+      item.folder_id = folder.id
+      next unless item.save
+
+      moved << item
+    end
+
+    render_change_all(moved: moved, location: { action: :index, folder_id: params[:folder_id] })
+  end
+
+  def render_change_all(opts = {})
+    location = opts[:location].presence || crud_redirect_url || { action: :index }
+    failed = @items.select { |item| item.errors.present? }
+
+    notice =
+      if failed.present?
+        t("gws/bookmark.notice.move_failed", names: failed.map(&:name).join("、"))
+      elsif opts[:moved].blank?
+        # 全件が移動先と同一フォルダーにあった等、実際には何も移動しなかった場合
+        t("gws/bookmark.notice.move_none")
+      else
+        t("ss.notice.saved")
+      end
+
+    # 一括移動はフォーム送信（HTML）のみで呼ばれるため、リダイレクトで応答する
+    redirect_to location, notice: notice
   end
 end

--- a/app/views/gws/bookmark/items/_list_head.html.erb
+++ b/app/views/gws/bookmark/items/_list_head.html.erb
@@ -1,0 +1,54 @@
+<%= jquery do %>
+  // ドロップダウンの項目は開いた時に初めて生成する。
+  // 一覧ページにはツリーナビに同名のフォルダーリンクが既に存在するため、移動先項目を
+  // 常時サーバー描画するとフォルダー名のクリック対象が二重化し、テスト環境
+  // （ignore_hidden_elements = false）で click_on が曖昧マッチになる。これを避けるため
+  // 遅延生成する。バインドは DOM ready 時・生成はユーザーが開いた後のため本番でも安全。
+  $(".move-menu").each(function() {
+    var $menu = $(this);
+    var $list = $menu.find(".dropdown-menu");
+    $menu.on("ss:dropdownOpened", function() {
+      if ($list.data("populated")) { return; }
+      $list.data("populated", true);
+
+      var folders = $menu.data("folders") || [];
+      $.each(folders, function(_i, folder) {
+        var $a = $("<a/>", { href: "#", role: "menuitem", "data-folder-id": folder.id, text: folder.name });
+        $list.append($("<li/>", { role: "none" }).append($a));
+      });
+    });
+  });
+
+  $(".move-menu").on("click", ".dropdown-menu a", function() {
+    var folderId = $(this).attr("data-folder-id");
+    var form = Gws_Bookmark_Item.buildForm("<%= url_for(action: :move_all) %>", "<%= t('gws/bookmark.links.confirm.move') %>");
+    if (!form) { return false; }
+    form.append($("<input/>", { name: "dst_folder_id", value: folderId, type: "hidden" }));
+    form.appendTo(document.body)[0].requestSubmit();
+    return false;
+  });
+<% end %>
+
+<div class="list-head">
+  <label class="check"><input type="checkbox" /></label>
+
+  <div class="list-head-action">
+    <% if @destination_folders.present? %>
+      <div class="dropdown dropdown-toggle gws-bookmark-dropdown move-menu"
+           data-folders="<%= @destination_folders.map { |folder| { id: folder.id, name: folder.name } }.to_json %>">
+        <button type="button" class="btn" aria-haspopup="true" aria-expanded="false">
+          <%= t('gws/bookmark.links.move') %> <i class="material-icons md-13">keyboard_arrow_down</i>
+        </button>
+        <ul class="dropdown-menu" role="menu"></ul>
+      </div>
+    <% end %>
+
+    <% if @deletable %>
+      <div class="list-head-action-destroy">
+        <%= ss_button_to t("ss.links.delete"), "", class: "destroy-all btn btn-red ml-2 btn-list-head-action", method: "delete", confirm: t('ss.confirm.delete') %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render template: "_search" %>
+</div>

--- a/app/views/gws/bookmark/items/index.html.erb
+++ b/app/views/gws/bookmark/items/index.html.erb
@@ -33,8 +33,13 @@
       $node.droppable({
         tolerance: "pointer",
         hoverClass: "gws-bookmark-drop-hover",
-        drop: function() {
+        drop: function(_event, ui) {
           if (!gwsBookmarkIsValidTarget($node)) { return; }
+
+          // 有効なフォルダーへドロップしたときだけ、ドラッグ元の行を選択対象に含める。
+          // （ドラッグ開始では選択を変更しないため、無効ドロップやキャンセルで選択が汚れない）
+          var sourceCheckbox = ui.draggable.find("label.check input[name='ids[]']");
+          if (!sourceCheckbox.prop("checked")) { sourceCheckbox.prop("checked", true); }
 
           var folderId = $node.data("id");
           var folderName = $node.find("a.item-name").text();
@@ -56,12 +61,13 @@
     opacity: 0.75,
     cursorAt: { top: 16, left: 5 },
     helper: function() {
+      // 表示用の件数のみ算出する。選択状態(checkbox)はドラッグ開始では変更せず、
+      // 実際の対象化は drop ハンドラ側でドラッグ元を含めて確定する。
       var checkbox = $(this).find("label.check input[name='ids[]']");
-      if (!checkbox.prop("checked")) { checkbox.prop("checked", true); }
-
       var checked = $(".index .list-item input:checkbox:checked");
+      var count = checked.length + (checkbox.prop("checked") ? 0 : 1);
       var helper = $('<div style="background-color: lightgreen; padding: 2px 10px;"></div>');
-      helper.text(checked.length + "<%= t('gws/bookmark.select_check') %>");
+      helper.text(count + "<%= t('gws/bookmark.select_check') %>");
       return helper;
     }
   });

--- a/app/views/gws/bookmark/items/index.html.erb
+++ b/app/views/gws/bookmark/items/index.html.erb
@@ -10,3 +10,73 @@
 <% end %>
 
 <%= render template: "gws/crud/index" %>
+
+<%= jquery do %>
+  var moveAllUrl = "<%= url_for(action: :move_all) %>";
+  // 移動先候補は移動ドロップダウン（.move-menu[data-folders]）を唯一の出所とし、
+  // ドロップダウンとD&Dで集合がズレないよう同じデータからIDの集合を作る。
+  var validFolderIds = {};
+  $.each($(".move-menu").data("folders") || [], function(_i, folder) {
+    validFolderIds[folder.id] = true;
+  });
+
+  function gwsBookmarkIsValidTarget($node) {
+    return !!validFolderIds[$node.data("id")];
+  }
+
+  // フォルダーノードをドロップ先として有効化する（既に初期化済みならスキップ）
+  function gwsBookmarkMakeDroppable($nodes) {
+    $nodes.filter(".tree-item[data-id]").each(function() {
+      var $node = $(this);
+      if ($node.data("ssDroppable")) { return; }
+      $node.data("ssDroppable", true);
+      $node.droppable({
+        tolerance: "pointer",
+        hoverClass: "gws-bookmark-drop-hover",
+        drop: function() {
+          if (!gwsBookmarkIsValidTarget($node)) { return; }
+
+          var folderId = $node.data("id");
+          var folderName = $node.find("a.item-name").text();
+          var confirmMsg = "<%= t('gws/bookmark.links.confirm.move_drop.head') %>" +
+            " \"" + folderName + "\" " + "<%= t('gws/bookmark.links.confirm.move_drop.tail') %>";
+
+          var form = Gws_Bookmark_Item.buildForm(moveAllUrl, confirmMsg);
+          if (!form) { return; }
+          form.append($("<input/>", { name: "dst_folder_id", value: folderId, type: "hidden" }));
+          form.appendTo(document.body)[0].requestSubmit();
+        }
+      });
+    });
+  }
+
+  // 一覧のブックマーク行をドラッグ可能にする
+  $(".index .list-item").draggable({
+    zIndex: 100,
+    opacity: 0.75,
+    cursorAt: { top: 16, left: 5 },
+    helper: function() {
+      var checkbox = $(this).find("label.check input[name='ids[]']");
+      if (!checkbox.prop("checked")) { checkbox.prop("checked", true); }
+
+      var checked = $(".index .list-item input:checkbox:checked");
+      var helper = $('<div style="background-color: lightgreen; padding: 2px 10px;"></div>');
+      helper.text(checked.length + "<%= t('gws/bookmark.select_check') %>");
+      return helper;
+    }
+  });
+
+  // ツリーは非同期・遅延描画されるため、追加されたノードに順次ドロップ先を適用する
+  var treeContainer = $("#content-navi .tree-navi").get(0);
+  if (treeContainer) {
+    gwsBookmarkMakeDroppable($(treeContainer).find(".tree-item"));
+    var observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        $(mutation.addedNodes).each(function() {
+          gwsBookmarkMakeDroppable($(this).find(".tree-item").addBack(".tree-item"));
+        });
+      });
+    });
+    observer.observe(treeContainer, { childList: true, subtree: true });
+  }
+<% end %>

--- a/config/locales/gws/bookmark/en.yml
+++ b/config/locales/gws/bookmark/en.yml
@@ -1,9 +1,19 @@
 en:
   gws/bookmark:
     all: All bookmarks
+    links:
+      move: Move
+      confirm:
+        move: Do you want to move the selected items?
+        move_drop:
+          head: Move the selected bookmarks to
+          tail: "?"
+    select_check: " bookmark(s) selected"
     notice:
       save: Saved in Favorites
       edit: Edit the favorite
+      move_failed: "Some items could not be moved: %{names}"
+      move_none: No items were moved.
     options:
       bookmark_model:
         external_link: External link

--- a/config/locales/gws/bookmark/ja.yml
+++ b/config/locales/gws/bookmark/ja.yml
@@ -1,9 +1,19 @@
 ja:
   gws/bookmark:
     all: 全てのブックマーク
+    links:
+      move: 移動する
+      confirm:
+        move: 選択した項目を移動しますか？
+        move_drop:
+          head: 選択したブックマークを
+          tail: に移動しますか？
+    select_check: 件のブックマークを選択
     notice:
       save: お気に入りを保存しました
       edit: お気に入りを編集
+      move_failed: "移動できなかった項目があります：%{names}"
+      move_none: 移動する項目がありませんでした。
     options:
       bookmark_model:
         external_link: 外部リンク

--- a/config/routes/gws/bookmark/routes.rb
+++ b/config/routes/gws/bookmark/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
     end
 
     scope(path: ':folder_id', defaults: { folder_id: '-' }) do
-      resources :items, concerns: [:deletion]
+      resources :items, concerns: [:deletion] do
+        post :move_all, on: :collection
+      end
     end
     resources :folders, concerns: [:deletion] do
       match :move, on: :member, via: [:get, :post]

--- a/spec/features/gws/bookmark/items/move_all_drag_spec.rb
+++ b/spec/features/gws/bookmark/items/move_all_drag_spec.rb
@@ -33,6 +33,8 @@ describe "gws_bookmark_items move_all (drag and drop)", type: :feature, dbscope:
       .click_and_hold(source.native)
       .move_by(15, 15)        # 最初の mousemove で jQuery UI のドラッグを開始させる
       .move_to(target.native) # ドロップ先ノードへ移動して droppable の hover を発火
+      # 2回目の移動で hover/over を確実に再発火させ、Selenium のタイミング依存による
+      # droppable 未認識（flaky）を避けるためのワークアラウンド。
       .move_to(target.native)
       .release
       .perform

--- a/spec/features/gws/bookmark/items/move_all_drag_spec.rb
+++ b/spec/features/gws/bookmark/items/move_all_drag_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+# ドラッグ＆ドロップ経路の試作 feature spec。
+#
+# 注意:
+# jQuery UI の draggable/droppable は mousedown → mousemove(閾値超え) → mouseup の
+# イベント列とタイミングに依存し、Selenium での再現は不安定（flaky）になりやすい。
+# サーバー側ロジックの確定的な担保は spec/requests/gws/bookmark/items/move_all_spec.rb
+# が担い、本 spec は D&D 経路のクライアント側配線（draggable/droppable → buildForm →
+# confirm → move_all 送信）が一通りつながっていることを確認する試作という位置づけ。
+describe "gws_bookmark_items move_all (drag and drop)", type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:user) { gws_user }
+
+  let!(:root_folder) { user.bookmark_root_folder(site) }
+  let!(:folder1) { create :gws_bookmark_folder, cur_user: user, in_parent: root_folder.id }
+  let!(:folder2) { create :gws_bookmark_folder, cur_user: user, in_parent: root_folder.id }
+
+  let!(:item1) { create :gws_bookmark_item, cur_user: user, folder: folder1 }
+  let!(:item2) { create :gws_bookmark_item, cur_user: user, folder: folder1 }
+
+  let(:index_path) { gws_bookmark_items_path site, folder_id: folder1 }
+
+  before { login_user user }
+
+  # 一覧行 item を、フォルダーツリーの folder ノードへ jQuery UI の D&D で移動する。
+  def drag_item_to_folder(item, folder)
+    source = find(".index .list-item[data-id='#{item.id}']")
+    target = find("#content-navi .tree-navi .tree-item[data-id='#{folder.id}']")
+
+    page.driver.browser.action
+      .move_to(source.native)
+      .click_and_hold(source.native)
+      .move_by(15, 15)        # 最初の mousemove で jQuery UI のドラッグを開始させる
+      .move_to(target.native) # ドロップ先ノードへ移動して droppable の hover を発火
+      .move_to(target.native)
+      .release
+      .perform
+  end
+
+  context "ブックマーク行をフォルダーツリーへドロップして移動できる" do
+    it do
+      visit index_path
+
+      within "#content-navi" do
+        expect(page).to have_css(".tree-item[data-id='#{folder2.id}'] .item-name", text: folder2.trailing_name)
+      end
+
+      expect(item1.folder_id).to eq folder1.id
+
+      page.accept_confirm do
+        drag_item_to_folder(item1, folder2)
+      end
+
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      # ドラッグした item1 のみが folder2 へ移動し、未選択の item2 は folder1 に残る
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder2.id
+      expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq folder1.id
+    end
+  end
+end

--- a/spec/features/gws/bookmark/items/move_all_spec.rb
+++ b/spec/features/gws/bookmark/items/move_all_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe "gws_bookmark_items move_all", type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:user) { gws_user }
+
+  let!(:root_folder) { user.bookmark_root_folder(site) }
+  let!(:folder1) { create :gws_bookmark_folder, cur_user: user, in_parent: root_folder.id }
+  let!(:folder2) { create :gws_bookmark_folder, cur_user: user, in_parent: root_folder.id }
+
+  let!(:item1) { create :gws_bookmark_item, cur_user: user, folder: folder1 }
+  let!(:item2) { create :gws_bookmark_item, cur_user: user, folder: folder1 }
+
+  let(:index_path) { gws_bookmark_items_path site, folder_id: folder1 }
+
+  before { login_user user }
+
+  context "移動ドロップダウンで選択したブックマークを別フォルダーへ一括移動できる" do
+    it do
+      visit index_path
+      within ".index .list-items" do
+        expect(page).to have_css(".list-item", text: item1.name)
+        expect(page).to have_css(".list-item", text: item2.name)
+      end
+
+      wait_for_event_fired("ss:checked-all-list-items") { find('.list-head label.check input').set(true) }
+
+      within ".list-head-action .move-menu" do
+        find("button.btn", text: I18n.t("gws/bookmark.links.move")).click
+        page.accept_confirm do
+          click_on folder2.name
+        end
+      end
+
+      wait_for_notice I18n.t('ss.notice.saved')
+
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder2.id
+      expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq folder2.id
+    end
+  end
+end

--- a/spec/requests/gws/bookmark/items/move_all_spec.rb
+++ b/spec/requests/gws/bookmark/items/move_all_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+# ブックマークの一括移動（移動ドロップダウン／ドラッグ&ドロップが叩く move_all
+# エンドポイント）のサーバーロジックを、ブラウザ非依存で決定的に検証する。
+describe "gws_bookmark_items move_all (request)", type: :request, dbscope: :example do
+  let!(:site) { gws_site }
+  let!(:user) { gws_user }
+
+  let!(:root_folder) { user.bookmark_root_folder(site) }
+  let!(:folder1) { create :gws_bookmark_folder, cur_user: user, in_parent: root_folder.id }
+  let!(:folder2) { create :gws_bookmark_folder, cur_user: user, in_parent: root_folder.id }
+
+  let!(:item1) { create :gws_bookmark_item, cur_user: user, folder: folder1 }
+  let!(:item2) { create :gws_bookmark_item, cur_user: user, folder: folder1 }
+
+  before do
+    get sns_auth_token_path(format: :json)
+    auth_token = response.parsed_body["auth_token"]
+    post sns_login_path(format: :json), params: {
+      'authenticity_token' => auth_token,
+      'item[email]' => user.email,
+      'item[password]' => ss_pass
+    }
+  end
+
+  # flash の notice はコントローラがリクエスト時のロケールで翻訳して格納するため、
+  # spec 側の I18n.locale（locale.rb がランダムに選ぶ）と一致するとは限らない。
+  # ロケールに依存せず「どの notice キーが使われたか」を検証するため、
+  # 利用可能な全ロケールの翻訳のいずれかと一致することを確認する。
+  def notice_translations(key)
+    I18n.available_locales.map { |locale| I18n.t(key, locale: locale) }
+  end
+
+  def post_move_all(dst, ids: [ item1.id, item2.id ], from: folder1)
+    post move_all_gws_bookmark_items_path(site, folder_id: from), params: { ids: ids, dst_folder_id: dst.id }
+  end
+
+  context "別フォルダーへ一括移動できる" do
+    it do
+      post_move_all(folder2)
+      expect(response.status).to eq 302
+      expect(notice_translations('ss.notice.saved')).to include(flash[:notice])
+
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder2.id
+      expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq folder2.id
+    end
+  end
+
+  context "ルートフォルダーへも一括移動できる" do
+    it do
+      post_move_all(root_folder)
+      expect(response.status).to eq 302
+
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq root_folder.id
+      expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq root_folder.id
+    end
+  end
+
+  context "移動先が現在のフォルダーと同一で、実際には何も移動しない場合" do
+    it do
+      post_move_all(folder1)
+      expect(response.status).to eq 302
+      expect(notice_translations('gws/bookmark.notice.move_none')).to include(flash[:notice])
+
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder1.id
+      expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq folder1.id
+    end
+  end
+
+  context "存在しない移動先フォルダーを指定した場合" do
+    it do
+      post move_all_gws_bookmark_items_path(site, folder_id: folder1), params: { ids: [ item1.id, item2.id ], dst_folder_id: 9_999_999 }
+      expect(response.status).to eq 404
+
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder1.id
+      expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq folder1.id
+    end
+  end
+
+  context "他ユーザーのフォルダーは移動先にできない" do
+    let!(:other_user) { create :gws_user, group_ids: user.group_ids, gws_role_ids: user.gws_role_ids }
+    let!(:other_folder) { other_user.bookmark_root_folder(site) }
+
+    it do
+      post move_all_gws_bookmark_items_path(site, folder_id: folder1), params: { ids: [ item1.id, item2.id ], dst_folder_id: other_folder.id }
+      expect(response.status).to eq 404
+
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder1.id
+      expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq folder1.id
+    end
+  end
+end

--- a/spec/requests/gws/bookmark/items/move_all_spec.rb
+++ b/spec/requests/gws/bookmark/items/move_all_spec.rb
@@ -91,4 +91,26 @@ describe "gws_bookmark_items move_all (request)", type: :request, dbscope: :exam
       expect(Gws::Bookmark::Item.find(item2.id).folder_id).to eq folder1.id
     end
   end
+
+  context "細工された ids[] に他ユーザーのブックマークを混ぜても名前を漏らさない" do
+    let!(:other_user) { create :gws_user, group_ids: user.group_ids, gws_role_ids: user.gws_role_ids }
+    let!(:other_folder) { other_user.bookmark_root_folder(site) }
+    let!(:other_item) do
+      create :gws_bookmark_item, cur_user: other_user, folder: other_folder, name: "他人の秘密ブックマーク"
+    end
+
+    it do
+      post move_all_gws_bookmark_items_path(site, folder_id: folder1),
+        params: { ids: [ item1.id, other_item.id ], dst_folder_id: folder2.id }
+      expect(response.status).to eq 302
+
+      # 権限エラーで弾いた項目があるため、名前を含まない汎用メッセージにフォールバックする
+      expect(notice_translations('errors.messages.auth_error')).to include(flash[:notice])
+      expect(flash[:notice]).not_to include(other_item.name)
+
+      # 自分の item1 は移動でき、他ユーザーの項目は元のフォルダーから動かない
+      expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder2.id
+      expect(Gws::Bookmark::Item.find(other_item.id).folder_id).to eq other_folder.id
+    end
+  end
 end

--- a/spec/requests/gws/bookmark/items/move_all_spec.rb
+++ b/spec/requests/gws/bookmark/items/move_all_spec.rb
@@ -69,7 +69,8 @@ describe "gws_bookmark_items move_all (request)", type: :request, dbscope: :exam
 
   context "存在しない移動先フォルダーを指定した場合" do
     it do
-      post move_all_gws_bookmark_items_path(site, folder_id: folder1), params: { ids: [ item1.id, item2.id ], dst_folder_id: 9_999_999 }
+      post move_all_gws_bookmark_items_path(site, folder_id: folder1),
+        params: { ids: [ item1.id, item2.id ], dst_folder_id: 9_999_999 }
       expect(response.status).to eq 404
 
       expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder1.id
@@ -82,7 +83,8 @@ describe "gws_bookmark_items move_all (request)", type: :request, dbscope: :exam
     let!(:other_folder) { other_user.bookmark_root_folder(site) }
 
     it do
-      post move_all_gws_bookmark_items_path(site, folder_id: folder1), params: { ids: [ item1.id, item2.id ], dst_folder_id: other_folder.id }
+      post move_all_gws_bookmark_items_path(site, folder_id: folder1),
+        params: { ids: [ item1.id, item2.id ], dst_folder_id: other_folder.id }
       expect(response.status).to eq 404
 
       expect(Gws::Bookmark::Item.find(item1.id).folder_id).to eq folder1.id


### PR DESCRIPTION
## 概要

グループウェアのブックマーク一覧で、複数のブックマークを選択してまとめて別フォルダーへ移動できる一括移動機能を追加しました。

## 変更内容

- **一括移動アクション**: ブックマーク一覧でチェックボックスにより選択した複数ブックマークを、移動先フォルダーへまとめて移動できるようにしました。
- **コントローラー** (`app/controllers/gws/bookmark/items_controller.rb`): `move_all` アクションを追加。
  - 対象はログインユーザー所有のブックマークに限定（細工された POST 対策）。
  - 移動は `folder_id` の更新のみ（容量集計は行いません）。
  - 移動先パラメーターは、ルートのパススコープ `:folder_id` と衝突するため `dst_folder_id` で受け取ります。
- **ルート** (`config/routes/gws/bookmark/routes.rb`): items collection に `POST move_all` を追加。
- **JS** (`app/assets/javascripts/gws/bookmark/item.js`): 選択された `ids[]` を収集してフォーム送信する処理を追加。
- **ビュー** (`_list_head.html.erb` / `index.html.erb`): 一括移動の UI を追加。
- **CSS / i18n（日英）**: スタイルとロケールを追加。
- **テスト**: request spec / feature spec を追加（ドラッグ＆ドロップ移動は試作扱い）。

## テスト

- `spec/requests/gws/bookmark/items/move_all_spec.rb`
- `spec/features/gws/bookmark/items/move_all_spec.rb`
- `spec/features/gws/bookmark/items/move_all_drag_spec.rb`（D&D 試作）

https://claude.ai/code/session_01JTvNosWQCWRvDZ1QbVmUWn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTvNosWQCWRvDZ1QbVmUWn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ブックマークの一括移動を追加。複数アイテムをドロップダウンまたはドラッグ＆ドロップで別フォルダーに移動可能。
* **スタイル**
  * 一括移動／ドラッグ＆ドロップ用の表示・ハイライト・ドロップダウンスタイルを追加。
* **テスト**
  * ブラウザ／リクエスト両面の自動テストを追加し、一括移動の挙動を検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->