### PR TITLE
[modify][cms] set canonical url in public page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,8 +13,8 @@ class ApplicationController < ActionController::Base
     before_action :set_received_by
   end
 
-  def new_agent(controller_name)
-    agent = SS::Agent.new controller_name
+  def new_agent(controller_name, request_path)
+    agent = SS::Agent.new(controller_name, request_path)
     agent.controller.params  = params
     agent.controller.request = request
     agent.controller.instance_variable_set :@controller, self

--- a/app/controllers/board/agents/nodes/post_controller.rb
+++ b/app/controllers/board/agents/nodes/post_controller.rb
@@ -39,7 +39,8 @@ class Board::Agents::Nodes::PostController < ApplicationController
 
   def generate
     return unless @item.errors.empty?
-    SS::Agent.invoke_action "board/agents/tasks/node/posts", :generate, cur_node: @cur_node, node: @cur_node
+    SS::Agent.invoke_action(
+      "board/agents/tasks/node/posts", :generate, @cur_node.url, cur_node: @cur_node, node: @cur_node)
   end
 
   public

--- a/app/controllers/board/posts_controller.rb
+++ b/app/controllers/board/posts_controller.rb
@@ -30,7 +30,8 @@ class Board::PostsController < ApplicationController
   def generate
     return unless @item.errors.empty?
 
-    SS::Agent.invoke_action "board/agents/tasks/node/posts", :generate, cur_node: @cur_node, node: @cur_node
+    SS::Agent.invoke_action(
+      "board/agents/tasks/node/posts", :generate, @cur_node.url, cur_node: @cur_node, node: @cur_node)
   end
 
   public

--- a/app/controllers/cms/agents/tasks/nodes_controller.rb
+++ b/app/controllers/cms/agents/tasks/nodes_controller.rb
@@ -110,14 +110,15 @@ class Cms::Agents::Tasks::NodesController < ApplicationController
             # ex: "article/page" => "article/agents/nodes/page"
             cont = node.route.sub("/", "/agents/nodes/")
             next if SS::Agent.invoke_action(
-              cont, :generate,
+              cont, :generate, node.url,
               task: @task, cur_site: @site, cur_node: node,
               cur_path: "#{node.url}index.html", cur_main_path: "#{node.url.sub(@site.url, "/")}index.html"
             )
 
             # ex: "article/page" => "article/agents/tasks/node/pages"
             cont = node.route.sub("/", "/agents/tasks/node/").pluralize
-            SS::Agent.invoke_action(cont, :generate, task: @task, site: @site, node: node)
+            SS::Agent.invoke_action(
+              cont, :generate, node.url, task: @task, site: @site, node: node)
           end
         end
       end

--- a/app/controllers/concerns/cms/node_filter/list_view.rb
+++ b/app/controllers/concerns/cms/node_filter/list_view.rb
@@ -84,6 +84,10 @@ module Cms::NodeFilter::ListView
     @all_pages ||= SS::SortEmulator.new(pages, @cur_node.sort_hash)
   end
 
+  def replace_canonical(html, full_url)
+    html.sub(/<link rel="canonical" href=".+?">/) { view_context.tag.link(rel: "canonical", href: full_url) }
+  end
+
   public
 
   def index
@@ -143,6 +147,7 @@ module Cms::NodeFilter::ListView
         basename = "index.html"
       else
         basename = "index.p#{page_index + 1}.html"
+        html = replace_canonical(html, "#{@cur_node.full_url}#{basename}")
       end
 
       if Fs.write_data_if_modified("#{@cur_node.path}/#{basename}", html)

--- a/app/controllers/concerns/cms/public_filter/layout.rb
+++ b/app/controllers/concerns/cms/public_filter/layout.rb
@@ -54,7 +54,7 @@ module Cms::PublicFilter::Layout
         @cur_part = part
         controller = part.route.sub(/\/.*/, "/agents/#{spec[:cell]}")
 
-        agent = new_agent controller
+        agent = new_agent(controller, @cur_item.url)
         agent.controller.params.merge! spec
         agent.controller.request = ActionDispatch::Request.new(request.env.merge("REQUEST_METHOD" => "GET"))
         resp = agent.render spec[:action]

--- a/app/controllers/concerns/cms/public_filter/layout.rb
+++ b/app/controllers/concerns/cms/public_filter/layout.rb
@@ -54,7 +54,7 @@ module Cms::PublicFilter::Layout
         @cur_part = part
         controller = part.route.sub(/\/.*/, "/agents/#{spec[:cell]}")
 
-        agent = new_agent(controller, @cur_item.url)
+        agent = new_agent(controller, request.path)
         agent.controller.params.merge! spec
         agent.controller.request = ActionDispatch::Request.new(request.env.merge("REQUEST_METHOD" => "GET"))
         resp = agent.render spec[:action]

--- a/app/controllers/concerns/cms/public_filter/node.rb
+++ b/app/controllers/concerns/cms/public_filter/node.rb
@@ -22,7 +22,7 @@ module Cms::PublicFilter::Node
     @cur_node = node
     controller = node.route.sub(/\/.*/, "/agents/#{spec[:cell]}")
 
-    agent = new_agent controller
+    agent = new_agent(controller, node.url)
     agent.controller.request.path_parameters.merge! spec
     agent.controller.params.merge! spec
     agent.render spec[:action]

--- a/app/controllers/concerns/cms/public_filter/node.rb
+++ b/app/controllers/concerns/cms/public_filter/node.rb
@@ -52,6 +52,10 @@ module Cms::PublicFilter::Node
     @layout_cache.delete(cache_key) if @layout_cache
   end
 
+  def replace_canonical(html, full_url)
+    html.sub(/<link rel="canonical" href=".+?">/) { view_context.tag.link(rel: "canonical", href: full_url) }
+  end
+
   public
 
   def recognize_node(node, path)
@@ -97,6 +101,11 @@ module Cms::PublicFilter::Node
       html = render_to_string html: "", layout: "cms/redirect"
     elsif response.media_type == "text/html" && node.layout
       html = render_layout_with_pagination_cache(node.layout, opts[:cache])
+      page_index = opts.dig(:params, :page)
+      if page_index.numeric? && page_index > 1 # page_index は 1 から始まる
+        basename = opts[:file] ? File.basename(opts[:file]) : ""
+        html = replace_canonical(html, "#{node.full_url}#{basename}")
+      end
     else
       html = response.body
     end

--- a/app/controllers/concerns/cms/public_filter/page.rb
+++ b/app/controllers/concerns/cms/public_filter/page.rb
@@ -11,7 +11,7 @@ module Cms::PublicFilter::Page
     @cur_page = page
     controller = page.route.sub(/\/.*/, "/agents/#{spec[:cell]}")
 
-    agent = new_agent controller
+    agent = new_agent(controller, page.url)
     agent.controller.params.merge! spec
     agent.render spec[:action]
   end
@@ -36,7 +36,7 @@ module Cms::PublicFilter::Page
     @csrf_token    = false
     @generate_page = true
 
-    agent = SS::Agent.new self.class
+    agent = SS::Agent.new(self.class, @cur_path)
     self.params   = agent.controller.params
     self.request  = agent.controller.request
     self.response = agent.controller.response

--- a/app/controllers/event/agents/nodes/page_controller.rb
+++ b/app/controllers/event/agents/nodes/page_controller.rb
@@ -25,6 +25,12 @@ class Event::Agents::Nodes::PageController < ApplicationController
     raise SS::NotFoundError if @date.nil?
     raise SS::NotFoundError if !within_one_year?(@date) && !within_one_year?(@date.advance(months: 1, days: -1))
 
+    # set canonical url
+    # サブサイト対応のため #full_url を用いて join した後 request_uri でパスのみ取り出す
+    full_url = Addressable::URI.join(
+      @cur_node.full_url, format("%04d%02d", @date.year, @date.month) + "/", "#{@cur_display}.#{params[:format] || "html"}")
+    request.path_info = full_url.request_uri
+
     index_monthly
   end
 
@@ -35,6 +41,15 @@ class Event::Agents::Nodes::PageController < ApplicationController
     @date  = Date.new(@year, @month, @day) rescue nil
     raise SS::NotFoundError if @date.nil?
     raise SS::NotFoundError if !within_one_year?(@date)
+
+    # set canonical url
+    # サブサイト対応のため #full_url を用いて join した後 request_uri でパスのみ取り出す
+    full_url = Addressable::URI.join(
+      @cur_node.full_url, format("%04d%02d%02d", @date.year, @date.month, @date.day) + "/")
+    if params[:format].present? && params[:format] != "html"
+      full_url = full_url.join("index.#{params[:format]}")
+    end
+    request.path_info = full_url.request_uri
 
     index_daily
   end

--- a/app/controllers/event/agents/nodes/page_controller.rb
+++ b/app/controllers/event/agents/nodes/page_controller.rb
@@ -15,6 +15,12 @@ class Event::Agents::Nodes::PageController < ApplicationController
     @month = @date.month
     raise SS::NotFoundError if !within_one_year?(@date) && !within_one_year?(@date.advance(months: 1, days: -1))
 
+    # set canonical url
+    # サブサイト対応のため #full_url を用いて join した後 request_uri でパスのみ取り出す
+    full_url = Addressable::URI.join(
+      @cur_node.full_url, format("%04d%02d", @date.year, @date.month) + "/", "#{@cur_display}.#{params[:format] || "html"}")
+    request.path_info = full_url.request_uri
+
     index_monthly
   end
 

--- a/app/controllers/event/agents/nodes/page_controller.rb
+++ b/app/controllers/event/agents/nodes/page_controller.rb
@@ -19,7 +19,7 @@ class Event::Agents::Nodes::PageController < ApplicationController
     # サブサイト対応のため #full_url を用いて join した後 request_uri でパスのみ取り出す
     full_url = Addressable::URI.join(
       @cur_node.full_url, format("%04d%02d", @date.year, @date.month) + "/", "#{@cur_display}.#{params[:format] || "html"}")
-    request.path_info = full_url.request_uri
+    request.env["ss.canonical_path"] = full_url.request_uri
 
     index_monthly
   end
@@ -35,7 +35,7 @@ class Event::Agents::Nodes::PageController < ApplicationController
     # サブサイト対応のため #full_url を用いて join した後 request_uri でパスのみ取り出す
     full_url = Addressable::URI.join(
       @cur_node.full_url, format("%04d%02d", @date.year, @date.month) + "/", "#{@cur_display}.#{params[:format] || "html"}")
-    request.path_info = full_url.request_uri
+    request.env["ss.canonical_path"] = full_url.request_uri
 
     index_monthly
   end
@@ -55,7 +55,7 @@ class Event::Agents::Nodes::PageController < ApplicationController
     if params[:format].present? && params[:format] != "html"
       full_url = full_url.join("index.#{params[:format]}")
     end
-    request.path_info = full_url.request_uri
+    request.env["ss.canonical_path"] = full_url.request_uri
 
     index_daily
   end

--- a/app/controllers/member/agents/nodes/login_controller.rb
+++ b/app/controllers/member/agents/nodes/login_controller.rb
@@ -106,6 +106,7 @@ class Member::Agents::Nodes::LoginController < ApplicationController
     unless request.post?
       @error = flash[:alert]
       flash[:ref] = params[:ref]
