### PR TITLE
[modify][gws][webmail] メッセージ一覧表示設定の feature spec を拡充 [J090-623]

### DIFF
--- a/spec/features/gws/user_message_display_setting_spec.rb
+++ b/spec/features/gws/user_message_display_setting_spec.rb
@@ -4,6 +4,13 @@ describe "gws_user_message_display_setting", type: :feature, dbscope: :example, 
   let(:site) { gws_site }
   before { login_gws_user }
 
+  # ヘッダ列の画面上の左端座標。flex + order による実際の列順（件名と差出人・宛先の左右）を検証する。
+  def head_field_left(field)
+    page.evaluate_script(
+      "document.querySelector('ul.gws-memos .list-item-head .head .#{field}').getBoundingClientRect().left"
+    )
+  end
+
   context "basic crud" do
     it do
       visit gws_user_message_display_setting_path(site: site)
@@ -52,6 +59,91 @@ describe "gws_user_message_display_setting", type: :feature, dbscope: :example, 
     it "does not show the setting page (403)" do
       login_user user, to: gws_user_message_display_setting_path(site: site)
       expect(page).to have_title("403 Forbidden | SHIRASAGI")
+    end
+  end
+
+  context "memo list column order is reflected by CSS order" do
+    it do
+      # 既定（差出人 → 件名）では差出人が件名より左に並ぶ
+      visit gws_memo_messages_path(site)
+      expect(page).to have_css("ul.gws-memos .list-item-head .head .from")
+      expect(head_field_left("from")).to be < head_field_left("title")
+
+      gws_user.update!(message_list_column_order: "subject_first")
+
+      # subject_first では件名が差出人より左に並ぶ
+      visit gws_memo_messages_path(site)
+      expect(page).to have_css("ul.gws-memos.subject-first .list-item-head .head .title")
+      expect(head_field_left("title")).to be < head_field_left("from")
+    end
+  end
+
+  context "sent box reflects the setting on the to column" do
+    it do
+      gws_user.update!(message_list_column_order: "subject_first")
+
+      # 送信箱は宛先（.to）列。subject_first では件名が宛先より左に並ぶ
+      visit gws_memo_messages_path(site, folder: "INBOX.Sent")
+      expect(page).to have_css("ul.gws-memos.subject-first .list-item-head .head .to")
+      expect(head_field_left("title")).to be < head_field_left("to")
+    end
+  end
+
+  context "revert subject_first to name_first via UI" do
+    before { gws_user.update!(message_list_column_order: "subject_first") }
+
+    it do
+      # 事前状態: 一覧は subject-first
+      visit gws_memo_messages_path(site)
+      expect(page).to have_css("ul.gws-memos.subject-first")
+
+      # 画面操作で name_first に戻す
+      visit gws_user_message_display_setting_path(site: site)
+      click_on I18n.t("ss.links.edit")
+      within "form#item-form" do
+        select I18n.t("ss.options.message_list_column_order.name_first"), from: "item[message_list_column_order]"
+        click_on I18n.t("ss.buttons.save")
+      end
+      wait_for_notice I18n.t("ss.notice.saved")
+
+      gws_user.reload
+      expect(gws_user.message_list_column_order).to eq "name_first"
+
+      # 一覧から subject-first クラスが消える
+      visit gws_memo_messages_path(site)
+      expect(page).to have_css("ul.gws-memos")
+      expect(page).to have_no_css("ul.gws-memos.subject-first")
+    end
+  end
+
+  context "navigation link visibility" do
+    let(:link_label) { I18n.t("modules.addons.ss/message_display_setting") }
+    let(:link_href) { gws_user_message_display_setting_path(site: site) }
+
+    it "shows the setting link in the navi when memo is usable" do
+      visit gws_user_profile_path(site: site)
+      expect(page).to have_link(link_label, href: link_href)
+    end
+
+    context "when memo menu is hidden in site setting" do
+      before { site.update!(menu_memo_state: "hide") }
+
+      it "hides the setting link in the navi" do
+        visit gws_user_profile_path(site: site)
+        expect(page).to have_no_link(link_label, href: link_href)
+      end
+    end
+
+    context "when user has no memo permission" do
+      let(:role) { create :gws_role_portal_user_use, cur_site: site }
+      let(:user) do
+        create :gws_user, name: unique_id, email: unique_email, group_ids: [ site.id ], gws_role_ids: [ role.id ]
+      end
+
+      it "hides the setting link in the navi" do
+        login_user user, to: gws_user_profile_path(site: site)
+        expect(page).to have_no_link(link_label, href: link_href)
+      end
     end
   end
 end

