### PR TITLE
[style][gws]通知ポップアップのホバー時に背景が黒くなる不具合を修正

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -245,17 +245,15 @@ _:future,
 .gws-memo-notice {
   display: inline-block;
   //color: init.$white;
-  a {
+  > .ajax-popup-notice {
+    display: block;
+    position: relative;
+    padding: 12px;
     color: init.$white;
     &:hover {
       background: #424242;
       color: init.$white;
     }
-  }
-  > .ajax-popup-notice {
-    display: block;
-    position: relative;
-    padding: 12px;
     .unseen {
       display: inline-block;
       position: absolute;


### PR DESCRIPTION
## 概要

通知欄（ベルアイコン）のポップアップで、各通知にマウスホバーした際だけ背景が黒くなる不具合を修正します。メッセージ欄と同じ挙動に揃えました。

## 原因

`app/assets/stylesheets/ss/_pc_mb.scss` の `.gws-memo-notice` ブロックに、コンテナ内の **すべての** `a` 要素を対象とする以下のルールがありました。

```scss
.gws-memo-notice {
  a {
    color: $white;
    &:hover {
      background: #424242;  // ← ホバー時の黒い背景
      color: $white;
    }
  }
}
```

この `a` セレクタはヘッダーのベルアイコンのリンクだけでなく、ポップアップ内の各通知タイトルのリンクにもマッチしてしまい、ホバー時に背景が黒（`#424242`）になっていました。メッセージ欄（`.gws-memo-message`）には同様の `a` ルールが無いため、正常な挙動になっていました。

## 修正内容

白文字＋黒ホバーの指定を、ヘッダーのトグルリンク（`> .ajax-popup-notice`）だけにスコープしました。これによりポップアップ内の項目は独自のホバースタイル（`background: #fbeee8`）が適用され、メッセージ欄と同じ挙動になります。HTML構造は通知・メッセージで同一のため、CSSの修正のみで対応しています。

CMS用（`_head_user_base_notice`）・GWS用（`_head_user_gws_notice`）の両通知パーシャルが `gws-memo-notice` クラスを共有しているため、両方ともこの修正でカバーされます。

<img width="1280" height="720" alt="test-finished-1-2" src="https://github.com/user-attachments/assets/0d41368f-ad83-45d7-a08a-72b7f5618bee" />


## 出典

GWS改善要望まとめ（スプレッドシート）No.54

https://claude.ai/code/session_01DK1kZZu8YUaxgFZptYToKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DK1kZZu8YUaxgFZptYToKs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **スタイル改善**
  * メモ通知ポップアップのUIスタイルを改善しました。配色とホバー時の動作を調整し、より一貫性のある表示になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->