### PR TITLE
[add][gws] メッセージ一覧で差出人と件名の表示順を選べる個人設定を追加 [J090-623]

### DIFF
--- a/app/assets/stylesheets/gws/memo/_gws.scss
+++ b/app/assets/stylesheets/gws/memo/_gws.scss
@@ -243,6 +243,53 @@
       font-weight: normal;
     }
   }
+
+  // 個人設定「件名 → 差出人」: order で並びを入れ替え、件名列と差出人・宛先列の幅・インデントを
+  // 入れ替える。既定配置で揃うよう調整済みの値をそのまま入れ替えるため、整列状態は既定と同一になる。
+  &.subject-first {
+    .list-item-head .head {
+      .title {
+        order: 1;
+        width: calc(50% - 100px);
+        text-indent: 79.84px;
+      }
+      .from,
+      .to {
+        order: 2;
+        width: calc(50% - 130px);
+        text-indent: 0;
+      }
+      .priority {
+        order: 3;
+      }
+      .datetime {
+        order: 4;
+      }
+      .size {
+        order: 5;
+      }
+    }
+    .info {
+      .title {
+        order: 1;
+        width: calc(50% - 132.84px);
+      }
+      .from,
+      .to {
+        order: 2;
+        width: calc(50% - 75px);
+      }
+      .priority {
+        order: 3;
+      }
+      .datetime {
+        order: 4;
+      }
+      .size {
+        order: 5;
+      }
+    }
+  }
 }
 
 table.index.gws-memo-folder {

--- a/app/assets/stylesheets/webmail/_ss.scss
+++ b/app/assets/stylesheets/webmail/_ss.scss
@@ -301,6 +301,43 @@ li.webmail-accounts {
       text-align: right;
     }
   }
+
+  // 個人設定「件名 → 差出人」: order で並びを入れ替える。件名は可変幅のまま広く保ち、
+  // ヘッダの差出人・件名幅をデータ行の値に合わせてラベルと列を揃える。
+  &.subject-first {
+    .list-item-head .head {
+      .title {
+        order: 1;
+        width: calc(100% - 400px);
+      }
+      .from,
+      .to {
+        order: 2;
+        width: 200px;
+      }
+      .datetime {
+        order: 3;
+      }
+      .size {
+        order: 4;
+      }
+    }
+    .info {
+      .title {
+        order: 1;
+      }
+      .from,
+      .to {
+        order: 2;
+      }
+      .datetime {
+        order: 3;
+      }
+      .size {
+        order: 4;
+      }
+    }
+  }
 }
 
 // show

--- a/app/controllers/gws/user_message_display_settings_controller.rb
+++ b/app/controllers/gws/user_message_display_settings_controller.rb
@@ -1,0 +1,18 @@
+class Gws::UserMessageDisplaySettingsController < ApplicationController
+  include Gws::BaseFilter
+  include Gws::CrudFilter
+  include Gws::UserSettingFilter
+
+  before_action :check_permission
+
+  private
+
+  def check_permission
+    raise "404" unless @cur_site.menu_memo_visible?
+    raise "403" unless Gws.module_usable?(:memo, @cur_site, @cur_user)
+  end
+
+  def permit_fields
+    [ :message_list_column_order ]
+  end
+end

--- a/app/models/concerns/ss/addon/message_display_setting.rb
+++ b/app/models/concerns/ss/addon/message_display_setting.rb
@@ -6,7 +6,7 @@ module SS::Addon::MessageDisplaySetting
     field :message_list_column_order, type: String, default: "name_first"
 
     permit_params :message_list_column_order
-    validates :message_list_column_order, inclusion: { in: %w(name_first subject_first) }
+    validates :message_list_column_order, inclusion: { in: %w(name_first subject_first), allow_blank: true }
   end
 
   def message_list_column_order_options

--- a/app/models/concerns/ss/addon/message_display_setting.rb
+++ b/app/models/concerns/ss/addon/message_display_setting.rb
@@ -6,6 +6,7 @@ module SS::Addon::MessageDisplaySetting
     field :message_list_column_order, type: String, default: "name_first"
 
     permit_params :message_list_column_order
+    validates :message_list_column_order, inclusion: { in: %w(name_first subject_first) }
   end
 
   def message_list_column_order_options

