### PR TITLE
[modify] SS.notice : extend delay time and add timeout_delay setting

### DIFF
--- a/app/assets/javascripts/ss/lib/base.js.erb
+++ b/app/assets/javascripts/ss/lib/base.js.erb
@@ -12,6 +12,8 @@ this.SS = (function () {
 
   SS.noticeTimeoutId = null;
 
+  SS.noticeTimeoutDelay = <%= SS.config.ss.notice["timeout_delay"].to_json %>;
+
   SS.page = "";
 
   SS.pageName = null;
@@ -403,7 +405,7 @@ this.SS = (function () {
     }
     SS.noticeTimeoutId = setTimeout((function () {
       return $('#notice').slideUp('normal');
-    }), 1800);
+    }), SS.noticeTimeoutDelay);
 
     return SS.noticeTimeoutId;
   };

--- a/config/defaults/ss.yml
+++ b/config/defaults/ss.yml
@@ -84,6 +84,9 @@ production: &production
 
   dc_guard_timeout_millis: 5000
 
+  notice:
+    timeout_delay: 3600
+
 test:
   <<: *production
   disable: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 通知メッセージの表示後、自動でスライドアップするまでの待機時間を設定できるようになりました。
  * 本番環境では、通知の待機時間にデフォルト値が設定されています。

* **改善**
  * 通知の表示タイミングが固定ではなく、環境設定に応じて調整されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->