+      request.env["ss.canonical_path"] = @cur_node.url
       return
     end
 
@@ -113,6 +114,7 @@ class Member::Agents::Nodes::LoginController < ApplicationController
     member = Cms::Member.site(@cur_site).and_enabled.where(email: @item.email, password: SS::Crypto.crypt(@item.password)).first
     unless member
       @error = t "sns.errors.invalid_login"
+      request.env["ss.canonical_path"] = @cur_node.url
       return
     end
 

--- a/app/models/cms.rb
+++ b/app/models/cms.rb
@@ -447,4 +447,18 @@ module Cms
       contains_urls.include?(file.url_with_name) ||
       contains_urls.include?(file.url_with_filename)
   end
+
+  def self.canonical_full_url(site, request_path)
+    if request_path.end_with?("/index.html")
+      request_path = request_path[0..-11]
+    end
+
+    # 以下のコードで末尾の "/" が削除される。
+    # https://github.com/rails/rails/blob/v8.0.5/actionpack/lib/action_dispatch/routing/route_set.rb#L907
+    # ここでは末尾の "/" を復活させる。
+    if !request_path.end_with?("/") && ::File.extname(request_path).blank?
+      request_path += "/"
+    end
+    Addressable::URI.join(site.full_root_url, request_path).to_s
+  end
 end

--- a/app/models/cms.rb
+++ b/app/models/cms.rb
@@ -452,6 +452,12 @@ module Cms
     request_path = request.env["ss.canonical_path"] || SS.request_path(request)
     return if request_path.blank? || request_path == :none
 
+    request_basename = ::File.basename(request_path, ".*")
+    if request_basename.numeric? && Rack::Utils::HTTP_STATUS_CODES[request_basename.to_i]
+      # 404 ページに canonical を出力しないようにする
+      return
+    end
+
     if request_path.end_with?("/index.html")
       request_path = request_path[0..-11]
     end

--- a/app/models/cms.rb
+++ b/app/models/cms.rb
@@ -461,4 +461,17 @@ module Cms
     end
     Addressable::URI.join(site.full_root_url, request_path).to_s
   end
+
+  def self.canonical_link_tag(site, request)
+    canonical_path = request.env["ss.canonical_path"] || SS.request_path(request)
+    return if canonical_path.blank? || canonical_path == :none
+
+    canonical_full_url = Cms.canonical_full_url(site, canonical_path)
+    return if canonical_full_url.blank?
+
+    ApplicationController.helpers.tag.link(rel: "canonical", href: canonical_full_url)
+  rescue => e
+    Rails.logger.warn { "#{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}" }
+    nil
+  end
 end

--- a/app/models/cms.rb
+++ b/app/models/cms.rb
@@ -452,10 +452,13 @@ module Cms
     request_path = request.env["ss.canonical_path"] || SS.request_path(request)
     return if request_path.blank? || request_path == :none
 
-    request_basename = ::File.basename(request_path, ".*")
-    if request_basename.numeric? && Rack::Utils::HTTP_STATUS_CODES[request_basename.to_i]
-      # 404 ページに canonical を出力しないようにする
-      return
+    request_dirname = ::File.dirname(request_path)
+    if request_dirname == "/"
+      request_basename = ::File.basename(request_path, ".*")
+      if request_basename.numeric? && Rack::Utils::HTTP_STATUS_CODES[request_basename.to_i]
+        # 404 ページに canonical を出力しないようにする
+        return
+      end
     end
 
     if request_path.end_with?("/index.html")

--- a/app/models/cms.rb
+++ b/app/models/cms.rb
@@ -448,7 +448,10 @@ module Cms
       contains_urls.include?(file.url_with_filename)
   end
 
-  def self.canonical_full_url(site, request_path)
+  def self.canonical_full_url(site, request)
+    request_path = request.env["ss.canonical_path"] || SS.request_path(request)
+    return if request_path.blank? || request_path == :none
+
     if request_path.end_with?("/index.html")
       request_path = request_path[0..-11]
     end
@@ -460,18 +463,5 @@ module Cms
       request_path += "/"
     end
     Addressable::URI.join(site.full_root_url, request_path).to_s
-  end
-
-  def self.canonical_link_tag(site, request)
-    canonical_path = request.env["ss.canonical_path"] || SS.request_path(request)
-    return if canonical_path.blank? || canonical_path == :none
-
-    canonical_full_url = Cms.canonical_full_url(site, canonical_path)
-    return if canonical_full_url.blank?
-
-    ApplicationController.helpers.tag.link(rel: "canonical", href: canonical_full_url)
-  rescue => e
-    Rails.logger.warn { "#{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}" }
-    nil
   end
 end

--- a/app/models/concerns/ss/model/task.rb
+++ b/app/models/concerns/ss/model/task.rb
@@ -331,7 +331,7 @@ module SS::Model::Task
     if !controller.is_a?(String)
       controller = controller.name.underscore.sub('_controller', '')
     end
-    SS::Agent.invoke_action(controller, action, nil, **params.merge(task: self))
+    SS::Agent.invoke_action(controller, action, nil, task: self, **params)
   end
 
   def performance

--- a/app/models/concerns/ss/model/task.rb
+++ b/app/models/concerns/ss/model/task.rb
@@ -331,7 +331,7 @@ module SS::Model::Task
     if !controller.is_a?(String)
       controller = controller.name.underscore.sub('_controller', '')
     end
-    SS::Agent.invoke_action(controller, action, params.merge(task: self))
+    SS::Agent.invoke_action(controller, action, nil, **params.merge(task: self))
   end
 
   def performance

--- a/app/views/ads/agents/pages/banner/index.html.erb
+++ b/app/views/ads/agents/pages/banner/index.html.erb
@@ -6,7 +6,7 @@
 <meta http-equiv="refresh" content="0; URL=<%= @cur_page.link_url %>">
 <% end %>
 <title><%= @cur_page.name %></title>
-<%= Cms.canonical_link_tag(@cur_site, request) %>
+<%= Cms.canonical_full_url(@cur_site, request).try { tag.link(rel: "canonical", href: _1) } %>
 </head>
 <body>
   <%= @cur_page.name %><br />

--- a/app/views/ads/agents/pages/banner/index.html.erb
+++ b/app/views/ads/agents/pages/banner/index.html.erb
@@ -6,6 +6,7 @@
 <meta http-equiv="refresh" content="0; URL=<%= @cur_page.link_url %>">
 <% end %>
 <title><%= @cur_page.name %></title>
+<%= Cms.canonical_link_tag(@cur_site, request) %>
 </head>
 <body>
   <%= @cur_page.name %><br />

--- a/app/views/layouts/cms/page.html.erb
+++ b/app/views/layouts/cms/page.html.erb
@@ -4,6 +4,10 @@
 <head>
 <meta charset="UTF-8" />
 <title><%= @window_name %></title>
+<% canonical_full_url = Cms.canonical_full_url(@cur_site, SS.request_path(request)) rescue nil %>
+<% if canonical_full_url %>
+  <link rel="canonical" href="<%= canonical_full_url %>" />
+<% end %>
 <%= stylesheet_link_tag "cms/public", media: "all" %>
 <%= stylesheet_link_tag "jplayer", media: "all" %>
 <%= javascript_include_tag "cms/compat" %>

--- a/app/views/layouts/cms/page.html.erb
+++ b/app/views/layouts/cms/page.html.erb
@@ -4,8 +4,13 @@
 <head>
 <meta charset="UTF-8" />
 <title><%= @window_name %></title>
-<% canonical_full_url = Cms.canonical_full_url(@cur_site, SS.request_path(request)) rescue nil %>
-<% if canonical_full_url %>
+<%
+  canonical_full_url = request.env["ss.canonical_path"] || SS.request_path(request)
+  if canonical_full_url && canonical_full_url != :none
+    canonical_full_url = Cms.canonical_full_url(@cur_site, canonical_full_url) rescue nil
+  end
+%>
+<% if canonical_full_url && canonical_full_url != :none %>
   <link rel="canonical" href="<%= canonical_full_url %>" />
 <% end %>
 <%= stylesheet_link_tag "cms/public", media: "all" %>

--- a/app/views/layouts/cms/page.html.erb
+++ b/app/views/layouts/cms/page.html.erb
@@ -4,7 +4,7 @@
 <head>
 <meta charset="UTF-8" />
 <title><%= @window_name %></title>
-<%= Cms.canonical_link_tag(@cur_site, request) %>
+<%= Cms.canonical_full_url(@cur_site, request).try { tag.link(rel: "canonical", href: _1) } %>
 <%= stylesheet_link_tag "cms/public", media: "all" %>
 <%= stylesheet_link_tag "jplayer", media: "all" %>
 <%= javascript_include_tag "cms/compat" %>

--- a/app/views/layouts/cms/page.html.erb
+++ b/app/views/layouts/cms/page.html.erb
@@ -4,15 +4,7 @@
 <head>
 <meta charset="UTF-8" />
 <title><%= @window_name %></title>
-<%
-  canonical_full_url = request.env["ss.canonical_path"] || SS.request_path(request)
-  if canonical_full_url && canonical_full_url != :none
-    canonical_full_url = Cms.canonical_full_url(@cur_site, canonical_full_url) rescue nil
-  end
-%>
-<% if canonical_full_url && canonical_full_url != :none %>
-  <link rel="canonical" href="<%= canonical_full_url %>" />
-<% end %>
+<%= Cms.canonical_link_tag(@cur_site, request) %>
 <%= stylesheet_link_tag "cms/public", media: "all" %>
 <%= stylesheet_link_tag "jplayer", media: "all" %>
 <%= javascript_include_tag "cms/compat" %>

--- a/app/views/layouts/cms/redirect.html.erb
+++ b/app/views/layouts/cms/redirect.html.erb
@@ -17,7 +17,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="refresh" content="0; URL=<%= @redirect_link %>">
   <title><%= @window_name %></title>
-  <%= Cms.canonical_link_tag(@cur_site, request) %>
+  <%= Cms.canonical_full_url(@cur_site, request).try { tag.link(rel: "canonical", href: _1) } %>
 </head>
 <body></body>
 

--- a/app/views/layouts/cms/redirect.html.erb
+++ b/app/views/layouts/cms/redirect.html.erb
@@ -17,6 +17,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="refresh" content="0; URL=<%= @redirect_link %>">
   <title><%= @window_name %></title>
+  <%= Cms.canonical_link_tag(@cur_site, request) %>
 </head>
 <body></body>
 

--- a/lib/cms/part_agent.rb
+++ b/lib/cms/part_agent.rb
@@ -23,7 +23,7 @@ class Cms::PartAgent < SS::Agent
     @part = part
     @options = options
 
-    super(controller)
+    super(controller, options[:cur_path])
 
     self.controller.params
     self.controller.request = ActionDispatch::Request.new(new_env)

--- a/lib/ss/agent.rb
+++ b/lib/ss/agent.rb
@@ -1,7 +1,7 @@
 class SS::Agent
   attr_accessor :controller
 
