### PR TITLE
[modify][sys] postal code import improvements

### DIFF
--- a/app/jobs/sys/postal_code/official_csv_import_job.rb
+++ b/app/jobs/sys/postal_code/official_csv_import_job.rb
@@ -3,9 +3,16 @@ require 'nkf'
 
 class Sys::PostalCode::OfficialCsvImportJob < Sys::PostalCode::ImportBase
   def import_file
+    error_count = 0
     SS::Csv.foreach_row(@cur_file, headers: false) do |row, i|
-      import_row(row, i)
+      Rails.logger.tagged("#{i + 1}行目") do
+        import_row(row, i)
+      rescue => e
+        Rails.logger.error { "#{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}" }
+        error_count += 1
+      end
     end
+    throw :abort if error_count > 0
     nil
   end
 
@@ -21,38 +28,50 @@ class Sys::PostalCode::OfficialCsvImportJob < Sys::PostalCode::ImportBase
 
     item = Sys::PostalCode.where(code: postal_code).first_or_create
     item.prefecture = pref
-    item.prefecture_kana = normalize_pref_kana(pref_kana)
+    item.prefecture_kana = normalize_pref_kana(pref_kana, max_length: Sys::PostalCode::MAX_PREFECTURE_KANA_LENGTH)
     item.prefecture_code = pref_code
-    item.city = normalize_city(city)
-    item.city_kana = normalize_city_kana(city_kana)
-    item.town = normalize_town(town)
-    item.town_kana = normalize_town_kana(town_kana)
+    item.city = normalize_city(city, max_length: Sys::PostalCode::MAX_CITY_LENGTH)
+    item.city_kana = normalize_city_kana(city_kana, max_length: Sys::PostalCode::MAX_CITY_KANA_LENGTH)
+    item.town = normalize_town(town, max_length: Sys::PostalCode::MAX_TOWN_LENGTH)
+    item.town_kana = normalize_town_kana(town_kana, max_length: Sys::PostalCode::MAX_TOWN_KANA_LENGTH)
     item.save!
   end
 
-  def normalize_pref_kana(pref_kana)
+  def normalize_pref_kana(pref_kana, max_length:)
     pref_kana = NKF::nkf('-Z1 -Ww', pref_kana)
+    if pref_kana.length > max_length
+      Rails.logger.warn { "#{Sys::PostalCode.t(:prefecture_kana)}が#{max_length}を超えています。超過分は切り捨てられます。" }
+      pref_kana = pref_kana[0, max_length]
+    end
     pref_kana
   end
 
-  def normalize_city(city)
+  def normalize_city(city, max_length:, field_name: nil)
     city = city.sub(I18n.t('sys.postal_code_normalize_city'), "")
     city = city.gsub(/（.+）/, "")
+    if city.length > max_length
+      Rails.logger.warn { "#{field_name || Sys::PostalCode.t(:city)}が#{max_length}を超えています。超過分は切り捨てられます。" }
+      city = city[0, max_length]
+    end
     city
   end
 
-  def normalize_city_kana(city_kana)
+  def normalize_city_kana(city_kana, max_length:, field_name: nil)
     city_kana = city_kana.sub("ｲｶﾆｹｲｻｲｶﾞﾅｲﾊﾞｱｲ", "")
     city_kana = city_kana.gsub(/\(.+\)/, "")
     city_kana = NKF::nkf('-Z1 -Ww', city_kana)
+    if city_kana.length > max_length
+      Rails.logger.warn { "#{field_name || Sys::PostalCode.t(:city_kana)}が#{max_length}を超えています。超過分は切り捨てられます。" }
+      city_kana = city_kana[0, max_length]
+    end
     city_kana
   end
 
-  def normalize_town(town)
-    normalize_city(town)
+  def normalize_town(town, max_length:)
+    normalize_city(town, max_length: max_length, field_name: Sys::PostalCode.t(:town))
   end
 
-  def normalize_town_kana(town_kana)
-    normalize_city_kana(town_kana)
+  def normalize_town_kana(town_kana, max_length:)
+    normalize_city_kana(town_kana, max_length: max_length, field_name: Sys::PostalCode.t(:town_kana))
   end
 end

--- a/app/models/concerns/ss/model/postal_code.rb
+++ b/app/models/concerns/ss/model/postal_code.rb
@@ -3,6 +3,14 @@ module SS::Model::PostalCode
   extend SS::Translation
   include SS::Document
 
+  MAX_PREFECTURE_LENGTH = 40
+  MAX_PREFECTURE_KANA_LENGTH = 40
+  MAX_PREFECTURE_CODE_LENGTH = 40
+  MAX_CITY_LENGTH = 40
+  MAX_CITY_KANA_LENGTH = 40
+  MAX_TOWN_LENGTH = 80
+  MAX_TOWN_KANA_LENGTH = 80
+
   included do
     store_in collection: "ss_postal_codes"
 
@@ -19,13 +27,13 @@ module SS::Model::PostalCode
     permit_params :code, :prefecture, :prefecture_kana, :prefecture_code, :city, :city_kana, :town, :town_kana
 
     validates :code, presence: true, uniqueness: true
-    validates :prefecture, presence: true, length: { maximum: 40 }
-    validates :prefecture_kana, length: { maximum: 40 }
-    validates :prefecture_code, length: { maximum: 40 }
-    validates :city, length: { maximum: 40 }
-    validates :city_kana, length: { maximum: 40 }
-    validates :town, length: { maximum: 80 }
-    validates :town_kana, length: { maximum: 80 }
+    validates :prefecture, presence: true, length: { maximum: MAX_PREFECTURE_LENGTH }
+    validates :prefecture_kana, length: { maximum: MAX_PREFECTURE_KANA_LENGTH }
+    validates :prefecture_code, length: { maximum: MAX_PREFECTURE_CODE_LENGTH }
+    validates :city, length: { maximum: MAX_CITY_LENGTH }
+    validates :city_kana, length: { maximum: MAX_CITY_KANA_LENGTH }
+    validates :town, length: { maximum: MAX_TOWN_LENGTH }
+    validates :town_kana, length: { maximum: MAX_TOWN_KANA_LENGTH }
 
     index({ code: 1 }, { unique: true })
     index({ prefecture_code: 1, code: 1, _id: 1 })


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

郵便局が配布しているCSVをインポートする際の問題点を改善

- エラーが発生したCSVの行番号をログに記録
- 途中で止まらないように。CSVの最後まで進むように修正。
- 長すぎる「町名（カナ）」をトリム。トリムしたことをログに出力するように。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 郵便番号CSVインポート処理でエラー発生時に詳細なログ記録と安全な中止処理が実装されました。

* **Improvements**
  * 住所フィールド（都道府県、市区町村、町丁目など）の文字数制限が厳密に管理されるようになり、データの一貫性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->