### PR TITLE
[modify][style]汎用DB: .input-group内の項目が多い場合の折り返し対応

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -3311,6 +3311,8 @@ form .CodeMirror {
 }
 .input-group {
   display: flex;
+  flex-wrap: wrap;
+  gap: 5px 0;
 
   .input-group-append {
     display: flex;


### PR DESCRIPTION
## 概要

汎用DB（gws/tabular）のタクソノミー機能について、`.input-group` 内の項目が多いとレイアウトが崩れるとの報告に対応しました。

## 原因

タクソノミー（enumフィールドの複数チェックボックス／ラジオなど）の選択肢は、`app/components/gws/tabular/column/base_component.html.erb` の `.input-group`（`display: flex`）内に横並びで描画されます。`.input-group` は `flex-wrap: nowrap`（既定）のままだったため、選択肢が多いと一行に収まらずはみ出して崩れていました。

## 変更内容

`app/assets/stylesheets/ss/_pc_mb.scss` の既存の `.input-group` ルールに、以下を追加しました。

```scss
.input-group {
  display: flex;
  flex-wrap: wrap;   // 追加
  gap: 5px 0;        // 追加
  ...
}
```

- `display: flex` は既存のため重複させず、`flex-wrap: wrap` と `gap: 5px 0` のみ追加しています。
- `gap: 5px 0`（行間5px・列間0）なので、折り返した時のみ縦に5pxの間隔が空き、横方向の既存の間隔は変更していません。

## 補足

`.input-group` はグローバルな共通クラスのため、汎用DB以外（各種API一覧・フォーム等）にも適用されます。狭い幅のコンテナで `.input-group-append` 等が折り返す可能性は理論上ありますが、行折り返しと行gapの追加のみで低リスクと判断しています。汎用DBのタクソノミーに限定したい場合は `.gws-tabular-column .input-group` へのスコープ変更も可能です。

https://claude.ai/code/session_01WdKaNW5KDXbt5zyh5yuq5p

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdKaNW5KDXbt5zyh5yuq5p)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 関連PR
[# 6073](https://github.com/shirasagi/shirasagi/pull/6073)

## Summary by CodeRabbit

* **スタイル**
  * 検索フィールドのレイアウトが複数行表示に対応し、より柔軟な表示が可能になりました。要素間の間隔も最適化されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->