-  def initialize(controller_or_name)
+  def initialize(controller_or_name, request_path)
     if controller_or_name.is_a?(String)
       controller = "#{controller_or_name}_controller".camelize.constantize
       controller_name = controller_or_name
@@ -12,7 +12,13 @@ class SS::Agent
     @controller_name = controller_name
     @controller = controller.new
     @controller.params   = ActionController::Parameters.new
-    @controller.request  = ActionDispatch::Request.new("rack.input" => "", "REQUEST_METHOD" => "GET")
+    @controller.request  = ActionDispatch::Request.new(
+      "rack.input" => "",
+      "REQUEST_METHOD" => "GET",
+      "PATH_INFO" => request_path,
+      # "REQUEST_PATH" => request_path,
+      # "REQUEST_URI" => request_path,
+    )
     @controller.response = ActionDispatch::Response.new.tap do |res|
       res.request = @controller.request
     end
@@ -22,8 +28,8 @@ class SS::Agent
   end
 
   class << self
-    def invoke_action(controller_name, action, variables)
-      agent = SS::Agent.new(controller_name) rescue nil
+    def invoke_action(controller_name, action, request_path, **variables)
+      agent = SS::Agent.new(controller_name, request_path) rescue nil
       return if agent.blank?
       return unless agent.controller.respond_to?(action)
 

--- a/lib/ss/agent.rb
+++ b/lib/ss/agent.rb
@@ -15,9 +15,7 @@ class SS::Agent
     @controller.request  = ActionDispatch::Request.new(
       "rack.input" => "",
       "REQUEST_METHOD" => "GET",
-      "PATH_INFO" => request_path,
-      # "REQUEST_PATH" => request_path,
-      # "REQUEST_URI" => request_path,
+      "PATH_INFO" => request_path
     )
     @controller.response = ActionDispatch::Response.new.tap do |res|
       res.request = @controller.request

--- a/spec/features/article/agents/nodes/page_spec.rb
+++ b/spec/features/article/agents/nodes/page_spec.rb
@@ -25,6 +25,7 @@ describe "article_agents_nodes_page", type: :feature, dbscope: :example do
       visit node.url
       expect(page).to have_css(".article-pages")
       expect(page).to have_selector(".article-pages article")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
     end
 
     it "#index with kana", mecab: true do
@@ -32,13 +33,15 @@ describe "article_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css(".article-pages")
       expect(page).to have_selector(".article-pages article")
       expect(page).to have_selector("a[href='/node/item.html']")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"http://#{site.domain}#{SS.config.kana.location}#{node.url}\"]")
     end
 
     it "#index with mobile" do
       visit node.url.sub('/', site.mobile_location + '/')
       expect(page).to have_css(".article-pages")
       expect(page).to have_selector(".article-pages .tag-article")
-      expect(page).to have_selector("a[href='/mobile/node/item.html']")
+      expect(page).to have_selector("a[href='#{site.mobile_location}/node/item.html']")
+      expect(page).to have_no_css("[rel=\"canonical\"]")
     end
 
     it "#rss" do

--- a/spec/features/article/agents/nodes/paginate_spec.rb
+++ b/spec/features/article/agents/nodes/paginate_spec.rb
@@ -30,6 +30,7 @@ describe "article_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_no_link item3.name
       expect(page).to have_no_link item4.name
       expect(page).to have_no_link item5.name
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
       within ".pagination" do
         expect(page).to have_css(".page.current", text: "1")
         click_on I18n.t("views.pagination.next")
@@ -40,6 +41,7 @@ describe "article_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_link item3.name
       expect(page).to have_link item4.name
       expect(page).to have_no_link item5.name
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}index.p2.html\"]")
       within ".pagination" do
         expect(page).to have_css(".page.current", text: "2")
         click_on I18n.t("views.pagination.next")
@@ -50,6 +52,7 @@ describe "article_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_no_link item3.name
       expect(page).to have_no_link item4.name
       expect(page).to have_link item5.name
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}index.p3.html\"]")
       within ".pagination" do
         expect(page).to have_css(".page.current", text: "3")
         expect(page).to have_no_link I18n.t("views.pagination.next")

--- a/spec/features/article/agents/pages/canonical_spec.rb
+++ b/spec/features/article/agents/pages/canonical_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'article_agents_pages_page', type: :feature, dbscope: :example, js: true do
+  let(:site) { cms_site }
+  let(:layout) { create_cms_layout }
+  let!(:node) { create(:article_node_page, cur_site: site, layout: layout) }
+  let!(:item) { create(:article_page, cur_site: site, cur_node: node, layout: layout) }
+
+  before do
+    FileUtils.rm_rf(node.path)
+  end
+
+  it do
+    visit item.full_url
+    expect(page).to have_css("[rel=\"canonical\"][href=\"#{item.full_url}\"]")
+  end
+end

--- a/spec/features/cms/agents/nodes/node_spec.rb
+++ b/spec/features/cms/agents/nodes/node_spec.rb
@@ -26,6 +26,7 @@ describe "cms_agents_nodes_node", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_css(".nodes")
       expect(page).to have_selector("article")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
     end
 
     it "#kana", mecab: true do
@@ -34,6 +35,7 @@ describe "cms_agents_nodes_node", type: :feature, dbscope: :example do
       expect(page).to have_css(".nodes")
       expect(page).to have_selector("article")
       expect(page).to have_selector("a[href='/node/item/']")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"http://#{site.domain}#{SS.config.kana.location}#{node.url}\"]")
     end
 
     it "#mobile" do
@@ -42,6 +44,7 @@ describe "cms_agents_nodes_node", type: :feature, dbscope: :example do
       expect(page).to have_css(".nodes")
       expect(page).to have_selector(".tag-article")
       expect(page).to have_selector("a[href='/mobile/node/item/']")
+      expect(page).to have_no_css("[rel=\"canonical\"]")
     end
   end
 

--- a/spec/features/cms/agents/nodes/page_spec.rb
+++ b/spec/features/cms/agents/nodes/page_spec.rb
@@ -26,6 +26,7 @@ describe "cms_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_css(".pages")
       expect(page).to have_selector("article")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
     end
 
     it "#index with kana", mecab: true do
@@ -34,6 +35,7 @@ describe "cms_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css(".pages")
       expect(page).to have_selector("article")
       expect(page).to have_selector("a[href='/node/item.html']")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"http://#{site.domain}#{SS.config.kana.location}#{node.url}\"]")
     end
 
     it "#index with mobile" do
@@ -42,6 +44,7 @@ describe "cms_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css(".pages")
       expect(page).to have_selector(".tag-article")
       expect(page).to have_selector("a[href='/mobile/node/item.html']")
+      expect(page).to have_no_css("[rel=\"canonical\"]")
     end
 
     it "#rss" do

--- a/spec/features/cms/agents/pages/canonical_spec.rb
+++ b/spec/features/cms/agents/pages/canonical_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe "cms_agents_nodes_page", type: :feature, dbscope: :example, js: true do
+  let!(:site) { cms_site }
+  let!(:layout) { create_cms_layout }
+
+  context "root index page" do
+    let!(:item) do
+      html = <<~HTML
+        <p class="hello">#{unique_id}</p>
+      HTML
+      item = create :cms_page, cur_site: site, layout: layout, basename: "index.html", html: html
+      FileUtils.rm_rf(item.path)
+      item
+    end
+
+    it do
+      visit item.full_url
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{site.full_url}\"]")
+      expect(page).to have_css(".hello")
+    end
+  end
+
+  context "root non-index page" do
+    let!(:item) do
+      html = <<~HTML
+        <p class="hello">#{unique_id}</p>
+      HTML
+      item = create :cms_page, cur_site: site, layout: layout, basename: "#{unique_id}.html", html: html
+      FileUtils.rm_rf(item.path)
+      item
+    end
+
+    it do
+      visit item.full_url
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{item.full_url}\"]")
+      expect(page).to have_css(".hello")
+    end
+  end
+
+  context "index page under a folder" do
+    let!(:node) { create :article_node_page, cur_site: site, layout: layout }
+    let!(:item) do
+      html = <<~HTML
+        <p class="hello">#{unique_id}</p>
+      HTML
+      item = create :cms_page, cur_site: site, cur_node: node, layout: layout, basename: "index.html", html: html
+      FileUtils.rm_rf(item.path)
+      item
+    end
+
+    it do
+      visit item.full_url
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+      expect(page).to have_css(".hello")
+    end
+  end
+
+  context "non-index page under a folder" do
+    let!(:node) { create :article_node_page, cur_site: site, layout: layout }
+    let!(:item) do
+      html = <<~HTML
+        <p class="hello">#{unique_id}</p>
+      HTML
+      item = create :cms_page, cur_site: site, cur_node: node, layout: layout, basename: "#{unique_id}.html", html: html
+      FileUtils.rm_rf(item.path)
+      item
+    end
+
+    it do
+      visit item.full_url
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{item.full_url}\"]")
+      expect(page).to have_css(".hello")
+    end
+  end
+end

--- a/spec/features/event/agents/nodes/page/basic_spec.rb
+++ b/spec/features/event/agents/nodes/page/basic_spec.rb
@@ -310,7 +310,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       visit "#{node.full_url}list.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
-      canonical_url = format("%s%04d%02d/list.html", node.full_url, today.year, today.month, node.event_display)
+      canonical_url = format("%s%04d%02d/list.html", node.full_url, today.year, today.month)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -320,7 +320,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("%s%04d%02d/table.html", node.full_url, today.year, today.month, node.event_display)
+      canonical_url = format("%s%04d%02d/table.html", node.full_url, today.year, today.month)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -518,7 +518,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("%s%04d%02d/table.html", node.full_url, today.year, today.month, node.event_display)
+      canonical_url = format("%s%04d%02d/table.html", node.full_url, today.year, today.month)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 

--- a/spec/features/event/agents/nodes/page/basic_spec.rb
+++ b/spec/features/event/agents/nodes/page/basic_spec.rb
@@ -150,23 +150,44 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
     end
 
+    it "monthly canonical index" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
     it "monthly index type1" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
-      visit full_url
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
     end
 
     it "monthly index type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly index type3" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
@@ -230,25 +251,50 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
     end
 
