### PR TITLE
[modify] 1階層のオプションと2階層のオプションとが混在したケース

### DIFF
--- a/app/components/ss/options_for_select_component.rb
+++ b/app/components/ss/options_for_select_component.rb
@@ -23,6 +23,12 @@ class SS::OptionsForSelectComponent < ApplicationComponent
       label = option[1]
       remains = option[2..-1]
 
+      if group.blank?
+        overall_options = [ [ label, *remains ] ]
+        yield group, overall_options
+        next
+      end
+
       same_group_options = grouped_options.select { |option| option[0] == group }
       same_group_options.each { |option| grouped_options.delete(option) }
 

--- a/spec/components/ss/options_for_select_component_spec.rb
+++ b/spec/components/ss/options_for_select_component_spec.rb
@@ -147,4 +147,58 @@ describe SS::OptionsForSelectComponent, type: :component, dbscope: :example do
       end
     end
   end
+
+  context "flat options and 2-layer options mixed" do
+    let(:options) do
+      # name is shuffled but ordered by id
+      [
+        [ "parent1", 1 ],
+        [ "parent2/child1", 2 ],
+        [ "parent2/child2", 3 ],
+        [ "parent3", 4 ],
+        [ "parent4/child3", 5 ],
+        [ "parent4/child4", 6 ],
+        [ "parent5", 7 ],
+      ]
+    end
+    let(:selected) { 5 }
+
+    it do
+      child_elements = subject.children.select { _1.type == Nokogiri::XML::Node::ELEMENT_NODE }
+      expect(child_elements).to have(5).items
+      child_elements[0].tap do |child_element|
+        expect(child_element.name).to eq "option"
+        expect(child_element.text).to eq "parent1"
+        expect(child_element["value"]).to eq "1"
+      end
+      child_elements[1].tap do |child_element|
+        expect(child_element.name).to eq "optgroup"
+        expect(child_element["label"]).to eq "parent2"
+        expect(child_element.css("option")).to have(2).items
+        expect(child_element.css("option")[0].text).to eq "child1"
+        expect(child_element.css("option")[0]["value"]).to eq "2"
+        expect(child_element.css("option")[1].text).to eq "child2"
+        expect(child_element.css("option")[1]["value"]).to eq "3"
+      end
+      child_elements[2].tap do |child_element|
+        expect(child_element.name).to eq "option"
+        expect(child_element.text).to eq "parent3"
+        expect(child_element["value"]).to eq "4"
+      end
+      child_elements[3].tap do |child_element|
+        expect(child_element.name).to eq "optgroup"
+        expect(child_element["label"]).to eq "parent4"
+        expect(child_element.css("option")).to have(2).items
+        expect(child_element.css("option")[0].text).to eq "child3"
+        expect(child_element.css("option")[0]["value"]).to eq "5"
+        expect(child_element.css("option")[1].text).to eq "child4"
+        expect(child_element.css("option")[1]["value"]).to eq "6"
+      end
+      child_elements[4].tap do |child_element|
+        expect(child_element.name).to eq "option"
+        expect(child_element.text).to eq "parent5"
+        expect(child_element["value"]).to eq "7"
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * フラットな選択肢とグループ化された選択肢が混在する場合でも、表示順が正しく保たれるようになりました。
  * 空のグループに対しても、選択肢が適切にまとめて表示されるようになりました。

* **Tests**
  * 混在パターンの選択肢表示について、要素数・並び順・各項目の内容を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->