### PR TITLE
[modify][gws] レポート/回覧板/照会・回答の送信先ラベルを用途別の名称に変更 [J090-636]

### DIFF
--- a/app/models/concerns/gws/addon/circular/member.rb
+++ b/app/models/concerns/gws/addon/circular/member.rb
@@ -1,0 +1,5 @@
+module Gws::Addon::Circular::Member
+  extend ActiveSupport::Concern
+  extend SS::Addon
+  include Gws::Member
+end

--- a/app/models/concerns/gws/addon/report/member.rb
+++ b/app/models/concerns/gws/addon/report/member.rb
@@ -1,0 +1,5 @@
+module Gws::Addon::Report::Member
+  extend ActiveSupport::Concern
+  extend SS::Addon
+  include Gws::Member
+end

--- a/app/models/gws/circular/post.rb
+++ b/app/models/gws/circular/post.rb
@@ -10,7 +10,7 @@ class Gws::Circular::Post
   include SS::Addon::Markdown
   include Gws::Addon::File
   include Gws::Addon::Circular::Category
-  include Gws::Addon::Member
+  include Gws::Addon::Circular::Member
   include Gws::Addon::GroupPermission
   include Gws::Addon::History
 

--- a/app/models/gws/report/file.rb
+++ b/app/models/gws/report/file.rb
@@ -5,7 +5,7 @@ class Gws::Report::File
   include Gws::Reference::Site
   #include Gws::Addon::Reminder
   include Gws::Addon::Report::CustomForm
-  include Gws::Addon::Member
+  include Gws::Addon::Report::Member
   include Gws::Addon::Schedules
   include Gws::Addon::ReadableSetting
   include Gws::Addon::GroupPermission

--- a/app/views/gws/agents/addons/circular/member/_form.html.erb
+++ b/app/views/gws/agents/addons/circular/member/_form.html.erb
@@ -1,0 +1,1 @@
+<%= render "gws/agents/addons/member/form", f: f %>

--- a/app/views/gws/agents/addons/circular/member/_show.html.erb
+++ b/app/views/gws/agents/addons/circular/member/_show.html.erb
@@ -1,0 +1,1 @@
+<%= render "gws/agents/addons/member/show" %>

--- a/app/views/gws/agents/addons/report/member/_form.html.erb
+++ b/app/views/gws/agents/addons/report/member/_form.html.erb
@@ -1,0 +1,1 @@
+<%= render "gws/agents/addons/member/form", f: f %>

--- a/app/views/gws/agents/addons/report/member/_show.html.erb
+++ b/app/views/gws/agents/addons/report/member/_show.html.erb
@@ -1,0 +1,1 @@
+<%= render "gws/agents/addons/member/show" %>

--- a/config/locales/gws/circular/en.yml
+++ b/config/locales/gws/circular/en.yml
@@ -19,7 +19,7 @@ en:
       unset_seen: Mark as unread
       seen_at: Date and time read
       download: Output to CSV
-      member: Participants
+      member: Recipients
       type: Category
       update_at: Change date and time
       user: User
@@ -67,6 +67,7 @@ en:
     addons:
       gws/circular/group_setting: Circular boards
       gws/circular/category: Category
+      gws/circular/member: Recipients
   gws_role:
     use_gws_circular: Use of circulars
     read_other_gws_circular_posts: View circulars (all)
@@ -107,7 +108,7 @@ en:
     errors:
       models:
         gws/circular/post:
-          member_length: Set the number of participants at no more than %{max}.
+          member_length: Set the number of recipients at no more than %{max}.
           file_size_limit: The size of the attachment (%{size}) has exceeded the maximum size (%{limit}).
         gws/circular/category:
           too_deep: The hierarchy is too deep and should be below %{max}.
@@ -122,6 +123,9 @@ en:
         see_type: Format to mark as read
         deleted: Deletion date and time
         seen: Read
+        member_ids: Recipient users
+        member_group_ids: Recipient groups
+        member_custom_group_ids: Recipient custom groups
       gws/circular/comment:
         name: Title
         text: Comments
@@ -161,7 +165,7 @@ en:
       circular_sort:
         - Select order of circular boards.
       circular_max_member:
-        - Enter the maximum number of participants.
+        - Enter the maximum number of recipients.
         - If unspecified, the number is not restricted.
         - The initial value is unspecified.
       circular_filesize_limit:

--- a/config/locales/gws/circular/ja.yml
+++ b/config/locales/gws/circular/ja.yml
@@ -19,7 +19,7 @@ ja:
       unset_seen: 未読にする
       seen_at: 既読日時
       download: CSVに出力する
-      member: 参加者
+      member: 回覧先
       type: 区分
       update_at: 変更日時
       user: ユーザー
@@ -67,6 +67,7 @@ ja:
     addons:
       gws/circular/group_setting: 回覧板
       gws/circular/category: カテゴリー
+      gws/circular/member: 回覧先
   gws_role:
     use_gws_circular: 回覧板の利用
     read_other_gws_circular_posts: 回覧板の閲覧（全て）
