### PR TITLE
[fix][kana] 絵文字の出現によって位置がずれ Kana::ConvertError が発生する問題の修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@ spec/fixtures/gws/memo/*.eml binary
 spec/fixtures/gws/schedule/*.csv binary
 spec/fixtures/gws/user/*.csv binary
 spec/fixtures/gws/workload/*.csv binary
+spec/fixtures/kana/*.html binary
 spec/fixtures/ldap/*.csv binary
 spec/fixtures/opendata/*.csv binary
 spec/fixtures/opendata/harvest/shirasagi_scraper/*.csv binary

--- a/lib/kana/converter.rb
+++ b/lib/kana/converter.rb
@@ -18,7 +18,7 @@ module Kana::Converter
       skip_marks = config['skip-marks']
       html = html.tr("\u00A0", " ")
 
-      text = html.gsub(/[\r\n\t]/, " ")
+      text = html.gsub(/[\r\n\t]+/) { " " * _1.bytesize }
       text.gsub!(/<!--[^>]*?\s#{kana_marks[1]}\s[^>]*?-->.*?<!--[^>]*?\s#{kana_marks[0]}\s[^>]*?-->/im) do |m|
         "\r" * m.bytes.length
       end
@@ -41,7 +41,7 @@ module Kana::Converter
       text.gsub!(/<!--[^>]*?\s#{skip_marks[0]}\s[^>]*?-->(.*?)<!--[^>]*?\s#{skip_marks[1]}\s[^>]*?-->/im) do |m|
         "\r" * m.bytes.length
       end
-      text.gsub!(/[ -\/:-@\[-`{-~]/m) { |m| "\r" * m.bytes.length }
+      text.gsub!(/[ -\/:-@\[-`{-~]+/m) { |m| "\r" * m.bytesize }
 
       byte = html.bytes
       kana = ""

--- a/lib/kana/converter.rb
+++ b/lib/kana/converter.rb
@@ -32,10 +32,9 @@ module Kana::Converter
       text.gsub!(/<!\[CDATA\[.*?\]\]>/m) { |m| mpad(m) }
       text.gsub!(/<!--.*?-->/m) { |m| mpad(m) }
       tags.each { |t| text.gsub!(/<#{t}( [^>]*\/>|[^\w].*?<\/#{t}>)/m) { |m| mpad(m) } }
-      text.gsub!(/<.*?>/m) do |m|
-        mpad(m).gsub(/\s*=\s*['"]([^'"]*)['"]/im) do |m|
-          "\r" * m.bytesize
-        end
+      text.gsub!(/<.*?>/m) do |matched|
+        matched = mpad(matched)
+        matched.gsub(/\s*=\s*['"]([^'"]*)['"]/im) { "\r" * _1.bytesize }
       end
       text.gsub!(/\\u003c.*?\\u003e/m) { |m| mpad(m) } #<>
       text.gsub!(/<!--[^>]*?\s#{skip_marks[0]}\s[^>]*?-->(.*?)<!--[^>]*?\s#{skip_marks[1]}\s[^>]*?-->/im) do |m|

--- a/lib/kana/converter.rb
+++ b/lib/kana/converter.rb
@@ -20,13 +20,13 @@ module Kana::Converter
 
       text = html.gsub(/[\r\n\t]+/) { " " * _1.bytesize }
       text.gsub!(/<!--[^>]*?\s#{kana_marks[1]}\s[^>]*?-->.*?<!--[^>]*?\s#{kana_marks[0]}\s[^>]*?-->/im) do |m|
-        "\r" * m.bytes.length
+        "\r" * m.bytesize
       end
       text.gsub!(/.*?<!--[^>]*?\s#{kana_marks[0]}\s[^>]*?-->/im) do |m|
-        "\r" * m.bytes.length
+        "\r" * m.bytesize
       end
       text.gsub!(/<!--[^>]*?\s#{kana_marks[1]}\s[^>]*?-->.*/im) do |m|
-        "\r" * m.bytes.length
+        "\r" * m.bytesize
       end
       tags = %w(head ruby script style)
       text.gsub!(/<!\[CDATA\[.*?\]\]>/m) { |m| mpad(m) }