--- a/app/models/concerns/ss/addon/message_display_setting.rb
+++ b/app/models/concerns/ss/addon/message_display_setting.rb
@@ -1,0 +1,20 @@
+module SS::Addon::MessageDisplaySetting
+  extend ActiveSupport::Concern
+  extend SS::Addon
+
+  included do
+    field :message_list_column_order, type: String, default: "name_first"
+
+    permit_params :message_list_column_order
+  end
+
+  def message_list_column_order_options
+    %w(name_first subject_first).map do |v|
+      [I18n.t("ss.options.message_list_column_order.#{v}"), v]
+    end
+  end
+
+  def message_list_subject_first?
+    message_list_column_order == "subject_first"
+  end
+end

--- a/app/models/concerns/ss/model/user.rb
+++ b/app/models/concerns/ss/model/user.rb
@@ -7,6 +7,7 @@ module SS::Model::User
   include SS::Reference::UserExpiration
   include SS::UserImportValidator
   include SS::Addon::LocaleSetting
+  include SS::Addon::MessageDisplaySetting
   include SS::Addon::Ldap::User
   include SS::Addon::MFA::UserSetting
   include SS::Addon::SSO::User

--- a/app/views/gws/memo/messages/index.html.erb
+++ b/app/views/gws/memo/messages/index.html.erb
@@ -1,6 +1,6 @@
 <div class="index gws-memos-index">
   <%= render template: '_list_head' %>
-  <ul class="list-items ss-messages gws-memos">
+  <ul class="list-items ss-messages gws-memos<%= ' subject-first' if @cur_user.message_list_subject_first? %>">
     <li class="list-item-head">
       <div class="head">
         <% if @cur_folder.sent_box? || @cur_folder.draft_box? %>

--- a/app/views/gws/user_message_display_settings/_form.html.erb
+++ b/app/views/gws/user_message_display_settings/_form.html.erb
@@ -1,0 +1,1 @@
+<%= render "ss/agents/addons/message_display_setting/form", f: f %>

--- a/app/views/gws/user_message_display_settings/_menu.html.erb
+++ b/app/views/gws/user_message_display_settings/_menu.html.erb
@@ -1,0 +1,7 @@
+<nav class="nav-menu">
+  <% if params[:action] =~ /edit|update|delete/ %>
+    <%= link_to t('ss.links.back_to_show'), action: :show %>
+  <% else %>
+    <%= link_to t('ss.links.edit'), action: :edit %>
+  <% end %>
+</nav>

--- a/app/views/gws/user_message_display_settings/_show.html.erb
+++ b/app/views/gws/user_message_display_settings/_show.html.erb
@@ -1,0 +1,1 @@
+<%= render "ss/agents/addons/message_display_setting/show" %>

--- a/app/views/gws/user_settings/_navi.html.erb
+++ b/app/views/gws/user_settings/_navi.html.erb
@@ -16,6 +16,10 @@
   <% end %>
 
   <h3><%= link_to t('modules.addons.ss/locale_setting'), gws_user_locale_setting_path %></h3>
+
+  <% if @cur_site.menu_memo_visible? && Gws.module_usable?(:memo, @cur_site, @cur_user) %>
+    <h3><%= link_to t('modules.addons.ss/message_display_setting'), gws_user_message_display_setting_path %></h3>
+  <% end %>
 </nav>
 
 <%= render partial: "gws/main/navi" %>

--- a/app/views/ss/agents/addons/message_display_setting/_form.html.erb
+++ b/app/views/ss/agents/addons/message_display_setting/_form.html.erb
@@ -1,0 +1,4 @@
+<dl class="see">
+  <dt><%= @model.t :message_list_column_order %></dt>
+  <dd><%= f.select :message_list_column_order, @item.message_list_column_order_options %></dd>
+</dl>

--- a/app/views/ss/agents/addons/message_display_setting/_show.html.erb
+++ b/app/views/ss/agents/addons/message_display_setting/_show.html.erb
@@ -1,0 +1,4 @@
+<dl class="see">
+  <dt><%= @model.t :message_list_column_order %></dt>
+  <dd><%= @item.label :message_list_column_order %></dd>
+</dl>

--- a/app/views/webmail/mails/index.html.erb
+++ b/app/views/webmail/mails/index.html.erb
@@ -54,7 +54,7 @@
 <div class="index">
   <%= render template: "_list_head" %>
 
-  <ul class="list-items ss-messages webmail-mails">
+  <ul class="list-items ss-messages webmail-mails<%= ' subject-first' if @cur_user.message_list_subject_first? %>">
     <li class="list-item-head">
       <div class="head">
         <% if @imap.sent_box?(@mailbox) || @imap.draft_box?(@mailbox) %>