@@ -107,7 +108,7 @@ ja:
     errors:
       models:
         gws/circular/post:
-          member_length: 参加者は%{max}人以下にしてください。
+          member_length: 回覧先は%{max}人以下にしてください。
           file_size_limit: 添付ファイルのサイズ（%{size}）が 最大サイズ（%{limit}）を超えました。
         gws/circular/category:
           too_deep: は%{max}階層以下にしてください。
@@ -122,6 +123,9 @@ ja:
         see_type: 既読にする形式
         deleted: 削除日時
         seen: 既読
+        member_ids: 回覧先ユーザー
+        member_group_ids: 回覧先グループ
+        member_custom_group_ids: 回覧先カスタムグループ
       gws/circular/comment:
         name: タイトル
         text: コメント
@@ -161,7 +165,7 @@ ja:
       circular_sort:
         - 表示する回覧板の並びを選択します。
       circular_max_member:
-        - 参加者の人数の上限を入力します。
+        - 回覧先の人数の上限を入力します。
         - 未指定である場合、制限されません。
         - 初期値は 未指定 です。
       circular_filesize_limit:

--- a/config/locales/gws/monitor/en.yml
+++ b/config/locales/gws/monitor/en.yml
@@ -14,7 +14,7 @@ en:
       update: Update
       delete: Delete
       disabled_items: Deleted
-      browsing_state: Participating groups
+      browsing_state: Target groups
       browsed: View
       type: Status
       mark_at: Date and time confirmed
@@ -171,7 +171,7 @@ en:
     addons:
       gws/monitor/category: Category
       gws/monitor/contributor: Contributors
-      gws/monitor/group: Participating groups
+      gws/monitor/group: Target groups
       gws/monitor/release: Publishing settings
       gws/monitor/group_setting: Inquiries and responses
 
@@ -252,7 +252,7 @@ en:
         release_date: Publishing start date and time (reservation)
         close_date: Publishing end date and time (reservation)
       gws/addon/monitor/group:
-        attend_group_ids: Participating groups
+        attend_group_ids: Target groups
       gws/monitor/postable:
         name: Title
         created: Date and time created
@@ -305,7 +305,7 @@ en:
           - Select the contributor name.
       gws/addon/monitor/group:
         group_name:
-          - Select the participating groups.
+          - Select the target groups.
           - "You can edit it by changing to Draft status in \"Publishing settings.”"
       gws/monitor/postable:
         name:

--- a/config/locales/gws/monitor/ja.yml
+++ b/config/locales/gws/monitor/ja.yml
@@ -14,7 +14,7 @@ ja:
       update: 更新
       delete: 削除
       disabled_items: 削除済み
-      browsing_state: 参加グループ
+      browsing_state: 照会対象グループ
       browsed: 閲覧
       type: 状態
       mark_at: 確認日時
@@ -171,7 +171,7 @@ ja:
     addons:
       gws/monitor/category: カテゴリー
       gws/monitor/contributor: 投稿者
-      gws/monitor/group: 参加グループ
+      gws/monitor/group: 照会対象グループ
       gws/monitor/release: 公開設定
       gws/monitor/group_setting: 照会・回答
 
@@ -252,7 +252,7 @@ ja:
         release_date: 公開開始日時(予約)
         close_date: 公開終了日時(予約)
       gws/addon/monitor/group:
-        attend_group_ids: 参加グループ
+        attend_group_ids: 照会対象グループ
       gws/monitor/postable:
         name: タイトル
         created: 作成日時
@@ -305,7 +305,7 @@ ja:
           - 投稿者名を選択します。
       gws/addon/monitor/group:
         group_name:
-          - 参加するグループを選択します。
+          - 照会対象グループを選択します。
           - 「公開設定」でステータスを下書きにすることで編集可能となります。
       gws/monitor/postable:
         name:

--- a/config/locales/gws/report/en.yml
+++ b/config/locales/gws/report/en.yml
@@ -40,6 +40,7 @@ en:
       gws/report/custom_form: Input details
       gws/report/category: Category
       gws/report/group_setting: Reports
+      gws/report/member: Recipients
 
   gws_role:
     use_gws_report: Use of reports
@@ -78,6 +79,8 @@ en:
     attributes:
       gws/report/file:
         name: Title
+        member_ids: Recipient users
+        member_group_ids: Recipient groups
       gws/report/form:
         name: Title
         order: Order

--- a/config/locales/gws/report/ja.yml
+++ b/config/locales/gws/report/ja.yml
@@ -40,6 +40,7 @@ ja:
       gws/report/custom_form: 入力内容
       gws/report/category: カテゴリー
       gws/report/group_setting: レポート
+      gws/report/member: 提出先
 
   gws_role:
     use_gws_report: レポートの利用
@@ -78,6 +79,8 @@ ja:
     attributes:
       gws/report/file:
         name: タイトル
+        member_ids: 提出先ユーザー
+        member_group_ids: 提出先グループ
       gws/report/form:
         name: タイトル
         order: 並び順

