### PR TITLE
[fix][webmail] Fix flaky export_mails feature spec (await enqueue before performing jobs)

### DIFF
--- a/spec/features/webmail/export_mails_spec.rb
+++ b/spec/features/webmail/export_mails_spec.rb
@@ -42,15 +42,15 @@ describe "webmail_export_mails", type: :feature, dbscope: :example, imap: true, 
     context "export all mails" do
       it do
         visit webmail_export_mails_path(account: 0)
-        within "form#item-form" do
-          choose "item_all_export_all"
-          perform_enqueued_jobs do
+        perform_enqueued_jobs do
+          within "form#item-form" do
+            choose "item_all_export_all"
             click_on I18n.t("ss.export")
           end
-        end
 
-        within "#addon-basic" do
-          expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+          within "#addon-basic" do
+            expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+          end
         end
 
         expect(Gws::Job::Log.count).to eq 1
@@ -86,14 +86,14 @@ describe "webmail_export_mails", type: :feature, dbscope: :example, imap: true, 
           expect(page).to have_content(mail3.subject)
           wait_for_cbox_closed { click_on mail2.subject }
         end
-        within "form#item-form" do
-          perform_enqueued_jobs do
+        perform_enqueued_jobs do
+          within "form#item-form" do
             click_on I18n.t("ss.export")
           end
-        end
 
-        within "#addon-basic" do
-          expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+          within "#addon-basic" do
+            expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+          end
         end
 
         expect(Gws::Job::Log.count).to eq 1
@@ -168,15 +168,15 @@ describe "webmail_export_mails", type: :feature, dbscope: :example, imap: true, 
 
     it do
       visit webmail_export_mails_path(account: 0)
-      within "form#item-form" do
-        choose "item_all_export_all"
-        perform_enqueued_jobs do
+      perform_enqueued_jobs do
+        within "form#item-form" do
+          choose "item_all_export_all"
           click_on I18n.t("ss.export")
         end
-      end
 
-      within "#addon-basic" do
-        expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+        within "#addon-basic" do
+          expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+        end
       end
 
       expect(Gws::Job::Log.count).to eq 1
@@ -212,15 +212,15 @@ describe "webmail_export_mails", type: :feature, dbscope: :example, imap: true, 
 
     it do
       visit webmail_export_mails_path(account: 0)
-      within "form#item-form" do
-        choose "item_all_export_all"
-        perform_enqueued_jobs do
+      perform_enqueued_jobs do
+        within "form#item-form" do
+          choose "item_all_export_all"
           click_on I18n.t("ss.export")
         end
-      end
 
-      within "#addon-basic" do
-        expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+        within "#addon-basic" do
+          expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+        end
       end
 
       expect(Gws::Job::Log.count).to eq 1
@@ -263,15 +263,15 @@ describe "webmail_export_mails", type: :feature, dbscope: :example, imap: true, 
 
     it do
       visit webmail_export_mails_path(account: 0)
-      within "form#item-form" do
-        choose "item_all_export_all"
-        perform_enqueued_jobs do
+      perform_enqueued_jobs do
+        within "form#item-form" do
+          choose "item_all_export_all"
           click_on I18n.t("ss.export")
         end
-      end
 
-      within "#addon-basic" do
-        expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+        within "#addon-basic" do
+          expect(page).to have_content(I18n.t("gws/memo/message.export.start_message").split("\n").first)
+        end
       end
 
       expect(Gws::Job::Log.count).to eq 1


### PR DESCRIPTION
## 概要

`spec/features/webmail/export_mails_spec.rb` が CI 上で不安定に失敗する問題を修正します。特に **「選択メールのエクスポート」** ケース（`export_mails_spec.rb:78`）が現行の CI ランナーで安定して失敗していました。

## 失敗内容

```
webmail_export_mails with usual mails export selected mails is expected to eq 1
  Failure/Error: expect(Gws::Job::Log.count).to eq 1
  expected: 1, got: 0        # RSpec::Retry の3回リトライすべて失敗
  # ./spec/features/webmail/export_mails_spec.rb:99
```

## 原因（テストの競合）

```ruby
perform_enqueued_jobs do
  click_on(エクスポート)          # JS(Selenium) のクリックは送信後すぐに返る
end                                # ← ここでキューを flush
within "#addon-basic" do ... end   # リダイレクト完了(=ジョブ投入)はこの後
```

`click_on` が即座に戻るため、サーバ側がジョブを `enqueue` する前に `perform_enqueued_jobs` ブロックがキューを flush してしまい、ジョブが実行されず `Gws::Job::Log.count` が `0` になることがありました。エクスポート開始メッセージ（リダイレクト完了＝ジョブ投入の確定）の待機が `perform_enqueued_jobs` ブロックの**外側**にあるのが原因です。

「全件エクスポート」は処理が速くたまたま勝つ一方、「選択エクスポート」は colorbox 操作の分だけ遅くなり、現行ランナーでは安定して負けていました。

## 修正

リダイレクト完了を示す開始メッセージ（`gws/memo/message.export.start_message`）の待機を `perform_enqueued_jobs` ブロックの**内側**へ移動しました。Capybara がリダイレクトの完了を待ってからブロックを抜けるため、ジョブ投入後にキューが flush され、確実にジョブが実行されます。これは「JS のナビゲーションを伴うクリックを `perform_enqueued_jobs` で囲む」際の定石パターンです。

同一パターンの 5 箇所（全件 / 選択 / 不正文字を含む件名 / collapsed multipart / 長すぎる件名）すべてに適用しました。製品コード（エクスポート機能）の挙動は変更していません（テストの待機方法のみの修正）。

## 補足

- この失敗は本修正対象のテスト不安定性によるもので、特定の機能変更とは無関係です（私のコミットを含まない以前のコミットでも同テストが同様に失敗していることを確認済み）。
- 実行環境の制約により本スペックは IMAP・JS ブラウザ・メールサーバを要するため、当環境ではローカル実行できていません。CI での検証をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C9M4t3R2yTuEcAvm9jiap

---
_Generated by [Claude Code](https://claude.ai/code/session_019C9M4t3R2yTuEcAvm9jiap)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * メールエクスポート機能のテスト実行タイミングを改善しました。処理完了後の確認がより正確に行われるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->