### PR TITLE
[modify][ss] ナビメニュー(.nav-menu)の矢印アイコンをフォントグリフに変更（コントラスト対応）

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1683,7 +1683,9 @@ _:future,
     }
     a {
       display: inline-block;
-      @include init.arrow;
+      // Material Icons Outlined: expand_circle_down を回転して右向き矢印として表示（コントラスト機能対応）
+      @include mi-icon($left: 0);
+      padding-left: 22px;
       color: init.$black;
       &:hover {
         color: init.$orange;


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

ページ内ナビメニュー（`#menu .nav-menu` / `.sns-nav-menu`）の「ポータルへ戻る / 印刷する / 一覧へ戻る / 新規作成」等のリンク先頭にある矢印アイコンを、背景画像（PNG: `ic-arrow16-off.png` / `-on.png`）から **Material Icons のフォントグリフ**に変更しました。

サイドメニュー（#6098）と同じ `mi-icon` mixin（Material Icons Outlined の `expand_circle_down` / `\e7cd` を `-90deg` 回転して右向き表示）を利用します。`::before` のグリフは固有色を持たず要素の `color` を継承するため、**グループウェアのコントラスト機能（`body * { color: ... !important }`）で色が追従**し、ホバー時のオレンジ化も従来どおり再現されます。

**新たなフォントの追加・npm 依存の追加は不要**です（#6098 で利用している既存のグリフのみ）。

## 変更内容

差分は `app/assets/stylesheets/ss/_pc_mb.scss` の1ファイルのみです。`#menu .nav-menu, .sns-nav-menu a` の `@include init.arrow;`（PNG背景）を `@include mi-icon($left: 0);` + `padding-left: 22px;` に置き換えました。

```scss
a {
  display: inline-block;
  // Material Icons Outlined: expand_circle_down を回転して右向き矢印として表示（コントラスト機能対応）
  @include mi-icon($left: 0);
  padding-left: 22px;
  color: init.$black;
  &:hover {
    color: init.$orange;
  }
  ...
}
```

## 影響範囲

`ss/style` は `SS::BaseFilter` で全管理画面に読み込まれるため、GWS だけでなく **CMS / webmail / opendata / sns** のページ内ナビメニュー矢印も同じフォントグリフになります。`init.arrow` mixin の利用箇所はこの1箇所のみのため、他へ波及する変更はありません（mixin 定義自体は変更していません）。

## 関連

- 前提 PR: #6098（サイドメニューのアイコンフォント化 / `mi-icon` mixin 導入）
- Backlog: J090-635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * メニュー内のリンクに表示される矢印アイコンを、より見やすいアイコンデザインに変更しました。
  * 併せて、アイコンとテキストの余白を調整し、表示バランスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->