--- a/spec/features/gws/circular/admins/basic_crud_spec.rb
+++ b/spec/features/gws/circular/admins/basic_crud_spec.rb
@@ -19,7 +19,7 @@ describe "gws_circular_admins", type: :feature, dbscope: :example, js: true do
 
       within "form#item-form" do
         fill_in "item[name]", with: name
-        within "#addon-gws-agents-addons-member" do
+        within "#addon-gws-agents-addons-circular-member" do
           wait_for_cbox_opened { click_on I18n.t("ss.apis.users.index") }
         end
       end
@@ -185,7 +185,7 @@ describe "gws_circular_admins", type: :feature, dbscope: :example, js: true do
       end
 
       within "form#item-form" do
-        within "#addon-gws-agents-addons-member" do
+        within "#addon-gws-agents-addons-circular-member" do
           wait_for_cbox_opened { click_on I18n.t("ss.apis.users.index") }
         end
       end
@@ -225,7 +225,7 @@ describe "gws_circular_admins", type: :feature, dbscope: :example, js: true do
 
       within "form#item-form" do
         fill_in "item[name]", with: name
-        within "#addon-gws-agents-addons-member" do
+        within "#addon-gws-agents-addons-circular-member" do
           wait_for_cbox_opened { click_on I18n.t("ss.apis.users.index") }
         end
       end
@@ -317,7 +317,7 @@ describe "gws_circular_admins", type: :feature, dbscope: :example, js: true do
 
       within "form#item-form" do
         fill_in "item[name]", with: name
-        within "#addon-gws-agents-addons-member" do
+        within "#addon-gws-agents-addons-circular-member" do
           wait_for_cbox_opened { click_on I18n.t("ss.apis.users.index") }
         end
       end
@@ -368,7 +368,7 @@ describe "gws_circular_admins", type: :feature, dbscope: :example, js: true do
       click_on topic.name
       click_on I18n.t("ss.links.edit")
       within "form#item-form" do
-        within "#addon-gws-agents-addons-member" do
+        within "#addon-gws-agents-addons-circular-member" do
           within ".ajax-selected [data-id='#{user1.id}']" do
             click_on I18n.t("ss.buttons.delete")
           end

--- a/spec/features/gws/circular/admins/filesize_limit_spec.rb
+++ b/spec/features/gws/circular/admins/filesize_limit_spec.rb
@@ -31,7 +31,7 @@ describe "gws_circular_admins", type: :feature, dbscope: :example, js: true do
         ss_upload_file file_path, addon: "#addon-gws-agents-addons-file"
 
         # choose member
-        within "#addon-gws-agents-addons-member" do
+        within "#addon-gws-agents-addons-circular-member" do
           wait_for_cbox_opened { click_on I18n.t("ss.apis.users.index") }
         end
       end
@@ -80,7 +80,7 @@ describe "gws_circular_admins", type: :feature, dbscope: :example, js: true do
         ss_upload_file file_path, addon: "#addon-gws-agents-addons-file"
 
         # choose member
-        within "#addon-gws-agents-addons-member" do
+        within "#addon-gws-agents-addons-circular-member" do
           wait_for_cbox_opened { click_on I18n.t("ss.apis.users.index") }
         end
       end


### PR DESCRIPTION
## 概要

GWS の「参加者」という共有ラベルが、レポートや回覧板など機能ごとの実態（送信先・宛先）と合っていないという要望を受け、機能ごとに分かりやすい名称へ変更します。

- レポート　：参加者 → **提出先**
- 回覧板　　：参加者 → **回覧先**
- 照会・回答：参加グループ → **照会対象グループ**

## 変更方針

`modules.addons.gws/member`（「参加者」見出し）は `Gws::Addon::Member` を include する多数のモデルで共有されているため、共有キーを温存したまま専用アドオンを新設してラベルのみ差し替えます。

- `Gws::Addon::Report::Member` / `Gws::Addon::Circular::Member` を新設（`Gws::Member` を include）
- `Gws::Report::File` / `Gws::Circular::Post` の include を専用アドオンへ差し替え
- ビューはモジュール名からパスが導出されるため、`gws/agents/addons/report(circular)/member` のラッパー partial を新設し既存 member partial を描画
- ロケール（ja/en）に見出し・属性ラベル・付随文言（回覧板の人数制限エラー/ヘルプ、詳細 h2）を追加
- 照会・回答（monitor）は独立実装のためロケールのみ変更

## 影響範囲

- 掲示板・電子会議室・ワークフロー2 を含む他機能は共有キーを温存しているため**従来どおり「参加者」のまま影響なし**
- データ・スキーマ（`member_ids` 等）は不変

## テスト

- `spec/models/gws/circular/post_spec.rb` … green
- `spec/features/gws/circular/admins/basic_crud_spec.rb` / `filesize_limit_spec.rb` … 専用アドオンのコンテナ id へ追従修正し green
- rubocop … no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * サークル向けとレポート向けで、それぞれ専用のメンバー入力・表示が利用できるようになりました。
  * サークル関連画面で、専用のメンバー関連UIに切り替わりました。

* **Tests**
  * サークル管理の主要な操作フローに合わせて、画面確認用のテストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->