### PR TITLE
[modify] cms/form_search : support array query of Cms::FormSearchParam

### DIFF
--- a/app/models/cms/column/base.rb
+++ b/app/models/cms/column/base.rb
@@ -37,6 +37,8 @@ class Cms::Column::Base
       { value: /\A#{::Regexp.escape(value)}/ }
     when 'end_with'
       { value: /#{::Regexp.escape(value)}\z/ }
+    when 'in'
+      { value: { "$in" => value } }
     else
       { value: value }
     end

--- a/app/models/cms/column/check_box.rb
+++ b/app/models/cms/column/check_box.rb
@@ -15,6 +15,8 @@ class Cms::Column::CheckBox < Cms::Column::Base
       { values: /\A#{::Regexp.escape(value)}/ }
     when 'end_with'
       { values: /#{::Regexp.escape(value)}\z/ }
+    when 'in'
+      { values: { "$in" => value } }
     else
       { values: value }
     end

--- a/app/models/cms/column/list.rb
+++ b/app/models/cms/column/list.rb
@@ -42,6 +42,8 @@ class Cms::Column::List < Cms::Column::Base
       { lists: /\A#{::Regexp.escape(value)}/ }
     when 'end_with'
       { lists: /#{::Regexp.escape(value)}\z/ }
+    when 'in'
+      { lists: { "$in" => value } }
     else
       { lists: value }
     end

--- a/app/models/cms/form_search_param.rb
+++ b/app/models/cms/form_search_param.rb
@@ -48,6 +48,9 @@ class Cms::FormSearchParam
     when Hash
       operator = value[:op].presence
       value = value[:val].presence
+    when Array
+      operator = 'in'
+      value = value.select(&:present?)
     end
     operator ||= 'all'
 

--- a/spec/features/cms/agents/nodes/form_search_spec.rb
+++ b/spec/features/cms/agents/nodes/form_search_spec.rb
@@ -63,5 +63,14 @@ describe 'cms_agents_nodes_form_search', type: :feature, dbscope: :example, js: 
     visit form_search_node.full_url + "?" + query.to_query
     expect(page).to have_css(".pages .item-#{::File.basename(item1.basename, ".*")}", text: item1.name)
     expect(page).to have_no_css(".pages .item-#{::File.basename(item2.basename, ".*")}", text: item2.name)
+
+    # $in condition case
+    visit form_search_node.full_url + "?" + { s: { col: { column1.name => [select_options1[0]] } } }.to_query
+    expect(page).to have_css(".pages .item-#{::File.basename(item1.basename, ".*")}", text: item1.name)
+    expect(page).to have_no_css(".pages .item-#{::File.basename(item2.basename, ".*")}", text: item2.name)
+
+    visit form_search_node.full_url + "?" + { s: { col: { column1.name => [select_options1[0], select_options1[1]] } } }.to_query
+    expect(page).to have_css(".pages .item-#{::File.basename(item1.basename, ".*")}", text: item1.name)
+    expect(page).to have_css(".pages .item-#{::File.basename(item2.basename, ".*")}", text: item2.name)
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 配列で指定した検索条件に対応し、複数値に一致する項目をまとめて絞り込めるようになりました。
* **Bug Fixes**
  * 一部の列条件で、単一値の一致だけでなく「含まれる値」による検索が正しく動作するようになりました。
  * 空の値を除外して検索条件を作成するようになり、不要な条件が混ざりにくくなりました。
* **Tests**
  * 配列条件を使った検索結果の表示・非表示を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->