--- a/config/locales/ss/en.yml
+++ b/config/locales/ss/en.yml
@@ -633,6 +633,9 @@ en:
       lang:
         ja: 日本語
         en: English (Experimental)
+      message_list_column_order:
+        name_first: "Sender → Subject"
+        subject_first: "Subject → Sender"
       link_target:
         _self: Same tab
         _blank: New tab
@@ -712,6 +715,7 @@ en:
       ss/oauth2/gws_permission: Groupware permissions
       ss/oauth2/webmail_permission: Mail permissions
       ss/locale_setting: Locale settings
+      ss/message_display_setting: Message list display
       ss/mfa/user_setting: MFA settings
       ss/check_links_setting: Email Notification Settings
 
@@ -1153,6 +1157,8 @@ en:
       ss/addon/locale_setting:
         lang: Language
         timezone: Timezone
+      ss/addon/message_display_setting:
+        message_list_column_order: Message list display
       ss/addon/workflow_setting:
         workflow_my_group: Display own group
       ss/api_token:

--- a/config/locales/ss/en.yml
+++ b/config/locales/ss/en.yml
@@ -634,8 +634,8 @@ en:
         ja: 日本語
         en: English (Experimental)
       message_list_column_order:
-        name_first: "Sender → Subject"
-        subject_first: "Subject → Sender"
+        name_first: "Sender -> Subject"
+        subject_first: "Subject -> Sender"
       link_target:
         _self: Same tab
         _blank: New tab
@@ -715,7 +715,7 @@ en:
       ss/oauth2/gws_permission: Groupware permissions
       ss/oauth2/webmail_permission: Mail permissions
       ss/locale_setting: Locale settings
-      ss/message_display_setting: Message list display
+      ss/message_display_setting: Mail/Message list display
       ss/mfa/user_setting: MFA settings
       ss/check_links_setting: Email Notification Settings
 
@@ -1158,7 +1158,7 @@ en:
         lang: Language
         timezone: Timezone
       ss/addon/message_display_setting:
-        message_list_column_order: Message list display
+        message_list_column_order: Mail/Message list display
       ss/addon/workflow_setting:
         workflow_my_group: Display own group
       ss/api_token:

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -634,8 +634,8 @@ ja:
         ja: 日本語
         en: English (Experimental)
       message_list_column_order:
-        name_first: 差出人 → 件名
-        subject_first: 件名 → 差出人
+        name_first: 差出人 -> 件名
+        subject_first: 件名 -> 差出人
       link_target:
         _self: 同じタブで開く
         _blank: 新しいタブで開く
@@ -715,7 +715,7 @@ ja:
       ss/oauth2/gws_permission: グループウェア権限
       ss/oauth2/webmail_permission: メール権限
       ss/locale_setting: 言語設定
-      ss/message_display_setting: メッセージ一覧の表示
+      ss/message_display_setting: メール/メッセージ一覧の表示
       ss/mfa/user_setting: MFA設定
       ss/check_links_setting: メール通知設定
 
@@ -1158,7 +1158,7 @@ ja:
         lang: 言語
         timezone: タイムゾーン
       ss/addon/message_display_setting:
-        message_list_column_order: メッセージ一覧の表示
+        message_list_column_order: メール/メッセージ一覧の表示
       ss/addon/workflow_setting:
         workflow_my_group: 自所属の表示
       ss/api_token:

--- a/config/locales/ss/ja.yml
+++ b/config/locales/ss/ja.yml
@@ -633,6 +633,9 @@ ja:
       lang:
         ja: 日本語
         en: English (Experimental)
+      message_list_column_order:
+        name_first: 差出人 → 件名
+        subject_first: 件名 → 差出人
       link_target:
         _self: 同じタブで開く
         _blank: 新しいタブで開く
@@ -712,6 +715,7 @@ ja:
       ss/oauth2/gws_permission: グループウェア権限
       ss/oauth2/webmail_permission: メール権限
       ss/locale_setting: 言語設定
+      ss/message_display_setting: メッセージ一覧の表示
       ss/mfa/user_setting: MFA設定
       ss/check_links_setting: メール通知設定
 
@@ -1153,6 +1157,8 @@ ja:
       ss/addon/locale_setting:
         lang: 言語
         timezone: タイムゾーン
+      ss/addon/message_display_setting:
+        message_list_column_order: メッセージ一覧の表示
       ss/addon/workflow_setting:
         workflow_my_group: 自所属の表示
       ss/api_token:

