### PR TITLE
[fix][cms] kana dictionary translation key from dictionary_list to dictionary

### DIFF
--- a/app/controllers/kana/dictionaries_controller.rb
+++ b/app/controllers/kana/dictionaries_controller.rb
@@ -10,7 +10,7 @@ class Kana::DictionariesController < ApplicationController
 
   def set_crumbs
     @crumbs << [t("modules.kana"), nil]
-    @crumbs << [t("kana.dictionary_list"), action: :index]
+    @crumbs << [t("kana.dictionary"), action: :index]
   end
 
   def fix_params

--- a/app/views/cms/main/_conf_navi.html.erb
+++ b/app/views/cms/main/_conf_navi.html.erb
@@ -42,7 +42,7 @@
     <h3><%= link_to t("cms.syntax_check"), cms_syntax_checker_main_path %></h3>
   <% end %>
   <% if SS.config.kana.disable.blank? && Kana::Dictionary.allowed?(:read, @cur_user, site: @cur_site) %>
-    <h3><%= link_to t("kana.dictionary_list"), kana_dictionaries_path %></h3>
+    <h3><%= link_to t("kana.dictionary"), kana_dictionaries_path %></h3>
   <% end %>
   <% if Chorg::Revision.allowed?(:read, @cur_user, site: @cur_site) %>
     <h3><%= link_to t("chorg.revision"), chorg_main_path %></h3>

--- a/app/views/kana/main/_conf_navi.html.erb
+++ b/app/views/kana/main/_conf_navi.html.erb
@@ -3,7 +3,7 @@
     <h2><%= t "modules.kana" %></h2>
 
     <% if Kana::Dictionary.allowed?(:read, @cur_user, site: @cur_site) %>
-      <h3><%= link_to t("kana.dictionary_list"), kana_dictionaries_path %></h3>
+      <h3><%= link_to t("kana.dictionary"), kana_dictionaries_path %></h3>
     <% end %>
     <% if Kana::Dictionary.allowed?(:build, @cur_user, site: @cur_site) %>
       <h3><%= link_to t("kana.diagnostic"), kana_diagnostic_path %></h3>


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要
翻訳キーの不一致を修正しました。

## 変更内容
`kana.dictionary_list` から `kana.dictionary` への翻訳キーの統一

- `app/controllers/kana/dictionaries_controller.rb`: breadcrumb の翻訳キーを修正
- `app/views/cms/main/_conf_navi.html.erb`: ナビゲーションリンクの翻訳キーを修正

両箇所で同じ翻訳キーを使用するように統一しました。

<img width="1280" height="720" alt="test-finished-1" src="https://github.com/user-attachments/assets/bd2c448c-c884-43e2-b57b-50b965789224" />

## その他
翻訳キーの統一による表示の一貫性向上。既存の自動テストで検証済み。

関連PR
CMS / SYS / GWS のメニュー配下のパンくずを整備した一連のPRと同系列の修正です。本PRはCMSのパンくず表示崩れの修正にあたります。

https://github.com/shirasagi/shirasagi/pull/6054 [fix] cms : add parent crumbs under CMS menu（CMS サイト設定配下のパンくず親階層追加）
https://github.com/shirasagi/shirasagi/pull/6055 [fix] sys : add parent crumbs under システム設定
https://github.com/shirasagi/shirasagi/pull/6060 fix(gws): GW メニュー配下のパンくずに親階層を追加
https://github.com/shirasagi/shirasagi/pull/6069 [fix][cms] correct i18n key in source cleaner settings breadcrumb spec
https://github.com/shirasagi/shirasagi/pull/6072 [fix][cms]サイト内検索のパンくずの表示崩れを修正


https://claude.ai/code/session_01PrTKqewQdZA9vTiDedU4yN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Kana辞書関連のナビゲーションラベルを統一し、複数の画面での表示一貫性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->