@@ -34,12 +34,12 @@ module Kana::Converter
       tags.each { |t| text.gsub!(/<#{t}( [^>]*\/>|[^\w].*?<\/#{t}>)/m) { |m| mpad(m) } }
       text.gsub!(/<.*?>/m) do |m|
         mpad(m).gsub(/\s*=\s*['"]([^'"]*)['"]/im) do |m|
-          "\r" * m.bytes.length
+          "\r" * m.bytesize
         end
       end
       text.gsub!(/\\u003c.*?\\u003e/m) { |m| mpad(m) } #<>
       text.gsub!(/<!--[^>]*?\s#{skip_marks[0]}\s[^>]*?-->(.*?)<!--[^>]*?\s#{skip_marks[1]}\s[^>]*?-->/im) do |m|
-        "\r" * m.bytes.length
+        "\r" * m.bytesize
       end
       text.gsub!(/[ -\/:-@\[-`{-~]+/m) { |m| "\r" * m.bytesize }
 
@@ -85,7 +85,7 @@ module Kana::Converter
     private
 
     def mpad(str)
-      str.gsub(/[^ -~]+/) { |m| " " * m.bytes.length }
+      str.gsub(/[^ -~]+/) { |m| " " * m.bytesize }
     end
 
     def katakana_to_yomi(str, format)

--- a/lib/kana/converter.rb
+++ b/lib/kana/converter.rb
@@ -85,7 +85,7 @@ module Kana::Converter
     private
 
     def mpad(str)
-      str.gsub(/[^ -~]/, "   ")
+      str.gsub(/[^ -~]+/) { |m| " " * m.bytes.length }
     end
 
     def katakana_to_yomi(str, format)

--- a/lib/kana/converter.rb
+++ b/lib/kana/converter.rb
@@ -41,7 +41,7 @@ module Kana::Converter
       text.gsub!(/<!--[^>]*?\s#{skip_marks[0]}\s[^>]*?-->(.*?)<!--[^>]*?\s#{skip_marks[1]}\s[^>]*?-->/im) do |m|
         "\r" * m.bytes.length
       end
-      text.gsub!(/[ -\/:-@\[-`{-~]/m, "\r")
+      text.gsub!(/[ -\/:-@\[-`{-~]/m) { |m| "\r" * m.bytes.length }
 
       byte = html.bytes
       kana = ""

--- a/spec/fixtures/kana/test_emoji.html
+++ b/spec/fixtures/kana/test_emoji.html
@@ -1,0 +1,4 @@
+<body>
+  <img src="/fs/4/8/2/7/1/_/corn.jpg" alt="🌽とうもろこし">
+  <h2>件数</h2>
+</body>

--- a/spec/lib/kana/converter/emoji_spec.rb
+++ b/spec/lib/kana/converter/emoji_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Kana::Converter, dbscope: :example, mecab: true do
+  let!(:site) { create :cms_site }
+
+  context "絵文字（UTF-8で4バイト以上）で位置がずれてしまい Kana::ConvertError が発生" do
+    let!(:html) do
+      fixture_file = "#{Rails.root}/spec/fixtures/kana/test_emoji.html"
+      File.read(fixture_file)
+    end
+
+    it do
+      result = described_class.kana_html(site, html)
+      expect(result).to be_present
+
+      fragment = Nokogiri::HTML.fragment(result)
+      expect(fragment.css("h2 ruby")[0].content).to include("けんすう")
+    end
+  end
+end

--- a/spec/lib/kana/converter/mpad_spec.rb
+++ b/spec/lib/kana/converter/mpad_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Kana::Converter, dbscope: :example, mecab: true do
+  describe ".mpad" do
+    it do
+      expect(described_class.send(:mpad, "<body>")).to eq "<body>"
+      expect(described_class.send(:mpad, "あ")).to eq " " * 3
+      # emoji "corn"
+      expect(described_class.send(:mpad, "\xf0\x9f\x8c\xbd")).to eq " " * 4
+      # 点のある塚（宝塚や平塚の「塚」の本当の文字）: JIS X 0213 に定義がある
+      expect(described_class.send(:mpad, "\xe5\xa1\x9a\xf3\xa0\x84\x85")).to eq " " * 7
+    end
+  end
+end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 絵文字や一部の特殊文字を含むHTML変換で、文字位置のずれによるエラーが起きにくくなりました。
  * 置換の長さ判定を文字数ではなくバイト長に統一し、変換結果のズレを軽減しました。
* **Tests**
  * 絵文字を含むHTML変換の位置ずれ耐性を確認するテストを追加しました。
  * `mpad` の置換動作（特殊文字列→所定の空白）を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->