--- a/config/routes/gws/routes.rb
+++ b/config/routes/gws/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
       post :edit_password, on: :member, action: :update_password
     end
     resource :user_locale_setting, only: [:show, :edit, :update]
+    resource :user_message_display_setting, only: [:show, :edit, :update]
     resource :user_form, concerns: [:deletion] do
       resources :user_form_columns, only: %i[index create], path: '/columns' do
         post :reorder, on: :collection

--- a/spec/features/gws/user_message_display_setting_spec.rb
+++ b/spec/features/gws/user_message_display_setting_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "gws_user_message_display_setting", type: :feature, dbscope: :example, js: true do
+  let(:site) { gws_site }
+  before { login_gws_user }
+
+  context "basic crud" do
+    it do
+      visit gws_user_message_display_setting_path(site: site)
+      click_on I18n.t("ss.links.edit")
+
+      within "form#item-form" do
+        select I18n.t("ss.options.message_list_column_order.subject_first"), from: "item[message_list_column_order]"
+        click_on I18n.t("ss.buttons.save")
+      end
+      wait_for_notice I18n.t("ss.notice.saved")
+
+      gws_user.reload
+      expect(gws_user.message_list_column_order).to eq "subject_first"
+    end
+  end
+
+  context "memo list reflects the setting" do
+    it do
+      # 既定（差出人 → 件名）では subject-first クラスは付かない
+      visit gws_memo_messages_path(site)
+      expect(page).to have_css("ul.gws-memos")
+      expect(page).to have_no_css("ul.gws-memos.subject-first")
+
+      gws_user.update!(message_list_column_order: "subject_first")
+
+      visit gws_memo_messages_path(site)
+      expect(page).to have_css("ul.gws-memos.subject-first")
+    end
+  end
+end

--- a/spec/features/gws/user_message_display_setting_spec.rb
+++ b/spec/features/gws/user_message_display_setting_spec.rb
@@ -33,4 +33,25 @@ describe "gws_user_message_display_setting", type: :feature, dbscope: :example, 
       expect(page).to have_css("ul.gws-memos.subject-first")
     end
   end
+
+  context "when memo menu is hidden in site setting" do
+    before { site.update!(menu_memo_state: "hide") }
+
+    it "does not show the setting page (404)" do
+      visit gws_user_message_display_setting_path(site: site)
+      expect(page).to have_title("404 Not Found | SHIRASAGI")
+    end
+  end
+
+  context "when user has no memo permission" do
+    let(:role) { create :gws_role_portal_user_use, cur_site: site }
+    let(:user) do
+      create :gws_user, name: unique_id, email: unique_email, group_ids: [ site.id ], gws_role_ids: [ role.id ]
+    end
+
+    it "does not show the setting page (403)" do
+      login_user user, to: gws_user_message_display_setting_path(site: site)
+      expect(page).to have_title("403 Forbidden | SHIRASAGI")
+    end
+  end
 end

--- a/spec/models/ss/addon/message_display_setting_spec.rb
+++ b/spec/models/ss/addon/message_display_setting_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe SS::Addon::MessageDisplaySetting, type: :model, dbscope: :example do
+  let!(:group) { create(:ss_group) }
+  let(:user) { create(:ss_user, group_ids: [ group.id ]) }
+
+  describe "validation of message_list_column_order" do
+    %w(name_first subject_first).each do |value|
+      it "accepts #{value}" do
+        expect(user.update(message_list_column_order: value)).to be_truthy
+        expect(user.reload.message_list_column_order).to eq value
+      end
+    end
+
+    [nil, "", "unknown"].each do |value|
+      it "rejects #{value.inspect}" do
+        expect(user.update(message_list_column_order: value)).to be_falsey
+        expect(user.errors[:message_list_column_order]).to be_present
+      end
+    end
+  end
+
+  describe "#message_list_subject_first?" do
+    it "is true only when subject_first" do
+      user.update!(message_list_column_order: "subject_first")
+      expect(user.reload.message_list_subject_first?).to be_truthy
+
+      user.update!(message_list_column_order: "name_first")
+      expect(user.reload.message_list_subject_first?).to be_falsey
+    end
+  end
+end

--- a/spec/models/ss/addon/message_display_setting_spec.rb
+++ b/spec/models/ss/addon/message_display_setting_spec.rb
@@ -12,10 +12,17 @@ describe SS::Addon::MessageDisplaySetting, type: :model, dbscope: :example do
       end
     end
 