--- a/spec/features/webmail/mails/message_display_setting_spec.rb
+++ b/spec/features/webmail/mails/message_display_setting_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe "webmail_mails message display setting", type: :feature, dbscope: :example, js: true, imap: true do
+  let(:now) { Time.zone.now.change(usec: 0) }
+  let(:user) { webmail_imap }
+  let!(:mail1) { Mail.new(date: now - 20.minutes, from: "from-1@example.jp", to: user.email, subject: "subject-1") }
+
+  before do
+    Timecop.freeze(now - 20.minutes) { webmail_import_mail(user, mail1) }
+    Webmail.imap_pool.disconnect_all
+
+    login_user(user)
+  end
+
+  # ヘッダ列の画面上の左端座標。flex + order による実際の列順（件名と差出人の左右）を検証する。
+  def head_field_left(field)
+    page.evaluate_script(
+      "document.querySelector('ul.webmail-mails .list-item-head .head .#{field}').getBoundingClientRect().left"
+    )
+  end
+
+  context "default (name_first)" do
+    it "does not add subject-first class and shows sender before subject" do
+      visit webmail_mails_path(account: 0)
+
+      expect(page).to have_css("ul.webmail-mails")
+      expect(page).to have_no_css("ul.webmail-mails.subject-first")
+      expect(head_field_left("from")).to be < head_field_left("title")
+    end
+  end
+
+  context "subject_first" do
+    before { user.set(message_list_column_order: "subject_first") }
+
+    it "adds subject-first class and shows subject before sender" do
+      visit webmail_mails_path(account: 0)
+
+      expect(page).to have_css("ul.webmail-mails.subject-first .list-item-head .head .title")
+      expect(head_field_left("title")).to be < head_field_left("from")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
PR #6113（メッセージ一覧で差出人と件名の表示順を選べる個人設定）に対する **feature spec の拡充**です。設定の保存・アクセス制御（404/403）に加え、GWSメモ／ウェブメール両方の一覧で**実際の見た目・挙動**まで検証します。#6113 の共有フィールド `message_list_column_order` はウェブメール一覧にも反映されますが、#6113 のテストは GWS 側のみだったため、その抜けも補完します。#6113 はすでに master にマージ済みのため、本PRは master をベースにしています。

## 追加テスト

### GWSメモ一覧（`spec/features/gws/user_message_display_setting_spec.rb`）
- **列順の見た目検証**: `head_field_left` ヘルパーでヘッダ列の左端座標を取得し、CSS の `flex` + `order` による実際の列順（件名 ⇄ 差出人/宛先の左右）を座標比較で検証。
- 既定（`name_first`）は差出人が件名より左、`subject_first` では件名が差出人より左。
- **送信箱（INBOX.Sent）**: 宛先列（`.to`）に対する `subject_first` の反映。
- **UI往復**: 画面操作で `subject_first` → `name_first` に戻し、保存・永続化と `subject-first` クラス除去を検証。
- **ナビ表示条件**: 設定リンクが memo 利用可なら表示 / memo メニュー非表示なら非表示 / memo 権限なしなら非表示。

### ウェブメール一覧（`spec/features/webmail/mails/message_display_setting_spec.rb`・新規）
- 既定（`name_first`）は `subject-first` クラス非付与かつ差出人が件名より左。
- `subject_first` では `subject-first` クラス付与かつ件名が差出人より左。
- `imap: true` タグのため IMAP テストサーバー（dovecot）が必要。CI で実行されます。

## テスト結果
- GWS: `spec/features/gws/user_message_display_setting_spec.rb` … **10 examples, 0 failures**（ローカル実行で確認）。
- Webmail: `imap: true` のためローカルでは IMAP サーバー未起動により除外。セレクタは実装（[index.html.erb:57](app/views/webmail/mails/index.html.erb#L57) の `subject-first` 修飾子・`.head` 内 `.from`/`.title`）と一致することをコードで確認済み。CI で検証されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * メッセージ一覧の列順（差出人/件名/宛先）について、画面上の表示位置（左右関係）に基づく確認テストを追加しました。
  * Webmailのメッセージ表示設定（件名・差出人の表示順）を、設定変更前後での見た目の切り替わりまで含めて検証するテストを追加しました。
  * メモ表示設定ページへのナビゲーションが、利用可否や権限に応じて適切に表示・非表示になることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->