-    it "monthly index type1" do
+    it "monthly canonical index" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
-      visit full_url
+      visit sprintf("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly index type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
     end
 
     it "monthly index type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly index type3" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
@@ -308,16 +354,15 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 404
     end
 
-    it "monthly index type1" do
+    it "monthly canonical index" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
-      visit full_url
+      visit sprintf("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
     end
 
     it "monthly index type1" do
@@ -325,6 +370,28 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly index type2" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly index type3" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
@@ -382,25 +449,50 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
     end
 
-    it "monthly index type1" do
+    it "monthly canonical index" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
-      visit full_url
+      visit sprintf("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly index type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
     end
 
     it "monthly index type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly index type3" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")

--- a/spec/features/event/agents/nodes/page/basic_spec.rb
+++ b/spec/features/event/agents/nodes/page/basic_spec.rb
@@ -78,51 +78,55 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/", year, month)
+      visit format("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly type1" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("#{node.full_url}%04d%02d/index.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      visit format("#{node.full_url}%04d%02d", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly type3" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit format("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly list" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -133,7 +137,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
       visit full_url
       expect(status_code).to eq 404
     end
@@ -143,11 +147,12 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)
+      visit format("#{node.full_url}%04d%02d%02d/", year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "daily type1" do
@@ -155,11 +160,12 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit sprintf("#{node.full_url}%04d%02d%02d/index.html", year, month, day)
+      visit format("#{node.full_url}%04d%02d%02d/index.html", year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "daily type2" do
@@ -167,11 +173,12 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit sprintf("#{node.full_url}%04d%02d%02d", year, month, day)
+      visit format("#{node.full_url}%04d%02d%02d", year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "daily type3" do
@@ -179,11 +186,12 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit sprintf("#{node.full_url}%04d%02d%02d.html", year, month, day)
+      visit format("#{node.full_url}%04d%02d%02d.html", year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     include_context "with invalid date"
@@ -221,51 +229,55 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/", year, month)
+      visit format("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type1" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("#{node.full_url}%04d%02d/index.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      visit format("#{node.full_url}%04d%02d", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type3" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit format("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly list" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -276,7 +288,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
@@ -322,59 +334,63 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/", year, month)
+      visit format("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type1" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("#{node.full_url}%04d%02d/index.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      visit format("#{node.full_url}%04d%02d", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type3" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit format("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly list" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -385,7 +401,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
@@ -425,51 +441,55 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/", year, month)
+      visit format("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type1" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("#{node.full_url}%04d%02d/index.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      visit format("#{node.full_url}%04d%02d", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type3" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit format("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly list" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -480,7 +500,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
       visit full_url
       expect(status_code).to eq 404
     end
@@ -520,59 +540,63 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/", year, month)
+      visit format("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type1" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("#{node.full_url}%04d%02d/index.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type2" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      visit format("#{node.full_url}%04d%02d", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type3" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit format("#{node.full_url}%04d%02d.html", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly list" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      url = format("#{node.full_url}%04d%02d/list.html", year, month)
       visit url
       expect(status_code).to eq 404
     end
@@ -581,7 +605,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")

--- a/spec/features/event/agents/nodes/page/basic_spec.rb
+++ b/spec/features/event/agents/nodes/page/basic_spec.rb
@@ -74,16 +74,48 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 404
     end
 
-    it "monthly" do
+    it "monthly canonical index" do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
-      visit full_url
+      visit sprintf("#{node.full_url}%04d%02d/", year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+    end
+
+    it "monthly type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+    end
+
+    it "monthly type2" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
+    end
+
+    it "monthly type3" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly list" do
@@ -106,17 +138,52 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 404
     end
 
-    it "daily" do
+    it "daily canonical index" do
       time = Time.zone.now
       year = time.year
       month = time.month
       day = time.day
-      full_url = sprintf("#{node.full_url}%04d%02d%02d.html", year, month, day)
-      visit full_url
+      visit sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
+    end
+
+    it "daily type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      day = time.day
+      visit sprintf("#{node.full_url}%04d%02d%02d/index.html", year, month, day)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
+      expect(page).to have_css("div#event-list", text: '')
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
+    end
+
+    it "daily type2" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      day = time.day
+      visit sprintf("#{node.full_url}%04d%02d%02d", year, month, day)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
+      expect(page).to have_css("div#event-list", text: '')
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
+    end
+
+    it "daily type3" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      day = time.day
+      visit sprintf("#{node.full_url}%04d%02d%02d.html", year, month, day)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
+      expect(page).to have_css("div#event-list", text: '')
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d%02d/", year, month, day)}\"]")
     end
 
     include_context "with invalid date"
@@ -158,7 +225,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type1" do
@@ -169,7 +236,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type2" do
@@ -180,7 +247,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type3" do
@@ -191,7 +258,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly list" do
@@ -261,7 +328,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type1" do
@@ -274,7 +341,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type2" do
@@ -287,7 +354,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type3" do
@@ -300,7 +367,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly list" do
@@ -362,7 +429,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type1" do
@@ -373,7 +440,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type2" do
@@ -384,7 +451,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type3" do
@@ -395,7 +462,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly list" do
@@ -459,7 +526,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type1" do
@@ -472,7 +539,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type2" do
@@ -485,7 +552,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly index type3" do
@@ -498,7 +565,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)}\"]")
     end
 
     it "monthly list" do

--- a/spec/features/event/agents/nodes/page/basic_spec.rb
+++ b/spec/features/event/agents/nodes/page/basic_spec.rb
@@ -1,30 +1,9 @@
 require 'spec_helper'
 
 describe "event_agents_nodes_page", type: :feature, dbscope: :example do
-  let(:site) { cms_site }
-  let(:layout) { create_cms_layout }
-  let(:node) { create :event_node_page, layout_id: layout.id, filename: "node" }
-  let(:list_node) do
-    create(:event_node_page, layout_id: layout.id, filename: 'list_node', event_display: 'list',
-      event_display_tabs: %w(list table))
-  end
-  let(:table_node) do
-    create(:event_node_page, layout_id: layout.id, filename: 'list_node', event_display: 'table',
-      event_display_tabs: %w(list table))
-  end
-  let(:list_only_node) do
-    create(:event_node_page, layout_id: layout.id, filename: 'list_node', event_display: 'list',
-      event_display_tabs: %w(list))
-  end
-  let(:table_only_node) do
-    create(:event_node_page, layout_id: layout.id, filename: 'list_node', event_display: 'table',
-      event_display_tabs: %w(table))
-  end
-  let(:map_only_node) do
-    create(:event_node_page, layout_id: layout.id, filename: 'list_node', event_display: 'map',
-      event_display_tabs: %w(map))
-  end
-  let(:item) { create :event_page, cur_node: node }
+  let!(:site) { cms_site }
+  let!(:layout) { create_cms_layout cur_site: site }
+  let!(:item1) { create :event_page, cur_site: site, cur_node: node, layout: layout, ical_link: nil }
 
   before do
     # 書き出しテストの後に本テストが実行されると失敗する場合があるので、念のため書き出し済みのファイルを削除
@@ -32,353 +11,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     FileUtils.mkdir_p site.path
   end
 
-  context "when access node" do
-    it "index" do
-      visit node.full_url
-      expect(status_code).to eq 200
-      expect(page).to have_css("nav.event-date")
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "list" do
-      visit "#{node.full_url}list.html"
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "table" do
-      visit "#{list_only_node.full_url}table.html"
-      expect(status_code).to eq 404
-    end
-
-    it "monthly" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{node.full_url}%04d%02d.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{node.full_url}%04d%02d/list.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
-      visit url
-      expect(status_code).to eq 404
-    end
-
-    it "daily" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      day = time.day
-      visit sprintf("#{node.full_url}%04d%02d%02d.html", year, month, day)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
-      expect(page).to have_css("div#event-list", text: '')
-    end
-  end
-
-  context "when access list_node" do
-    it "index" do
-      visit list_node.full_url
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "list" do
-      visit "#{list_node.full_url}list.html"
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "table" do
-      visit "#{list_node.full_url}table.html"
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{list_node.full_url}%04d%02d.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly index type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{list_node.full_url}%04d%02d/index.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{list_node.full_url}%04d%02d/list.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{list_node.full_url}%04d%02d/table.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-  end
-
-  context "when access table_node" do
-    it "index" do
-      visit table_node.full_url
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "list" do
-      visit "#{table_node.full_url}list.html"
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "table" do
-      visit "#{table_node.full_url}table.html"
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{table_node.full_url}%04d%02d.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "monthly index type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{table_node.full_url}%04d%02d/index.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{table_node.full_url}%04d%02d/list.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{table_node.full_url}%04d%02d/table.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-  end
-
-  context "when access list_only_node" do
-    it "index" do
-      visit list_only_node.full_url
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "list" do
-      visit "#{list_only_node.full_url}list.html"
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "table" do
-      visit "#{list_only_node.full_url}table.html"
-      expect(status_code).to eq 404
-    end
-
-    it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{list_only_node.full_url}%04d%02d.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{list_only_node.full_url}%04d%02d/index.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{list_only_node.full_url}%04d%02d/list.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-list")
-    end
-
-    it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      url = sprintf("#{list_only_node.full_url}%04d%02d/table.html", year, month)
-      visit url
-      expect(status_code).to eq 404
-    end
-  end
-
-  context "when access table_only_node" do
-    it "index" do
-      visit table_only_node.full_url
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "list" do
-      visit "#{table_only_node.full_url}list.html"
-      expect(status_code).to eq 404
-    end
-
-    it "table" do
-      visit "#{table_only_node.full_url}table.html"
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{table_only_node.full_url}%04d%02d/index.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "monthly index type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{table_only_node.full_url}%04d%02d/index.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-
-    it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      url = sprintf("#{table_only_node.full_url}%04d%02d/list.html", year, month)
-      visit url
-      expect(status_code).to eq 404
-    end
-
-    it "monthly_table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      visit sprintf("#{table_only_node.full_url}%04d%02d/table.html", year, month)
-      expect(status_code).to eq 200
-      expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-    end
-  end
-
-  context "when access map_only_node", js: true do
-    let!(:event_date1) { Time.zone.now }
-    let!(:event_date2) { Time.zone.now.advance(months: 1) }
-    let!(:event_recurr1) { { kind: "date", start_at: event_date1, frequency: "daily", until_on: event_date1 } }
-    let!(:event_recurr2) { { kind: "date", start_at: event_date2, frequency: "daily", until_on: event_date2 } }
-    let!(:item1) do
-      create(
-        :event_page, cur_site: site, cur_node: map_only_node,
-        event_recurrences: [event_recurr1],
-        map_points: [{"name" => unique_id, "loc" => [134.589971, 34.067035], "text" => unique_id}])
-    end
-    let!(:item2) do
-      create(
-        :event_page, cur_site: site, cur_node: map_only_node,
-        event_recurrences: [event_recurr2],
-        map_points: [{"name" => unique_id, "loc" => [134.589971, 34.068], "text" => unique_id}])
-    end
-
-    it "index" do
-      visit map_only_node.full_url
-      expect(page).to have_css("#map-canvas")
-      expect(page).to have_text(item1.map_points[0]["name"])
-      expect(page).to have_no_text(item2.map_points[0]["name"])
-
-      within ".event-date" do
-        click_on "#{event_date2.month}#{I18n.t("datetime.prompts.month")}"
-      end
-      expect(page).to have_css("#map-canvas")
-      expect(page).to have_no_text(item1.map_points[0]["name"])
-      expect(page).to have_text(item2.map_points[0]["name"])
-    end
-  end
-
-  context "with invalid date" do
+  shared_examples "with invalid date" do
     context "with invalid year and date" do
       it do
         visit "#{node.full_url}698079.html"
@@ -415,6 +48,426 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
         visit "#{node.full_url}69807945/index.html"
         expect(status_code).to eq 404
       end
+    end
+  end
+
+  context "when access node" do
+    let!(:node) { create :event_node_page, cur_site: site, layout: layout }
+
+    it "index" do
+      visit node.full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("nav.event-date")
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+    end
+
+    it "list" do
+      visit "#{node.full_url}list.html"
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+    end
+
+    it "table" do
+      visit "#{node.full_url}table.html"
+      expect(status_code).to eq 404
+    end
+
+    it "monthly" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly list" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly table" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      visit full_url
+      expect(status_code).to eq 404
+    end
+
+    it "daily" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      day = time.day
+      full_url = sprintf("#{node.full_url}%04d%02d%02d.html", year, month, day)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
+      expect(page).to have_css("div#event-list", text: '')
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    include_context "with invalid date"
+  end
+
+  context "when access list_node" do
+    let!(:node) do
+      create(:event_node_page, cur_site: site, layout: layout, event_display: 'list', event_display_tabs: %w(list table))
+    end
+
+    it "index" do
+      visit node.full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+    end
+
+    it "list" do
+      visit "#{node.full_url}list.html"
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+    end
+
+    it "table" do
+      visit "#{node.full_url}table.html"
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
+    end
+
+    it "monthly index type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly index type2" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly list" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly table" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    include_context "with invalid date"
+  end
+
+  context "when access table_node" do
+    let!(:node) do
+      create(:event_node_page, cur_site: site, layout: layout, event_display: 'table', event_display_tabs: %w(list table))
+    end
+
+    it "index" do
+      visit node.full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+    end
+
+    it "list" do
+      visit "#{node.full_url}list.html"
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+    end
+
+    it "table" do
+      visit "#{node.full_url}table.html"
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
+    end
+
+    it "monthly index type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly index type2" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly list" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly table" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    include_context "with invalid date"
+  end
+
+  context "when access list_only_node" do
+    let!(:node) do
+      create(:event_node_page, cur_site: site, layout: layout, event_display: 'list', event_display_tabs: %w(list))
+    end
+
+    it "index" do
+      visit node.full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+    end
+
+    it "list" do
+      visit "#{node.full_url}list.html"
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+    end
+
+    it "table" do
+      visit "#{node.full_url}table.html"
+      expect(status_code).to eq 404
+    end
+
+    it "monthly index type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly index type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly list" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-list")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly table" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      visit full_url
+      expect(status_code).to eq 404
+    end
+
+    include_context "with invalid date"
+  end
+
+  context "when access table_only_node" do
+    let!(:node) do
+      create(:event_node_page, cur_site: site, layout: layout, event_display: 'table', event_display_tabs: %w(table))
+    end
+
+    it "index" do
+      visit node.full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+    end
+
+    it "list" do
+      visit "#{node.full_url}list.html"
+      expect(status_code).to eq 404
+    end
+
+    it "table" do
+      visit "#{node.full_url}table.html"
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
+    end
+
+    it "monthly index type1" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    it "monthly index type2" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      visit sprintf("#{node.full_url}%04d%02d/index.html", year, month)
+      expect(status_code).to eq 200
+      expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{sprintf("#{node.full_url}%04d%02d/", year, month)}\"]")
+    end
+
+    it "monthly list" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      url = sprintf("#{node.full_url}%04d%02d/list.html", year, month)
+      visit url
+      expect(status_code).to eq 404
+    end
+
+    it "monthly_table" do
+      time = Time.zone.now
+      year = time.year
+      month = time.month
+      full_url = sprintf("#{node.full_url}%04d%02d/table.html", year, month)
+      visit full_url
+      expect(status_code).to eq 200
+      expect(page).to have_css("div#event-table")
+      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
+    end
+
+    include_context "with invalid date"
+  end
+
+  context "when access map_only_node", js: true do
+    let!(:node) do
+      create(:event_node_page, cur_site: site, layout: layout, filename: 'list_node', event_display: 'map',
+             event_display_tabs: %w(map))
+    end
+    let!(:event_date1) { Time.zone.now }
+    let!(:event_date2) { Time.zone.now.advance(months: 1) }
+    let!(:event_recurr1) { { kind: "date", start_at: event_date1, frequency: "daily", until_on: event_date1 } }
+    let!(:event_recurr2) { { kind: "date", start_at: event_date2, frequency: "daily", until_on: event_date2 } }
+    let!(:item1) do
+      create(
+        :event_page, cur_site: site, cur_node: node, ical_link: nil,
+        event_recurrences: [event_recurr1],
+        map_points: [{"name" => unique_id, "loc" => [134.589971, 34.067035], "text" => unique_id}])
+    end
+    let!(:item2) do
+      create(
+        :event_page, cur_site: site, cur_node: node, ical_link: nil,
+        event_recurrences: [event_recurr2],
+        map_points: [{"name" => unique_id, "loc" => [134.589971, 34.068], "text" => unique_id}])
+    end
+
+    it "index" do
+      visit node.full_url
+      expect(page).to have_css("#map-canvas")
+      expect(page).to have_text(item1.map_points[0]["name"])
+      expect(page).to have_no_text(item2.map_points[0]["name"])
+
+      within ".event-date" do
+        click_on "#{event_date2.month}#{I18n.t("datetime.prompts.month")}"
+      end
+      expect(page).to have_css("#map-canvas")
+      expect(page).to have_no_text(item1.map_points[0]["name"])
+      expect(page).to have_text(item2.map_points[0]["name"])
     end
   end
 end

--- a/spec/features/event/agents/nodes/page/basic_spec.rb
+++ b/spec/features/event/agents/nodes/page/basic_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe "event_agents_nodes_page", type: :feature, dbscope: :example do
+  let(:today) { Time.zone.today }
+  let(:tomorrow) { Time.zone.tomorrow }
   let!(:site) { cms_site }
   let!(:layout) { create_cms_layout cur_site: site }
   let!(:item1) { create :event_page, cur_site: site, cur_node: node, layout: layout, ical_link: nil }
@@ -59,14 +61,16 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       expect(status_code).to eq 200
       expect(page).to have_css("nav.event-date")
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "list" do
       visit "#{node.full_url}list.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+      canonical_url = format("%s%04d%02d/list.html", node.full_url, today.year, today.month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "table" do
@@ -75,9 +79,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly canonical index" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -87,9 +90,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -99,9 +101,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -111,9 +112,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly type3" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -123,9 +123,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
@@ -134,19 +133,17 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 404
     end
 
     it "daily canonical index" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      day = time.day
+      year = today.year
+      month = today.month
+      day = today.day
       visit format("%s%04d%02d%02d/", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
@@ -156,10 +153,9 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "daily type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      day = time.day
+      year = today.year
+      month = today.month
+      day = today.day
       visit format("%s%04d%02d%02d/index.html", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
@@ -169,10 +165,9 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "daily type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      day = time.day
+      year = today.year
+      month = today.month
+      day = today.day
       visit format("%s%04d%02d%02d", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
@@ -182,10 +177,9 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "daily type3" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
-      day = time.day
+      year = today.year
+      month = today.month
+      day = today.day
       visit format("%s%04d%02d%02d.html", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
@@ -206,29 +200,31 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       visit node.full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "list" do
       visit "#{node.full_url}list.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+      canonical_url = format("%s%04d%02d/list.html", node.full_url, today.year, today.month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "table" do
       visit "#{node.full_url}table.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
+      canonical_url = format("%s%04d%02d/table.html", node.full_url, today.year, today.month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly canonical index" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -238,9 +234,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -250,9 +245,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly index type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -262,9 +256,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly index type3" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -274,9 +267,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
@@ -285,15 +277,14 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
     end
 
@@ -309,87 +300,85 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       visit node.full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "list" do
       visit "#{node.full_url}list.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+      canonical_url = format("%s%04d%02d/list.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "table" do
       visit "#{node.full_url}table.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
+      canonical_url = format("%s%04d%02d/table.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly canonical index" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type3" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
@@ -398,15 +387,14 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
     end
 
@@ -422,14 +410,16 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       visit node.full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "list" do
       visit "#{node.full_url}list.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}list.html\"]")
+      canonical_url = format("%s%04d%02d/list.html", node.full_url, today.year, today.month)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "table" do
@@ -438,9 +428,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly canonical index" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -450,9 +439,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -462,9 +450,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly index type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -474,9 +461,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly index type3" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
@@ -486,9 +472,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
@@ -497,9 +482,8 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
     end
 
     it "monthly table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 404
@@ -517,9 +501,10 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       visit node.full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "list" do
@@ -531,86 +516,81 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       visit "#{node.full_url}table.html"
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}table.html\"]")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
+      canonical_url = format("%s%04d%02d/table.html", node.full_url, today.year, today.month, node.event_display)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly canonical index" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type1" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type2" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly index type3" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
     it "monthly list" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit url
       expect(status_code).to eq 404
     end
 
     it "monthly_table" do
-      time = Time.zone.now
-      year = time.year
-      month = time.month
+      year = today.year
+      month = today.month
       full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
-      expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
-      expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
+      expect(page).to have_css("td.#{today.strftime('%a').downcase}.today")
+      expect(page).to have_css("td.#{tomorrow.strftime('%a').downcase}.future")
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{full_url}\"]")
     end
 

--- a/spec/features/event/agents/nodes/page/basic_spec.rb
+++ b/spec/features/event/agents/nodes/page/basic_spec.rb
@@ -78,11 +78,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/", year, month)
+      visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -90,11 +90,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -102,11 +102,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d", year, month)
+      visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -114,11 +114,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d.html", year, month)
+      visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -126,7 +126,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -137,7 +137,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 404
     end
@@ -147,11 +147,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      visit format("%s%04d%02d%02d/", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      canonical_url = format("%s%04d%02d%02d/", node.full_url, year, month, day)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -160,11 +160,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit format("#{node.full_url}%04d%02d%02d/index.html", year, month, day)
+      visit format("%s%04d%02d%02d/index.html", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      canonical_url = format("%s%04d%02d%02d/", node.full_url, year, month, day)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -173,11 +173,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit format("#{node.full_url}%04d%02d%02d", year, month, day)
+      visit format("%s%04d%02d%02d", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      canonical_url = format("%s%04d%02d%02d/", node.full_url, year, month, day)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -186,11 +186,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       year = time.year
       month = time.month
       day = time.day
-      visit format("#{node.full_url}%04d%02d%02d.html", year, month, day)
+      visit format("%s%04d%02d%02d.html", node.full_url, year, month, day)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, day), format: :long)))
       expect(page).to have_css("div#event-list", text: '')
-      canonical_url = format("#{node.full_url}%04d%02d%02d/", year, month, day)
+      canonical_url = format("%s%04d%02d%02d/", node.full_url, year, month, day)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -229,11 +229,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/", year, month)
+      visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -241,11 +241,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -253,11 +253,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d", year, month)
+      visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -265,11 +265,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d.html", year, month)
+      visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -277,7 +277,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -288,7 +288,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
@@ -334,13 +334,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/", year, month)
+      visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -348,13 +348,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -362,13 +362,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d", year, month)
+      visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -376,13 +376,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d.html", year, month)
+      visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -390,7 +390,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -401,7 +401,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")
@@ -441,11 +441,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/", year, month)
+      visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -453,11 +453,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -465,11 +465,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d", year, month)
+      visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -477,11 +477,11 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d.html", year, month)
+      visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-list")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -489,7 +489,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/list.html", year, month)
+      full_url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-list")
@@ -500,7 +500,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 404
     end
@@ -540,13 +540,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/", year, month)
+      visit format("%s%04d%02d/", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -554,13 +554,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d/index.html", year, month)
+      visit format("%s%04d%02d/index.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -568,13 +568,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d", year, month)
+      visit format("%s%04d%02d", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -582,13 +582,13 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      visit format("#{node.full_url}%04d%02d.html", year, month)
+      visit format("%s%04d%02d.html", node.full_url, year, month)
       expect(status_code).to eq 200
       expect(page).to have_title(::Regexp.compile(I18n.l(Date.new(year, month, 1), format: :long_month)))
       expect(page).to have_css("div#event-table")
       expect(page).to have_css("td.#{Time.zone.today.strftime('%a').downcase}.today")
       expect(page).to have_css("td.#{Time.zone.tomorrow.strftime('%a').downcase}.future")
-      canonical_url = format("#{node.full_url}%04d%02d/#{node.event_display}.html", year, month)
+      canonical_url = format("%s%04d%02d/%s.html", node.full_url, year, month, node.event_display)
       expect(page).to have_css("[rel=\"canonical\"][href=\"#{canonical_url}\"]")
     end
 
@@ -596,7 +596,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      url = format("#{node.full_url}%04d%02d/list.html", year, month)
+      url = format("%s%04d%02d/list.html", node.full_url, year, month)
       visit url
       expect(status_code).to eq 404
     end
@@ -605,7 +605,7 @@ describe "event_agents_nodes_page", type: :feature, dbscope: :example do
       time = Time.zone.now
       year = time.year
       month = time.month
-      full_url = format("#{node.full_url}%04d%02d/table.html", year, month)
+      full_url = format("%s%04d%02d/table.html", node.full_url, year, month)
       visit full_url
       expect(status_code).to eq 200
       expect(page).to have_css("div#event-table")

--- a/spec/features/event/agents/nodes/search_spec.rb
+++ b/spec/features/event/agents/nodes/search_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe "event_agents_nodes_search", type: :feature, dbscope: :example do
-  let(:site) { cms_site }
-  let(:layout) { create_cms_layout }
-  let(:node) { create :event_node_search, layout_id: layout.id, filename: "node" }
+  let!(:site) { cms_site }
+  let!(:layout) { create_cms_layout cur_site: site }
+  let!(:node) { create :event_node_search, cur_site: site, layout: layout }
   let!(:event_recur1) do
     { kind: "date", start_at: Time.zone.today - 3.days, frequency: "daily", until_on: Time.zone.today - 2.days }
   end
@@ -13,9 +13,9 @@ describe "event_agents_nodes_search", type: :feature, dbscope: :example do
   let!(:event_recur3) do
     { kind: "date", start_at: Time.zone.today + 2.days, frequency: "daily", until_on: Time.zone.today + 3.days }
   end
-  let!(:item1) { create :event_page, cur_node: node, event_recurrences: [event_recur1] }
-  let!(:item2) { create :event_page, cur_node: node, event_recurrences: [event_recur2] }
-  let!(:item3) { create :event_page, cur_node: node, event_recurrences: [event_recur3] }
+  let!(:item1) { create :event_page, cur_site: site, cur_node: node, layout: layout, event_recurrences: [event_recur1] }
+  let!(:item2) { create :event_page, cur_site: site, cur_node: node, layout: layout, event_recurrences: [event_recur2] }
+  let!(:item3) { create :event_page, cur_site: site, cur_node: node, layout: layout, event_recurrences: [event_recur3] }
 
   before do
     # 書き出しテストの後に本テストが実行されると失敗する場合があるので、念のため書き出し済みのファイルを削除
@@ -33,6 +33,7 @@ describe "event_agents_nodes_search", type: :feature, dbscope: :example do
       expect(page).to have_css("article:nth-child(1) a", text: item3.name)
       expect(page).to have_css("article:nth-child(2) a", text: item2.name)
       expect(page).to have_css("article:nth-child(3) a", text: item1.name)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
     end
   end
 
@@ -45,6 +46,7 @@ describe "event_agents_nodes_search", type: :feature, dbscope: :example do
       expect(page).to have_selector('article', count: 2)
       expect(page).to have_css("article:nth-child(1) a", text: item2.name)
       expect(page).to have_css("article:nth-child(2) a", text: item3.name)
+      expect(page).to have_css("[rel=\"canonical\"][href=\"#{node.full_url}\"]")
     end
   end
 end

--- a/spec/features/event/agents/pages/canonical_spec.rb
+++ b/spec/features/event/agents/pages/canonical_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe "event_agents_nodes_page", type: :feature, dbscope: :example do
+  let!(:site) { cms_site }
+  let!(:layout) { create_cms_layout cur_site: site }
+  let!(:node) { create :event_node_page, cur_site: site, layout: layout }
+  let!(:item1) { create :event_page, cur_site: site, cur_node: node, layout: layout, ical_link: nil }
+
+  before do
+    # 書き出しテストの後に本テストが実行されると失敗する場合があるので、念のため書き出し済みのファイルを削除
+    FileUtils.rm_rf site.path
+    FileUtils.mkdir_p site.path
+  end
+
+  it do
+    visit item1.full_url
+    expect(page).to have_css("[rel=\"canonical\"][href=\"#{item1.full_url}\"]")
+  end
+end

--- a/spec/jobs/cms/node/generate_job/article_spec.rb
+++ b/spec/jobs/cms/node/generate_job/article_spec.rb
@@ -18,6 +18,15 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
     it do
       expect(File.exist?("#{node.path}/index.html")).to be_truthy
+      Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.html")).tap do |doc|
+        title_elements = doc.css("title")
+        expect(title_elements).to have(1).items
+        expect(title_elements[0].text.strip).to include node.name
+
+        canonical_elements = doc.css("[rel=\"canonical\"]")
+        expect(canonical_elements).to have(1).items
+        expect(canonical_elements[0]["href"]).to eq node.full_url
+      end
 
       expect(Cms::Task.count).to eq 2
       Cms::Task.where(site_id: site.id, node_id: nil, name: 'cms:generate_nodes').first.tap do |task|
@@ -146,6 +155,15 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
     it do
       expect(File.exist?("#{node.path}/index.html")).to be_truthy
+      Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.html")).tap do |doc|
+        title_elements = doc.css("title")
+        expect(title_elements).to have(1).items
+        expect(title_elements[0].text.strip).to include node.name
+
+        canonical_elements = doc.css("[rel=\"canonical\"]")
+        expect(canonical_elements).to have(1).items
+        expect(canonical_elements[0]["href"]).to eq node.full_url
+      end
 
       expect(Cms::Task.count).to eq 2
       Cms::Task.where(site_id: site.id, node_id: nil, name: 'cms:generate_nodes').first.tap do |task|

--- a/spec/jobs/cms/node/generate_job/event_spec.rb
+++ b/spec/jobs/cms/node/generate_job/event_spec.rb
@@ -58,7 +58,7 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
             canonical_elements = doc.css("[rel=\"canonical\"]")
             expect(canonical_elements).to have(1).items
-            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/"
+            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/#{node.event_display}.html"
           end
           Nokogiri::HTML5::Document.parse(File.read("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).tap do |doc|
             title_elements = doc.css("title")
@@ -145,7 +145,7 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
             canonical_elements = doc.css("[rel=\"canonical\"]")
             expect(canonical_elements).to have(1).items
-            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/"
+            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/#{node.event_display}.html"
           end
           Nokogiri::HTML5::Document.parse(File.read("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).tap do |doc|
             title_elements = doc.css("title")

--- a/spec/jobs/cms/node/generate_job/event_spec.rb
+++ b/spec/jobs/cms/node/generate_job/event_spec.rb
@@ -7,6 +7,7 @@ describe Cms::Node::GenerateJob, dbscope: :example do
   let!(:page)  do
     create(:event_page, cur_site: cms_site, cur_node: node, layout_id: layout.id)
   end
+  let(:today) { Time.zone.today }
 
   before do
     Cms::Task.create!(site_id: site.id, node_id: node.id, name: 'cms:generate_nodes', state: 'ready')
@@ -42,12 +43,12 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
           canonical_elements = doc.css("[rel=\"canonical\"]")
           expect(canonical_elements).to have(1).items
-          expect(canonical_elements[0]["href"]).to eq node.full_url
+          expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{today.strftime("%Y%m")}/#{node.event_display}.html"
         end
 
-        this_month = Time.zone.now.beginning_of_month
-        cur_month = this_month - 1.year
-        while cur_month <= this_month + 1.year
+        cur_month = today - 1.year
+        last_month = today + 1.year
+        while cur_month <= last_month
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/index.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/table.html")).to be_truthy
@@ -129,12 +130,12 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
           canonical_elements = doc.css("[rel=\"canonical\"]")
           expect(canonical_elements).to have(1).items
-          expect(canonical_elements[0]["href"]).to eq node.full_url
+          expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{today.strftime("%Y%m")}/#{node.event_display}.html"
         end
 
-        this_month = Time.zone.now.beginning_of_month
-        cur_month = this_month - 1.year
-        while cur_month <= this_month + 1.year
+        cur_month = today - 1.year
+        last_month = today + 1.year
+        while cur_month <= last_month
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/index.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/table.html")).to be_falsey

--- a/spec/jobs/cms/node/generate_job/event_spec.rb
+++ b/spec/jobs/cms/node/generate_job/event_spec.rb
@@ -35,6 +35,15 @@ describe Cms::Node::GenerateJob, dbscope: :example do
         expect(File.exist?("#{node.path}/index.ics")).to be_truthy
         expect(File.exist?("#{node.path}/table.html")).to be_falsey
         expect(File.exist?("#{node.path}/list.html")).to be_falsey
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq node.full_url
+        end
 
         this_month = Time.zone.now.beginning_of_month
         cur_month = this_month - 1.year
@@ -42,6 +51,33 @@ describe Cms::Node::GenerateJob, dbscope: :example do
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/index.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/table.html")).to be_truthy
+          Nokogiri::HTML5::Document.parse(File.read("#{node.path}/#{cur_month.strftime("%Y%m")}/index.html")).tap do |doc|
+            title_elements = doc.css("title")
+            expect(title_elements).to have(1).items
+            expect(title_elements[0].text.strip).to include node.name
+
+            canonical_elements = doc.css("[rel=\"canonical\"]")
+            expect(canonical_elements).to have(1).items
+            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/"
+          end
+          Nokogiri::HTML5::Document.parse(File.read("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).tap do |doc|
+            title_elements = doc.css("title")
+            expect(title_elements).to have(1).items
+            expect(title_elements[0].text.strip).to include node.name
+
+            canonical_elements = doc.css("[rel=\"canonical\"]")
+            expect(canonical_elements).to have(1).items
+            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/list.html"
+          end
+          Nokogiri::HTML5::Document.parse(File.read("#{node.path}/#{cur_month.strftime("%Y%m")}/table.html")).tap do |doc|
+            title_elements = doc.css("title")
+            expect(title_elements).to have(1).items
+            expect(title_elements[0].text.strip).to include node.name
+
+            canonical_elements = doc.css("[rel=\"canonical\"]")
+            expect(canonical_elements).to have(1).items
+            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/table.html"
+          end
 
           cur_month += 1.month
         end
@@ -86,6 +122,15 @@ describe Cms::Node::GenerateJob, dbscope: :example do
         expect(File.exist?("#{node.path}/index.ics")).to be_truthy
         expect(File.exist?("#{node.path}/table.html")).to be_falsey
         expect(File.exist?("#{node.path}/list.html")).to be_falsey
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq node.full_url
+        end
 
         this_month = Time.zone.now.beginning_of_month
         cur_month = this_month - 1.year
@@ -93,6 +138,24 @@ describe Cms::Node::GenerateJob, dbscope: :example do
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/index.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).to be_truthy
           expect(File.exist?("#{node.path}/#{cur_month.strftime("%Y%m")}/table.html")).to be_falsey
+          Nokogiri::HTML5::Document.parse(File.read("#{node.path}/#{cur_month.strftime("%Y%m")}/index.html")).tap do |doc|
+            title_elements = doc.css("title")
+            expect(title_elements).to have(1).items
+            expect(title_elements[0].text.strip).to include node.name
+
+            canonical_elements = doc.css("[rel=\"canonical\"]")
+            expect(canonical_elements).to have(1).items
+            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/"
+          end
+          Nokogiri::HTML5::Document.parse(File.read("#{node.path}/#{cur_month.strftime("%Y%m")}/list.html")).tap do |doc|
+            title_elements = doc.css("title")
+            expect(title_elements).to have(1).items
+            expect(title_elements[0].text.strip).to include node.name
+
+            canonical_elements = doc.css("[rel=\"canonical\"]")
+            expect(canonical_elements).to have(1).items
+            expect(canonical_elements[0]["href"]).to eq "#{node.full_url}#{cur_month.strftime("%Y%m")}/list.html"
+          end
 
           cur_month += 1.month
         end

--- a/spec/jobs/cms/node/generate_job/paginate_spec.rb
+++ b/spec/jobs/cms/node/generate_job/paginate_spec.rb
@@ -6,11 +6,11 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
   context "with article/page node" do
     let!(:node) { create :article_node_page, cur_site: site, layout: layout, limit: 2, sort: "name" }
-    let!(:item1) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a_#{unique_id}" }
-    let!(:item2) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b_#{unique_id}" }
-    let!(:item3) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c_#{unique_id}" }
-    let!(:item4) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d_#{unique_id}" }
-    let!(:item5) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e_#{unique_id}" }
+    let!(:item1) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a" }
+    let!(:item2) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b" }
+    let!(:item3) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c" }
+    let!(:item4) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d" }
+    let!(:item5) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e" }
 
     describe "#perform without node" do
       before do
@@ -49,11 +49,11 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
   context "with faq/page node" do
     let!(:node) { create :faq_node_page, cur_site: site, layout: layout, limit: 2, sort: "name" }
-    let!(:item1) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a_#{unique_id}" }
-    let!(:item2) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b_#{unique_id}" }
-    let!(:item3) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c_#{unique_id}" }
-    let!(:item4) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d_#{unique_id}" }
-    let!(:item5) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e_#{unique_id}" }
+    let!(:item1) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a" }
+    let!(:item2) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b" }
+    let!(:item3) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c" }
+    let!(:item4) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d" }
+    let!(:item5) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e" }
 
     describe "#perform without node" do
       before do
@@ -92,11 +92,11 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
   context "with cms/node node" do
     let!(:node) { create :cms_node_node, cur_site: site, layout: layout, limit: 2, sort: "name" }
-    let!(:item1) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a_#{unique_id}" }
-    let!(:item2) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b_#{unique_id}" }
-    let!(:item3) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c_#{unique_id}" }
-    let!(:item4) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d_#{unique_id}" }
-    let!(:item5) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e_#{unique_id}" }
+    let!(:item1) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a" }
+    let!(:item2) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b" }
+    let!(:item3) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c" }
+    let!(:item4) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d" }
+    let!(:item5) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e" }
 
     describe "#perform without node" do
       before do

--- a/spec/jobs/cms/node/generate_job/paginate_spec.rb
+++ b/spec/jobs/cms/node/generate_job/paginate_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe Cms::Node::GenerateJob, dbscope: :example do
+  let!(:site) { cms_site }
+  let!(:layout) { create_cms_layout }
+
+  context "with article/page node" do
+    let!(:node) { create :article_node_page, cur_site: site, layout: layout, limit: 2, sort: "name" }
+    let!(:item1) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a_#{unique_id}" }
+    let!(:item2) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b_#{unique_id}" }
+    let!(:item3) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c_#{unique_id}" }
+    let!(:item4) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d_#{unique_id}" }
+    let!(:item5) { create :article_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e_#{unique_id}" }
+
+    describe "#perform without node" do
+      before do
+        described_class.bind(site_id: site.id).perform_now
+      end
+
+      it do
+        expect(File.exist?("#{node.path}/index.html")).to be_truthy
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          expect(doc.css(".pagination .page.current")[0].text.strip).to eq "1"
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq node.full_url
+        end
+
+        expect(File.exist?("#{node.path}/index.p2.html")).to be_truthy
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.p2.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          expect(doc.css(".pagination .page.current")[0].text.strip).to eq "2"
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq "#{node.full_url}index.p2.html"
+        end
+      end
+    end
+  end
+
+  context "with faq/page node" do
+    let!(:node) { create :faq_node_page, cur_site: site, layout: layout, limit: 2, sort: "name" }
+    let!(:item1) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a_#{unique_id}" }
+    let!(:item2) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b_#{unique_id}" }
+    let!(:item3) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c_#{unique_id}" }
+    let!(:item4) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d_#{unique_id}" }
+    let!(:item5) { create :faq_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e_#{unique_id}" }
+
+    describe "#perform without node" do
+      before do
+        described_class.bind(site_id: site.id).perform_now
+      end
+
+      it do
+        expect(File.exist?("#{node.path}/index.html")).to be_truthy
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          expect(doc.css(".pagination .page.current")[0].text.strip).to eq "1"
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq node.full_url
+        end
+
+        expect(File.exist?("#{node.path}/index.p2.html")).to be_truthy
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.p2.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          expect(doc.css(".pagination .page.current")[0].text.strip).to eq "2"
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq "#{node.full_url}index.p2.html"
+        end
+      end
+    end
+  end
+
+  context "with cms/node node" do
+    let!(:node) { create :cms_node_node, cur_site: site, layout: layout, limit: 2, sort: "name" }
+    let!(:item1) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page1", name: "a_#{unique_id}" }
+    let!(:item2) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page2", name: "b_#{unique_id}" }
+    let!(:item3) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page3", name: "c_#{unique_id}" }
+    let!(:item4) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page4", name: "d_#{unique_id}" }
+    let!(:item5) { create :cms_node_page, cur_site: site, cur_node: node, layout: layout, basename: "page5", name: "e_#{unique_id}" }
+
+    describe "#perform without node" do
+      before do
+        described_class.bind(site_id: site.id).perform_now
+      end
+
+      it do
+        expect(File.exist?("#{node.path}/index.html")).to be_truthy
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          expect(doc.css(".pagination .page.current")[0].text.strip).to eq "1"
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq node.full_url
+        end
+
+        expect(File.exist?("#{node.path}/index.p2.html")).to be_truthy
+        Nokogiri::HTML5::Document.parse(File.read("#{node.path}/index.p2.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include node.name
+
+          expect(doc.css(".pagination .page.current")[0].text.strip).to eq "2"
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq "#{node.full_url}index.p2.html"
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/cms/node/generate_job/photo_album_spec.rb
+++ b/spec/jobs/cms/node/generate_job/photo_album_spec.rb
@@ -54,6 +54,21 @@ describe Cms::Node::GenerateJob, dbscope: :example do
         expect(File.exist?("#{photo_album_node.path}/index.html")).to be_truthy
         # cms/photo には RSS を応答する公開アクションはないので rss.xml が作成されていないことを確認する
         expect(File.exist?("#{photo_album_node.path}/rss.xml")).to be_falsey
+        Nokogiri::HTML5::Document.parse(File.read("#{photo_album_node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include photo_album_node.name
+
+          doc.css(".photos .photo").tap do |photos|
+            expect(photos).to have(2).items
+            expect(photos[0].css(".title").text.strip).to eq page1.name
+            expect(photos[1].css(".title").text.strip).to eq page2.name
+          end
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq photo_album_node.full_url
+        end
 
         expect(Cms::Task.count).to eq 1
         Cms::Task.where(site_id: site.id, node_id: nil, name: 'cms:generate_nodes').first.tap do |task|
@@ -76,14 +91,6 @@ describe Cms::Node::GenerateJob, dbscope: :example do
         Job::Log.first.tap do |log|
           expect(log.logs).to include(/INFO -- : .* Started Job/)
           expect(log.logs).to include(/INFO -- : .* Completed Job/)
-        end
-
-        html = File.read("#{photo_album_node.path}/index.html")
-        html = Nokogiri::HTML5::Document.parse(html)
-        html.css(".photos .photo").tap do |photos|
-          expect(photos).to have(2).items
-          expect(photos[0].css(".title").text.strip).to eq page1.name
-          expect(photos[1].css(".title").text.strip).to eq page2.name
         end
       end
     end
@@ -99,6 +106,19 @@ describe Cms::Node::GenerateJob, dbscope: :example do
         expect(File.exist?("#{photo_album_node.path}/index.html")).to be_truthy
         # cms/photo には RSS を応答する公開アクションはないので rss.xml が作成されていないことを確認する
         expect(File.exist?("#{photo_album_node.path}/rss.xml")).to be_falsey
+        Nokogiri::HTML5::Document.parse(File.read("#{photo_album_node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include photo_album_node.name
+
+          doc.css(".photos .photo").tap do |photos|
+            expect(photos).to be_blank
+          end
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq photo_album_node.full_url
+        end
 
         expect(Cms::Task.count).to eq 1
         Cms::Task.where(site_id: site.id, node_id: nil, name: 'cms:generate_nodes').first.tap do |task|
@@ -121,12 +141,6 @@ describe Cms::Node::GenerateJob, dbscope: :example do
         Job::Log.first.tap do |log|
           expect(log.logs).to include(/INFO -- : .* Started Job/)
           expect(log.logs).to include(/INFO -- : .* Completed Job/)
-        end
-
-        html = File.read("#{photo_album_node.path}/index.html")
-        html = Nokogiri::HTML5::Document.parse(html)
-        html.css(".photos .photo").tap do |photos|
-          expect(photos).to be_blank
         end
       end
     end
@@ -155,10 +169,18 @@ describe Cms::Node::GenerateJob, dbscope: :example do
 
         expect(File.size("#{photo_album_node.path}/index.html")).to be > 0
 
-        html = File.read("#{photo_album_node.path}/index.html")
-        html = Nokogiri::HTML.fragment(html)
-        expect(html.css(".inquiry-form")).to have(1).items
-        expect(html.css(".member-photos")).to have(1).items
+        Nokogiri::HTML5::Document.parse(File.read("#{photo_album_node.path}/index.html")).tap do |doc|
+          title_elements = doc.css("title")
+          expect(title_elements).to have(1).items
+          expect(title_elements[0].text.strip).to include photo_album_node.name
+
+          expect(doc.css(".inquiry-form")).to have(1).items
+          expect(doc.css(".member-photos")).to have(1).items
+
+          canonical_elements = doc.css("[rel=\"canonical\"]")
+          expect(canonical_elements).to have(1).items
+          expect(canonical_elements[0]["href"]).to eq photo_album_node.full_url
+        end
       end
     end
   end

--- a/spec/jobs/cms/page/generate_job/article_spec.rb
+++ b/spec/jobs/cms/page/generate_job/article_spec.rb
@@ -71,11 +71,30 @@ describe Cms::Page::GenerateJob, dbscope: :example do
     it do
       expect(File.size(page1.path)).to be > 0
       expect(File.size(ss_file1.public_path)).to be > 0
+      Nokogiri::HTML5::Document.parse(File.read(page1.path)).tap do |doc|
+        title_elements = doc.css("title")
+        expect(title_elements).to have(1).items
+        expect(title_elements[0].text.strip).to include page1.name
+
+        canonical_elements = doc.css("[rel=\"canonical\"]")
+        expect(canonical_elements).to have(1).items
+        expect(canonical_elements[0]["href"]).to eq page1.full_url
+      end
 
       expect(File.size(page2.path)).to be > 0
       expect(File.size(ss_file2.public_path)).to be > 0
       expect(File.size(ss_file3.public_path)).to be > 0
       expect(File.size(ss_file4.public_path)).to be > 0
+      Nokogiri::HTML5::Document.parse(File.read(page2.path)).tap do |doc|
+        title_elements = doc.css("title")
+        expect(title_elements).to have(1).items
+        expect(title_elements[0].text.strip).to include page2.name
+
+        canonical_elements = doc.css("[rel=\"canonical\"]")
+        expect(canonical_elements).to have(1).items
+        expect(canonical_elements[0]["href"]).to eq page2.full_url
+      end
+
       expect(Cms::Task.count).to eq 2
       Cms::Task.where(site_id: site.id, node_id: nil, name: 'cms:generate_pages').first.tap do |task|
         expect(task.state).to eq 'completed'
@@ -142,11 +161,29 @@ describe Cms::Page::GenerateJob, dbscope: :example do
     it do
       expect(File.size(page1.path)).to be > 0
       expect(File.size(ss_file1.public_path)).to be > 0
+      Nokogiri::HTML5::Document.parse(File.read(page1.path)).tap do |doc|
+        title_elements = doc.css("title")
+        expect(title_elements).to have(1).items
+        expect(title_elements[0].text.strip).to include page1.name
+
+        canonical_elements = doc.css("[rel=\"canonical\"]")
+        expect(canonical_elements).to have(1).items
+        expect(canonical_elements[0]["href"]).to eq page1.full_url
+      end
 
       expect(File.size(page2.path)).to be > 0
       expect(File.size(ss_file2.public_path)).to be > 0
       expect(File.size(ss_file3.public_path)).to be > 0
       expect(File.size(ss_file4.public_path)).to be > 0
+      Nokogiri::HTML5::Document.parse(File.read(page2.path)).tap do |doc|
+        title_elements = doc.css("title")
+        expect(title_elements).to have(1).items
+        expect(title_elements[0].text.strip).to include page2.name
+
+        canonical_elements = doc.css("[rel=\"canonical\"]")
+        expect(canonical_elements).to have(1).items
+        expect(canonical_elements[0]["href"]).to eq page2.full_url
+      end
 
       expect(Cms::Task.count).to eq 2
       Cms::Task.where(site_id: site.id, node_id: nil, name: 'cms:generate_pages').first.tap do |task|

--- a/spec/models/cms/canonical_full_url_spec.rb
+++ b/spec/models/cms/canonical_full_url_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Cms, type: :model, dbscope: :example do
+  let!(:site) { cms_site }
+
+  describe ".canonical_full_url" do
+    it do
+      expect(Cms.canonical_full_url(site, "/news/")).to eq "#{site.full_root_url}news/"
+      expect(Cms.canonical_full_url(site, "/news/index.html")).to eq "#{site.full_root_url}news/"
+      expect(Cms.canonical_full_url(site, "/news")).to eq "#{site.full_root_url}news/"
+      expect(Cms.canonical_full_url(site, "/news/index.p2.html")).to eq "#{site.full_root_url}news/index.p2.html"
+      expect(Cms.canonical_full_url(site, "/docs/926.html")).to eq "#{site.full_root_url}docs/926.html"
+    end
+  end
+end

--- a/spec/models/cms/canonical_full_url_spec.rb
+++ b/spec/models/cms/canonical_full_url_spec.rb
@@ -65,5 +65,33 @@ describe Cms, type: :model, dbscope: :example do
         end
       end
     end
+
+    context "with calendar" do
+      it do
+        "/calendar/".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path,
+            "ss.canonical_path" => "/calendar/202607/table.html"
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}calendar/202607/table.html"
+        end
+      end
+    end
+
+    context "with none" do
+      it do
+        "/news/".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path,
+            "ss.canonical_path" => :none
+          )
+          expect(Cms.canonical_full_url(site, request)).to be_blank
+        end
+      end
+    end
   end
 end

--- a/spec/models/cms/canonical_full_url_spec.rb
+++ b/spec/models/cms/canonical_full_url_spec.rb
@@ -55,6 +55,8 @@ describe Cms, type: :model, dbscope: :example do
 
     context "with 404" do
       it do
+        # ルートの 404.html は 404 エラーのためのページ
+        # このページは canonical を出力しない
         "/404.html".tap do |request_path|
           request = ActionDispatch::Request.new(
             "rack.input" => "",
@@ -62,6 +64,17 @@ describe Cms, type: :model, dbscope: :example do
             "PATH_INFO" => request_path
           )
           expect(Cms.canonical_full_url(site, request)).to be_blank
+        end
+
+        # それ以外の 404.html は通常の記事ページ
+        # このページは canonical を出力する
+        "/docs/404.html".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}docs/404.html"
         end
       end
     end

--- a/spec/models/cms/canonical_full_url_spec.rb
+++ b/spec/models/cms/canonical_full_url_spec.rb
@@ -4,50 +4,65 @@ describe Cms, type: :model, dbscope: :example do
   let!(:site) { cms_site }
 
   describe ".canonical_full_url" do
-    it do
-      "/news/".tap do |request_path|
-        request = ActionDispatch::Request.new(
-          "rack.input" => "",
-          "REQUEST_METHOD" => "GET",
-          "PATH_INFO" => request_path
-        )
-        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
-      end
+    context "with regular pages" do
+      it do
+        "/news/".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
+        end
 
-      "/news/index.html".tap do |request_path|
-        request = ActionDispatch::Request.new(
-          "rack.input" => "",
-          "REQUEST_METHOD" => "GET",
-          "PATH_INFO" => request_path
-        )
-        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
-      end
+        "/news/index.html".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
+        end
 
-      "/news".tap do |request_path|
-        request = ActionDispatch::Request.new(
-          "rack.input" => "",
-          "REQUEST_METHOD" => "GET",
-          "PATH_INFO" => request_path
-        )
-        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
-      end
+        "/news".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
+        end
 
-      "/news/index.p2.html".tap do |request_path|
-        request = ActionDispatch::Request.new(
-          "rack.input" => "",
-          "REQUEST_METHOD" => "GET",
-          "PATH_INFO" => request_path
-        )
-        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/index.p2.html"
-      end
+        "/news/index.p2.html".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/index.p2.html"
+        end
 
-      "/docs/926.html".tap do |request_path|
-        request = ActionDispatch::Request.new(
-          "rack.input" => "",
-          "REQUEST_METHOD" => "GET",
-          "PATH_INFO" => request_path
-        )
-        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}docs/926.html"
+        "/docs/926.html".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}docs/926.html"
+        end
+      end
+    end
+
+    context "with 404" do
+      it do
+        "/404.html".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to be_blank
+        end
       end
     end
   end

--- a/spec/models/cms/canonical_full_url_spec.rb
+++ b/spec/models/cms/canonical_full_url_spec.rb
@@ -5,11 +5,50 @@ describe Cms, type: :model, dbscope: :example do
 
   describe ".canonical_full_url" do
     it do
-      expect(Cms.canonical_full_url(site, "/news/")).to eq "#{site.full_root_url}news/"
-      expect(Cms.canonical_full_url(site, "/news/index.html")).to eq "#{site.full_root_url}news/"
-      expect(Cms.canonical_full_url(site, "/news")).to eq "#{site.full_root_url}news/"
-      expect(Cms.canonical_full_url(site, "/news/index.p2.html")).to eq "#{site.full_root_url}news/index.p2.html"
-      expect(Cms.canonical_full_url(site, "/docs/926.html")).to eq "#{site.full_root_url}docs/926.html"
+      "/news/".tap do |request_path|
+        request = ActionDispatch::Request.new(
+          "rack.input" => "",
+          "REQUEST_METHOD" => "GET",
+          "PATH_INFO" => request_path
+        )
+        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
+      end
+
+      "/news/index.html".tap do |request_path|
+        request = ActionDispatch::Request.new(
+          "rack.input" => "",
+          "REQUEST_METHOD" => "GET",
+          "PATH_INFO" => request_path
+        )
+        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
+      end
+
+      "/news".tap do |request_path|
+        request = ActionDispatch::Request.new(
+          "rack.input" => "",
+          "REQUEST_METHOD" => "GET",
+          "PATH_INFO" => request_path
+        )
+        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/"
+      end
+
+      "/news/index.p2.html".tap do |request_path|
+        request = ActionDispatch::Request.new(
+          "rack.input" => "",
+          "REQUEST_METHOD" => "GET",
+          "PATH_INFO" => request_path
+        )
+        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}news/index.p2.html"
+      end
+
+      "/docs/926.html".tap do |request_path|
+        request = ActionDispatch::Request.new(
+          "rack.input" => "",
+          "REQUEST_METHOD" => "GET",
+          "PATH_INFO" => request_path
+        )
+        expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}docs/926.html"
+      end
     end
   end
 end

--- a/spec/models/cms/canonical_full_url_spec.rb
+++ b/spec/models/cms/canonical_full_url_spec.rb
@@ -106,5 +106,18 @@ describe Cms, type: :model, dbscope: :example do
         end
       end
     end
+
+    context "with ad page" do
+      it do
+        "/ad/page30.html?redirect=/kurashi/".tap do |request_path|
+          request = ActionDispatch::Request.new(
+            "rack.input" => "",
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => request_path
+          )
+          expect(Cms.canonical_full_url(site, request)).to eq "#{site.full_root_url}ad/page30.html?redirect=/kurashi/"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

公開ページに `<link rel="canonical" href="..." />` をセットする修正

## 変更内容

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CMS（記事/イベント/ページ）および広告バナーで、画面に応じた `<link rel="canonical">` を自動出力。
* **バグ修正**
  * `/index.html` や末尾スラッシュ、拡張子付きパスを正規化し、ページネーション/月次/日次/カナ表示でも canonical が期待URLに一致。モバイル表示では非表示を維持。
* **Tests**
  * 生成ジョブと feature spec で canonical の `href` を追加検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->