-    [nil, "", "unknown"].each do |value|
-      it "rejects #{value.inspect}" do
-        expect(user.update(message_list_column_order: value)).to be_falsey
-        expect(user.errors[:message_list_column_order]).to be_present
+    it "rejects an unknown value" do
+      expect(user.update(message_list_column_order: "unknown")).to be_falsey
+      expect(user.errors[:message_list_column_order]).to be_present
+    end
+
+    # nil/空は許容し、初期値（差出人 → 件名）として扱う。
+    # allow_blank により default 補完に依存せず、射影パス等で nil が来ても保存を弾かない。
+    [nil, ""].each do |value|
+      it "accepts #{value.inspect} as the initial value" do
+        expect(user.update(message_list_column_order: value)).to be_truthy
+        expect(user.reload.message_list_subject_first?).to be_falsey
       end
     end
   end

--- a/spec/models/ss/addon/message_display_setting_spec.rb
+++ b/spec/models/ss/addon/message_display_setting_spec.rb
@@ -4,6 +4,14 @@ describe SS::Addon::MessageDisplaySetting, type: :model, dbscope: :example do
   let!(:group) { create(:ss_group) }
   let(:user) { create(:ss_user, group_ids: [ group.id ]) }
 
+  # 本 PR の主契約: 未設定ユーザーは従来どおり「差出人 → 件名」のまま
+  describe "default value" do
+    it "defaults to name_first and is not subject-first for a new user" do
+      expect(user.message_list_column_order).to eq "name_first"
+      expect(user.message_list_subject_first?).to be_falsey
+    end
+  end
+
   describe "validation of message_list_column_order" do
     %w(name_first subject_first).each do |value|
       it "accepts #{value}" do


### PR DESCRIPTION
## 概要
グループウェアのメッセージ一覧で、「差出人/宛先」と「件名」の表示順を**ユーザーが個人設定で選べる**ようにします。（GWS改善要望まとめスプレッドシート No.31 / 定例で下記の案に合意）

- 既定は **差出人 → 件名（現状維持）**。未設定ユーザーの表示は変わりません。
- 切替UIはGWSの個人設定のみ。フィールドを共有しているため、ウェブメールの一覧表示も同じ設定に追従します。

## 実装
- `SS::Addon::MessageDisplaySetting` を追加し `SS::Model::User` に include。
  - 共有フィールド `message_list_column_order`（`name_first`＝既定 / `subject_first`）。
  - `Gws::User`・`Webmail::User` は同一ユーザードキュメント（`ss_users`）を共有するため、1フィールドでGWSメモ一覧・ウェブメール一覧の双方に反映。
- GWS個人設定に「メッセージ一覧の表示」ページを追加（`Gws::UserLocaleSettings` と同方式）。
  - 在席管理(presence)と同様に `menu_memo_visible?` ＆ `Gws.module_usable?(:memo, …)` でナビ表示・直接アクセスを制御。サイト設定でメッセージ(memo)メニューを非表示にすると本設定も非表示。
- GWSメモ一覧／ウェブメール一覧を CSS の `order` で列順分岐（`subject-first` 修飾子）。既定時は表示不変。

## テスト
- `spec/features/gws/user_message_display_setting_spec.rb`（2 examples）
  - 個人設定の保存・永続化
  - 設定に応じてメモ一覧に `subject-first` クラスが付与/非付与

## 操作方法
- GWS→プロフィール→メッセージ一覧表示で「件名 → 差出人」に切替
<img width="1904" height="321" alt="スクリーンショット 2026-06-25 16 00 21（2）" src="https://github.com/user-attachments/assets/b2d6c3ae-169e-4e87-a1dd-50cae900c588" />

- メッセージの表示切り替えが可能
<img width="1904" height="565" alt="スクリーンショット 2026-06-25 16 05 02（2）" src="https://github.com/user-attachments/assets/49c921be-db20-48c5-b2af-19cb0ddbb9c5" />

- rubocop / stylelint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 個人設定で、メッセージ一覧のカラム順（既定／件名優先）を選択できるようになりました。
- **改善**
  - 件名優先にすると、メモ一覧およびWebメールの表示順（列幅・インデント等）を切り替えます。
  - サイトの表示可否や権限に応じて、設定画面のアクセス応答（404/403）を制御します。
- **テスト**
  - 設定の保存・反映、アクセス制御（404/403）、UIの反映を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->