### PR TITLE
[modify][cms]複数ファイルアップロードの説明文入力欄の表示/非表示設定を追加

### DIFF
--- a/app/models/cms/column/multiple_files_upload.rb
+++ b/app/models/cms/column/multiple_files_upload.rb
@@ -1,7 +1,9 @@
 class Cms::Column::MultipleFilesUpload < Cms::Column::Base
   field :file_type, type: String, default: "image"
+  field :header_input_setting, type: String, default: "show"
   validates :file_type, inclusion: { in: %w(image attachment) }
-  permit_params :file_type
+  validates :header_input_setting, inclusion: { in: %w(show hide) }
+  permit_params :file_type, :header_input_setting
 
   def alignment_options
     %w(flow).map { |v| [ I18n.t("cms.options.alignment.#{v}"), v ] }
@@ -17,10 +19,21 @@ class Cms::Column::MultipleFilesUpload < Cms::Column::Base
     end
   end
 
+  def header_input_setting_options
+    %w(show hide).map do |v|
+      [ I18n.t("cms.options.multiple_files_upload_header_input_setting.#{v}", default: v), v ]
+    end
+  end
+
+  def header_enabled?
+    header_input_setting != "hide"
+  end
+
   class << self
     def default_attributes
       attrs = super
       attrs[:file_type] = "image"
+      attrs[:header_input_setting] = "show"
       attrs
     end
   end

--- a/app/views/cms/agents/columns/multiple_files_upload/_column_form.html.erb
+++ b/app/views/cms/agents/columns/multiple_files_upload/_column_form.html.erb
@@ -18,11 +18,13 @@
        data-label-name="item[column_values][][in_wrap][file_labels]"
        data-label-placeholder="<%= t("cms.column_multiple_files_upload.#{file_type}.file_label_placeholder") %>"
        data-order-aria-label="<%= t("cms.column_multiple_files_upload.order_aria_label") %>">
-    <div class="multiple-files-upload-header">
-      <label for="<%= "#{id}-header" %>"><%= t("cms.column_multiple_files_upload.#{file_type}.header") %></label>
-      <%= text_area_tag header_field_name, current_header, id: "#{id}-header", rows: 3,
-            placeholder: t("cms.column_multiple_files_upload.#{file_type}.header_placeholder") %>
-    </div>
+    <% if column.try(:header_enabled?) %>
+      <div class="multiple-files-upload-header">
+        <label for="<%= "#{id}-header" %>"><%= t("cms.column_multiple_files_upload.#{file_type}.header") %></label>
+        <%= text_area_tag header_field_name, current_header, id: "#{id}-header", rows: 3,
+              placeholder: t("cms.column_multiple_files_upload.#{file_type}.header_placeholder") %>
+      </div>
+    <% end %>
 
     <%=
       component = SS::FileSelectBoxComponent.new(

--- a/app/views/cms/agents/columns/multiple_files_upload/_column_show.html.erb
+++ b/app/views/cms/agents/columns/multiple_files_upload/_column_show.html.erb
@@ -3,7 +3,7 @@
   file_type = column.try(:file_type).presence || "image"
 %>
 <%= render 'cms/agents/columns/main/base', show: true, column: column, value: value do %>
-  <% if value && value.header.present? %>
+  <% if column.try(:header_enabled?) && value && value.header.present? %>
     <div class="multiple-files-upload-header"><%= simple_format(value.header) %></div>
   <% end %>
   <% if value && value.file_ids.present? %>

--- a/app/views/cms/agents/columns/multiple_files_upload/_form.html.erb
+++ b/app/views/cms/agents/columns/multiple_files_upload/_form.html.erb
@@ -1,4 +1,6 @@
 <dl class="see mod-cms-column-multiple-files-upload">
   <dt><%= @model.t :file_type %><%= @model.tt :file_type %></dt>
   <dd><%= f.select :file_type, @item.file_type_options %></dd>
+  <dt><%= @model.t :header_input_setting %><%= @model.tt :header_input_setting %></dt>
+  <dd><%= f.select :header_input_setting, @item.header_input_setting_options %></dd>
 </dl>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -644,6 +644,9 @@ ja:
       multiple_files_upload_file_type:
         image: 画像
         attachment: 添付ファイル
+      multiple_files_upload_header_input_setting:
+        show: 表示する
+        hide: 表示しない
       column_image_html_type:
         thumb: サムネイル
         image: 画像貼付
@@ -1654,6 +1657,7 @@ ja:
         file_type: ファイルタイプ
       cms/column/multiple_files_upload:
         file_type: ファイルタイプ
+        header_input_setting: 説明文入力欄
       cms/column/list:
         list_type: 種類
       cms/column/select_page:
@@ -3319,6 +3323,8 @@ ja:
     cms/column/multiple_files_upload:
       file_type:
         - 複数アップロードするファイルの種別を選択します。
+      header_input_setting:
+        - ファイルリストの先頭に表示する説明文の入力欄を表示するかどうかを選択します。
 
     cms/column/headline:
       min_headline_level:


### PR DESCRIPTION
## 概要

定型フォームの「複数ファイルアップロード」カラムで、入力画面に表示される「説明文（ブロック）」入力欄の表示／非表示をカラム設定で選べるようにしました。

<img width="1699" height="738" alt="スクリーンショット 2026-06-16 13 28 50（2）" src="https://github.com/user-attachments/assets/0e570167-eac9-4459-a92d-b98d76ecd4fe" />

<img width="1660" height="736" alt="スクリーンショット 2026-06-16 13 37 59（2）" src="https://github.com/user-attachments/assets/e23211ca-c2e8-4b16-bb91-94851740a4e4" />

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `app/models/cms/column/multiple_files_upload.rb` | `field :header_input_setting`（default `"show"`）／inclusion バリデーション／`permit_params`／`header_input_setting_options` メソッド／`header_enabled?` ヘルパー／`default_attributes` への追加 |
| `app/views/cms/agents/columns/multiple_files_upload/_form.html.erb` | カラム設定画面に `f.select :header_input_setting` を1行追加 |
| `app/views/cms/agents/columns/multiple_files_upload/_column_form.html.erb` | 説明文ブロックを `header_enabled?` による条件表示に変更 |
| `app/views/cms/agents/columns/multiple_files_upload/_column_show.html.erb` | 非表示時に説明文プレビューを隠す条件を追加 |
| `config/locales/cms/ja.yml` | 属性ラベル（説明文入力欄）／選択肢（表示する・表示しない）／ヘルプ文 |

## 仕様

- 既存の `file_type` と同じ `field + _options + f.select` パターンに揃えています。
- `header_enabled?` は `header_input_setting != "hide"` 判定とし、既存データ・新規ともデフォルトで「表示する」になります。

## 補足

- cms のロケールは `ja.yml` のみで `en.yml` は存在しないため、ja のみ更新しています。
- YAML 構文（aliases あり）と Ruby 構文の検証は通過済みです。

https://claude.ai/code/session_015pMjeiDWphmGRC82q1YJBz

---
_Generated by [Claude Code](https://claude.ai/code/session_015pMjeiDWphmGRC82q1YJBz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 関連PR：https://github.com/shirasagi/shirasagi/pull/6053

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数ファイルアップロード機能のヘッダー表示可否を設定できるようになりました。設定で「表示/非表示」を選択することで、各フィールドのヘッダーの表示を個別に制御できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->