### PR TITLE
[modify] gws/schedule : add calendar scroller in mobile timelineDay view

### DIFF
--- a/app/assets/javascripts/gws/schedule/lib/calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/calendar.js
@@ -155,7 +155,7 @@ SS.ready(function() {
             return target.prepend($('<span />', { class: "fc-loading" }).text(i18next.t("gws/schedule.errors.resource_error")));
           }
         },
-        viewRender: function(view, element) {
+        viewRender: function(view, _element) {
           $(selector).closest(".calendar-mb-scroller").attr("data-view", view.type);
         },
         eventRender: function(event, element) {

--- a/app/assets/javascripts/gws/schedule/lib/calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/calendar.js
@@ -155,6 +155,9 @@ SS.ready(function() {
             return target.prepend($('<span />', { class: "fc-loading" }).text(i18next.t("gws/schedule.errors.resource_error")));
           }
         },
+        viewRender: function(view, element) {
+          $(selector).closest(".calendar-mb-scroller").attr("data-view", view.type);
+        },
         eventRender: function(event, element) {
           var name = element.find('.fc-title').text();
           var span = $('<span class="fc-event-name"></span>').text(name);

--- a/app/assets/javascripts/gws/schedule/lib/multiple_calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/multiple_calendar.js
@@ -74,7 +74,7 @@ SS.ready(function() {
             maxTime: '22:00'
           }
         },
-        viewRender: function(view, element) {
+        viewRender: function(view, _element) {
           $(selector).closest(".calendar-mb-scroller").attr("data-view", view.type);
         },
       };

--- a/app/assets/javascripts/gws/schedule/lib/multiple_calendar.js
+++ b/app/assets/javascripts/gws/schedule/lib/multiple_calendar.js
@@ -52,7 +52,7 @@ SS.ready(function() {
       Gws_Schedule_Multiple_Calendar.onceRendered = true;
     };
 
-    Gws_Schedule_Multiple_Calendar.defaultParams = function (_selector, _opts) {
+    Gws_Schedule_Multiple_Calendar.defaultParams = function (selector, _opts) {
       return {
         firstDay: 0,
         defaultView: 'basicWeek',
@@ -73,7 +73,10 @@ SS.ready(function() {
             minTime: '08:00',
             maxTime: '22:00'
           }
-        }
+        },
+        viewRender: function(view, element) {
+          $(selector).closest(".calendar-mb-scroller").attr("data-view", view.type);
+        },
       };
     };
 

--- a/app/assets/stylesheets/gws/schedule/_gws.scss
+++ b/app/assets/stylesheets/gws/schedule/_gws.scss
@@ -872,6 +872,40 @@
   }
 }
 
+// multiple calendar (mb scroller)
+.calendar-mb-scroller {
+  @include init.mb {
+    .fc-toolbar {
+      position: sticky;
+      left: 0;
+      width: 443px;
+    }
+    .calendar-multiple-header .header-wrap {
+      position: sticky;
+      left: 5px;
+      width: 420px;
+    }
+    .calendar-attr {
+      float: none;
+      margin-top: 3px;
+      span {
+        margin-left: 0px;
+      }
+    }
+  }
+  &[data-view="timelineDay"] {
+    overflow: auto;
+    .calendar-wrap {
+      min-width: 1200px;
+    }
+    @include init.mb {
+      .calendar-wrap {
+        min-width: 1600px;
+      }
+    }
+  }
+}
+
 // facility calendar
 .calendar.facility .fc-facility {
   display: none;

--- a/app/assets/stylesheets/gws/schedule/_gws.scss
+++ b/app/assets/stylesheets/gws/schedule/_gws.scss
@@ -692,6 +692,14 @@
 }
 // Print View
 .print-preview {
+  .calendar-mb-scroller {
+    overflow: visible;
+    &[data-view="timelineDay"] {
+      .calendar-wrap {
+        min-width: 0;
+      }
+    }
+  }
   .fc-unthemed {
     th,
     td {
@@ -874,6 +882,8 @@
 
 // multiple calendar (mb scroller)
 .calendar-mb-scroller {
+  overflow-x: auto;
+  overflow-y: hidden;
   @include init.mb {
     .fc-toolbar {
       position: sticky;
@@ -886,20 +896,17 @@
       width: 420px;
     }
     .calendar-attr {
-      float: none;
       margin-top: 3px;
+      float: none;
       span {
         margin-left: 0px;
       }
     }
   }
   &[data-view="timelineDay"] {
-    overflow: auto;
     .calendar-wrap {
       min-width: 1200px;
-    }
-    @include init.mb {
-      .calendar-wrap {
+      @include init.mb {
         min-width: 1600px;
       }
     }

--- a/app/views/gws/discussion/todos/index.html.erb
+++ b/app/views/gws/discussion/todos/index.html.erb
@@ -27,5 +27,9 @@
       <%= render template: '_search' %>
     </nav>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/discussion/todos/print.html.erb
+++ b/app/views/gws/discussion/todos/print.html.erb
@@ -26,5 +26,9 @@
   <header>
     <h2><%= @forum.name %></h2>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/notice/calendars/_index.html.erb
+++ b/app/views/gws/notice/calendars/_index.html.erb
@@ -24,6 +24,10 @@
         <%= render template: "_search" %>
       </nav>
     </header>
-    <div id="calendar" class="calendar"></div>
+    <div class="calendar-mb-scroller">
+      <div class="calendar-wrap">
+        <div id="calendar" class="calendar"></div>
+      </div>
+    </div>
   </section>
 </div>

--- a/app/views/gws/notice/calendars/print.html.erb
+++ b/app/views/gws/notice/calendars/print.html.erb
@@ -25,5 +25,9 @@
       <%= @folder.try(:name) || t("gws/notice.all") %>
     </h2>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/portal/portlets/schedule/index.html.erb
+++ b/app/views/gws/portal/portlets/schedule/index.html.erb
@@ -26,41 +26,47 @@
 <% end %>
 
 <div class="main-box gws-schedule-box <%= "with-tabs" if @portal.my_portal? %>">
-  <div class="calendar calendar-controller"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div class="calendar calendar-controller"></div>
 
-  <% @portlet.find_schedule_members(@portal).each_with_index do |item, idx| %>
-    <div class="calendar-multiple-header">
-      <%= link_to gws_public_user_long_name(item.long_name), gws_schedule_user_plans_path(user: item.id), class: "calendar-name" %>
-      <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.id == @cur_user.id %>
-        <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: item.id), class: 'add-plan' %>
-      <% end %>
-      <%= render "gws/schedule/main/calendar_attr", user: item %>
-    </div>
-    <div class="calendar multiple cal-<%= item.id %>"></div>
+      <% @portlet.find_schedule_members(@portal).each_with_index do |item, idx| %>
+        <div class="calendar-multiple-header">
+          <div class="header-wrap">
+            <%= link_to gws_public_user_long_name(item.long_name), gws_schedule_user_plans_path(user: item.id), class: "calendar-name" %>
+            <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.id == @cur_user.id %>
+              <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: item.id), class: 'add-plan' %>
+            <% end %>
+            <%= render "gws/schedule/main/calendar_attr", user: item %>
+          </div>
+        </div>
+        <div class="calendar multiple cal-<%= item.id %>"></div>
 
-    <%
-      calendar_options = {
-        tapMenu: item.id == @cur_user.id,
-        restUrl: gws_schedule_user_plans_path(user: item.id),
-        eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: item.id, format: :json)}?#{search_query}" }],
-        useWorkload: use_workload?,
-        firstDay: @cur_site.schedule_first_day,
-        views: {
-          timelineDay: {
-            minTime: @cur_site.schedule_min_time,
-            maxTime: @cur_site.schedule_max_time
+        <%
+          calendar_options = {
+            tapMenu: item.id == @cur_user.id,
+            restUrl: gws_schedule_user_plans_path(user: item.id),
+            eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: item.id, format: :json)}?#{search_query}" }],
+            useWorkload: use_workload?,
+            firstDay: @cur_site.schedule_first_day,
+            views: {
+              timelineDay: {
+                minTime: @cur_site.schedule_min_time,
+                maxTime: @cur_site.schedule_max_time
+              }
+            }
           }
-        }
-      }
-      if @cur_site.schedule_drag_drop_denied?
-        calendar_options[:eventStartEditable] = false
-      end
-      init_options = params[:calendar] || {}
-    %>
-    <%= jquery do %>
-      $(document).on("gws:calendarInitialized", function() {
-        Gws_Schedule_Multiple_Calendar.render('<%== portlet_selector %> .cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
-      });
-    <% end %>
-  <% end %>
+          if @cur_site.schedule_drag_drop_denied?
+            calendar_options[:eventStartEditable] = false
+          end
+          init_options = params[:calendar] || {}
+        %>
+        <%= jquery do %>
+          $(document).on("gws:calendarInitialized", function() {
+            Gws_Schedule_Multiple_Calendar.render('<%== portlet_selector %> .cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
+          });
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/gws/schedule/custom_group_plans/index.html.erb
+++ b/app/views/gws/schedule/custom_group_plans/index.html.erb
@@ -31,38 +31,44 @@
     <nav><%= render template: '_search' %></nav>
   </header>
 
-  <div class="calendar calendar-controller" id="calendar-controller"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div class="calendar calendar-controller" id="calendar-controller"></div>
 
-  <% @users.each_with_index do |user, idx| %>
-    <div class="calendar-multiple-header">
-      <%= link_to gws_public_user_long_name(user.long_name), gws_schedule_user_plans_path(user: user.id), class: "calendar-name" %>
-      <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && user.id == @cur_user.id %>
-        <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: user.id), class: 'add-plan' %>
-      <% end %>
-      <%= render "gws/schedule/main/calendar_attr", user: user %>
-    </div>
-    <div class="calendar multiple" id="cal-<%= user.id %>"></div>
+      <% @users.each_with_index do |user, idx| %>
+        <div class="calendar-multiple-header">
+          <div class="header-wrap">
+            <%= link_to gws_public_user_long_name(user.long_name), gws_schedule_user_plans_path(user: user.id), class: "calendar-name" %>
+            <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && user.id == @cur_user.id %>
+              <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: user.id), class: 'add-plan' %>
+            <% end %>
+            <%= render "gws/schedule/main/calendar_attr", user: user %>
+          </div>
+        </div>
+        <div class="calendar multiple" id="cal-<%= user.id %>"></div>
 
-    <%
-      calendar_options = {
-        tapMenu: user.id == @cur_user.id,
-        restUrl: url_for(action: :index),
-        eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: user.id, format: :json)}?#{search_query}" }],
-        useWorkload: use_workload?,
-        firstDay: @cur_site.schedule_first_day,
-        views: {
-          timelineDay: {
-            minTime: @cur_site.schedule_min_time,
-            maxTime: @cur_site.schedule_max_time
+        <%
+          calendar_options = {
+            tapMenu: user.id == @cur_user.id,
+            restUrl: url_for(action: :index),
+            eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: user.id, format: :json)}?#{search_query}" }],
+            useWorkload: use_workload?,
+            firstDay: @cur_site.schedule_first_day,
+            views: {
+              timelineDay: {
+                minTime: @cur_site.schedule_min_time,
+                maxTime: @cur_site.schedule_max_time
+              }
+            }
           }
-        }
-      }
-      init_options = params[:calendar] || {}
-    %>
-    <%= jquery do %>
-      $(document).on("gws:calendarInitialized", function() {
-        Gws_Schedule_Multiple_Calendar.render('#cal-<%= user.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
-      });
-    <% end %>
-  <% end %>
+          init_options = params[:calendar] || {}
+        %>
+        <%= jquery do %>
+          $(document).on("gws:calendarInitialized", function() {
+            Gws_Schedule_Multiple_Calendar.render('#cal-<%= user.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
+          });
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/facilities/index.html.erb
+++ b/app/views/gws/schedule/facilities/index.html.erb
@@ -26,50 +26,56 @@
     <nav><%= render 'gws/schedule/facilities/search' %></nav>
   </header>
 
-  <div class="calendar calendar-controller" id="calendar-controller"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div class="calendar calendar-controller" id="calendar-controller"></div>
 
-  <% @items.each_with_index do |item, idx| %>
-    <div class="calendar-multiple-header" id="cal-<%= item.id %>-header">
-      <%= link_to item.name, gws_schedule_facility_plans_path(facility: item.id), class: "calendar-name" %>
+      <% @items.each_with_index do |item, idx| %>
+        <div class="calendar-multiple-header" id="cal-<%= item.id %>-header">
+          <div class="header-wrap">
+            <%= link_to item.name, gws_schedule_facility_plans_path(facility: item.id), class: "calendar-name" %>
 
-      <% if item.approval_check? %>
-        <span class="approval-check"><%= t("gws/facility.views.required_approval") %></span>
-      <% end %>
+            <% if item.approval_check? %>
+              <span class="approval-check"><%= t("gws/facility.views.required_approval") %></span>
+            <% end %>
 
-      <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.reservable?(@cur_user) %>
-        <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_facility_plan_path(facility: item.id), class: 'add-plan' %>
-      <% end %>
+            <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.reservable?(@cur_user) %>
+              <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_facility_plan_path(facility: item.id), class: 'add-plan' %>
+            <% end %>
 
-      <% if item.text.present? %>
-      <span class="calendar-attr calendar-text">
-        <a class="calendar-text-link" href="#"><%= item.t :html %></a>
-        <span class="calendar-text-popup markdown-body" style="display: none;"><%= item.html %></span>
-      </span>
+            <% if item.text.present? %>
+            <span class="calendar-attr calendar-text">
+              <a class="calendar-text-link" href="#"><%= item.t :html %></a>
+              <span class="calendar-text-popup markdown-body" style="display: none;"><%= item.html %></span>
+            </span>
+            <% end %>
+          </div>
+        </div>
+        <div class="calendar multiple facility" id="cal-<%= item.id %>"></div>
+
+        <%
+          calendar_options = {
+            tapMenu: item.reservable?(@cur_user),
+            defaultView: 'timelineDay',
+            header: { left: 'today prev next title reload', right: 'basicWeek timelineDay' },
+            restUrl: gws_schedule_facility_plans_path(facility: item.id),
+            eventSources: [{ url: "#{events_gws_schedule_facility_plans_path(facility: item.id, format: :json)}?#{search_query}" }],
+            firstDay: @cur_site.schedule_first_day,
+            views: {
+              timelineDay: {
+                minTime: @cur_site.facility_min_time,
+                maxTime: @cur_site.facility_max_time
+              }
+            }
+          }
+          init_options = params[:calendar] || {}
+        %>
+        <%= jquery do %>
+          $(document).on("gws:calendarInitialized", function() {
+            Gws_Schedule_Multiple_Calendar.render('#cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
+          });
+        <% end %>
       <% end %>
     </div>
-    <div class="calendar multiple facility" id="cal-<%= item.id %>"></div>
-
-    <%
-      calendar_options = {
-        tapMenu: item.reservable?(@cur_user),
-        defaultView: 'timelineDay',
-        header: { left: 'today prev next title reload', right: 'basicWeek timelineDay' },
-        restUrl: gws_schedule_facility_plans_path(facility: item.id),
-        eventSources: [{ url: "#{events_gws_schedule_facility_plans_path(facility: item.id, format: :json)}?#{search_query}" }],
-        firstDay: @cur_site.schedule_first_day,
-        views: {
-          timelineDay: {
-            minTime: @cur_site.facility_min_time,
-            maxTime: @cur_site.facility_max_time
-          }
-        }
-      }
-      init_options = params[:calendar] || {}
-    %>
-    <%= jquery do %>
-      $(document).on("gws:calendarInitialized", function() {
-        Gws_Schedule_Multiple_Calendar.render('#cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
-      });
-    <% end %>
-  <% end %>
+  </div>
 </section>

--- a/app/views/gws/schedule/facilities/print.html.erb
+++ b/app/views/gws/schedule/facilities/print.html.erb
@@ -26,38 +26,44 @@
     <h2><%= t('gws/schedule.tabs.facility') %></h2>
   </header>
 
-  <div class="calendar calendar-controller" id="calendar-controller"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div class="calendar calendar-controller" id="calendar-controller"></div>
 
-  <% @items.each_with_index do |item, idx| %>
-    <div class="calendar-multiple-header">
-      <%= link_to item.name, gws_schedule_facility_plans_path(facility: item.id), class: "calendar-name" %>
-      <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.reservable?(@cur_user) %>
-        <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_facility_plan_path(facility: item.id), class: 'add-plan' %>
+        <% @items.each_with_index do |item, idx| %>
+        <div class="calendar-multiple-header">
+          <div class="header-wrap">
+            <%= link_to item.name, gws_schedule_facility_plans_path(facility: item.id), class: "calendar-name" %>
+            <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.reservable?(@cur_user) %>
+              <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_facility_plan_path(facility: item.id), class: 'add-plan' %>
+            <% end %>
+          </div>
+        </div>
+        <div class="calendar multiple facility" id="cal-<%= item.id %>"></div>
+
+        <%
+          calendar_options = {
+            tapMenu: item.reservable?(@cur_user),
+            defaultView: 'timelineDay',
+            header: { left: 'today prev next title reload', right: 'basicWeek timelineDay' },
+            restUrl: gws_schedule_facility_plans_path(facility: item.id),
+            eventSources: [{ url: "#{events_gws_schedule_facility_plans_path(facility: item.id, format: :json)}?#{search_query}" }],
+            firstDay: @cur_site.schedule_first_day,
+            views: {
+              timelineDay: {
+                minTime: @cur_site.facility_min_time,
+                maxTime: @cur_site.facility_max_time
+              }
+            }
+          }
+          init_options = params[:calendar] || {}
+        %>
+        <%= jquery do %>
+          $(document).on("gws:calendarInitialized", function() {
+            Gws_Schedule_Multiple_Calendar.render('#cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
+          });
+        <% end %>
       <% end %>
     </div>
-    <div class="calendar multiple facility" id="cal-<%= item.id %>"></div>
-
-    <%
-      calendar_options = {
-        tapMenu: item.reservable?(@cur_user),
-        defaultView: 'timelineDay',
-        header: { left: 'today prev next title reload', right: 'basicWeek timelineDay' },
-        restUrl: gws_schedule_facility_plans_path(facility: item.id),
-        eventSources: [{ url: "#{events_gws_schedule_facility_plans_path(facility: item.id, format: :json)}?#{search_query}" }],
-        firstDay: @cur_site.schedule_first_day,
-        views: {
-          timelineDay: {
-            minTime: @cur_site.facility_min_time,
-            maxTime: @cur_site.facility_max_time
-          }
-        }
-      }
-      init_options = params[:calendar] || {}
-    %>
-    <%= jquery do %>
-      $(document).on("gws:calendarInitialized", function() {
-        Gws_Schedule_Multiple_Calendar.render('#cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
-      });
-    <% end %>
-  <% end %>
+  </div>
 </section>

--- a/app/views/gws/schedule/facility_plans/index.html.erb
+++ b/app/views/gws/schedule/facility_plans/index.html.erb
@@ -32,5 +32,9 @@
       <%= render template: '_search' %>
     </nav>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/facility_plans/print.html.erb
+++ b/app/views/gws/schedule/facility_plans/print.html.erb
@@ -27,5 +27,9 @@
       <%= @facility.try(:name) || gws_public_user_long_name((@user || @cur_user).long_name) %>
     </h2>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/group_plans/index.html.erb
+++ b/app/views/gws/schedule/group_plans/index.html.erb
@@ -28,42 +28,48 @@
     <nav><%= render template: '_search' %></nav>
   </header>
 
-  <div class="calendar calendar-controller" id="calendar-controller"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div class="calendar calendar-controller" id="calendar-controller"></div>
 
-  <% @users.each_with_index do |user, idx| %>
-    <div class="calendar-multiple-header">
-      <%= link_to gws_public_user_long_name(user.long_name), gws_schedule_user_plans_path(user: user.id), class: "calendar-name" %>
-      <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && user.id == @cur_user.id %>
-        <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: user.id), class: 'add-plan' %>
-      <% end %>
-      <%= render "gws/schedule/main/calendar_attr", user: user %>
-    </div>
-    <div class="calendar multiple" id="cal-<%= user.id %>"></div>
+      <% @users.each_with_index do |user, idx| %>
+        <div class="calendar-multiple-header">
+          <div class="header-wrap">
+            <%= link_to gws_public_user_long_name(user.long_name), gws_schedule_user_plans_path(user: user.id), class: "calendar-name" %>
+            <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && user.id == @cur_user.id %>
+              <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: user.id), class: 'add-plan' %>
+            <% end %>
+            <%= render "gws/schedule/main/calendar_attr", user: user %>
+          </div>
+        </div>
+        <div class="calendar multiple" id="cal-<%= user.id %>"></div>
 
-    <%
-      calendar_options = {
-        tapMenu: user.id == @cur_user.id,
-        useWorkload: use_workload?,
-        restUrl: url_for(action: :index),
-        eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: user.id, format: :json)}?#{search_query}" }],
-        firstDay: @cur_site.schedule_first_day,
-        views: {
-          timelineDay: {
-            minTime: @cur_site.schedule_min_time,
-            maxTime: @cur_site.schedule_max_time
+        <%
+          calendar_options = {
+            tapMenu: user.id == @cur_user.id,
+            useWorkload: use_workload?,
+            restUrl: url_for(action: :index),
+            eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: user.id, format: :json)}?#{search_query}" }],
+            firstDay: @cur_site.schedule_first_day,
+            views: {
+              timelineDay: {
+              minTime: @cur_site.schedule_min_time,
+              maxTime: @cur_site.schedule_max_time
+              }
+            }
           }
-        }
-      }
-      if @cur_site.schedule_drag_drop_denied?
-        calendar_options[:eventStartEditable] = false
-      end
+          if @cur_site.schedule_drag_drop_denied?
+            calendar_options[:eventStartEditable] = false
+          end
 
-      init_options = params[:calendar] || {}
-    %>
-    <%= jquery do %>
-      $(document).on("gws:calendarInitialized", function() {
-        Gws_Schedule_Multiple_Calendar.render('#cal-<%= user.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
-      });
-    <% end %>
-  <% end %>
+          init_options = params[:calendar] || {}
+        %>
+        <%= jquery do %>
+          $(document).on("gws:calendarInitialized", function() {
+            Gws_Schedule_Multiple_Calendar.render('#cal-<%= user.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
+          });
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/group_plans/print.html.erb
+++ b/app/views/gws/schedule/group_plans/print.html.erb
@@ -27,35 +27,41 @@
     <h2><%= @group.try(:trailing_name) || @group.name %></h2>
   </header>
 
-  <div class="calendar calendar-controller" id="calendar-controller"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div class="calendar calendar-controller" id="calendar-controller"></div>
 
-  <% @users.each_with_index do |user, idx| %>
-    <div class="calendar-multiple-header">
-      <%= link_to gws_public_user_long_name(user.long_name), gws_schedule_user_plans_path(user: user.id), class: "calendar-name" %>
-      <%= render "gws/schedule/main/calendar_attr", user: user %>
-    </div>
-    <div class="calendar multiple" id="cal-<%= user.id %>"></div>
+      <% @users.each_with_index do |user, idx| %>
+        <div class="calendar-multiple-header">
+          <div class="header-wrap">
+            <%= link_to gws_public_user_long_name(user.long_name), gws_schedule_user_plans_path(user: user.id), class: "calendar-name" %>
+            <%= render "gws/schedule/main/calendar_attr", user: user %>
+          </div>
+        </div>
+        <div class="calendar multiple" id="cal-<%= user.id %>"></div>
 
-    <%
-      calendar_options = {
-        tapMenu: user.id == @cur_user.id,
-        restUrl: url_for(action: :index),
-        eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: user.id, format: :json)}?#{search_query}" }],
-        useWorkload: use_workload?,
-        firstDay: @cur_site.schedule_first_day,
-        views: {
-          timelineDay: {
-            minTime: @cur_site.schedule_min_time,
-            maxTime: @cur_site.schedule_max_time
+        <%
+          calendar_options = {
+            tapMenu: user.id == @cur_user.id,
+            restUrl: url_for(action: :index),
+            eventSources: [{ url: "#{events_gws_schedule_user_plans_path(user: user.id, format: :json)}?#{search_query}" }],
+            useWorkload: use_workload?,
+            firstDay: @cur_site.schedule_first_day,
+            views: {
+              timelineDay: {
+                minTime: @cur_site.schedule_min_time,
+                maxTime: @cur_site.schedule_max_time
+              }
+            }
           }
-        }
-      }
-      init_options = params[:calendar] || {}
-    %>
-    <%= jquery do %>
-      $(document).on("gws:calendarInitialized", function() {
-        Gws_Schedule_Multiple_Calendar.render('#cal-<%= user.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
-      });
-    <% end %>
-  <% end %>
+          init_options = params[:calendar] || {}
+        %>
+        <%= jquery do %>
+          $(document).on("gws:calendarInitialized", function() {
+            Gws_Schedule_Multiple_Calendar.render('#cal-<%= user.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
+          });
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/holidays/index.html.erb
+++ b/app/views/gws/schedule/holidays/index.html.erb
@@ -27,5 +27,9 @@
       <% end %>
     </h2>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/plans/index.html.erb
+++ b/app/views/gws/schedule/plans/index.html.erb
@@ -35,5 +35,9 @@
       <%= render template: '_search' %>
     </nav>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/plans/print.html.erb
+++ b/app/views/gws/schedule/plans/print.html.erb
@@ -28,5 +28,9 @@
       <%= @facility.try(:name) || gws_public_user_long_name((@user || @cur_user).long_name) %>
     </h2>
   </header>
-  <div id="calendar" class="calendar"></div>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <div id="calendar" class="calendar"></div>
+    </div>
+  </div>
 </section>

--- a/app/views/gws/schedule/search/users/index.html.erb
+++ b/app/views/gws/schedule/search/users/index.html.erb
@@ -25,40 +25,46 @@
 <section class="main-box gws-schedule-box gws-schedule-search">
   <%= render "search" %>
 
-  <% if @items.present? %>
-  <div class="gws-schedule-search-hr"></div>
-  <div class="calendar calendar-controller" id="calendar-controller"></div>
-  <% end %>
-
-  <% @items.each_with_index do |item, idx| %>
-    <div class="calendar-multiple-header">
-      <%= link_to gws_public_user_long_name(item.long_name), gws_schedule_user_plans_path(user: item.id), class: "calendar-name" %>
-      <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.id == @cur_user.id %>
-        <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: item.id), class: 'add-plan' %>
+  <div class="calendar-mb-scroller">
+    <div class="calendar-wrap">
+      <% if @items.present? %>
+      <div class="gws-schedule-search-hr"></div>
+      <div class="calendar calendar-controller" id="calendar-controller"></div>
       <% end %>
-      <%= render "gws/schedule/main/calendar_attr", user: item %>
-    </div>
-    <div class="calendar multiple" id="cal-<%= item.id %>"></div>
 
-    <%
-      calendar_options = {
-        tapMenu: item.id == @cur_user.id,
-        restUrl: gws_schedule_user_plans_path(user: item.id),
-        eventSources: [{ url: events_gws_schedule_user_plans_path(user: item.id, format: :json) }],
-        firstDay: @cur_site.schedule_first_day,
-        views: {
-          timelineDay: {
-            minTime: @cur_site.schedule_min_time,
-            maxTime: @cur_site.schedule_max_time
+      <% @items.each_with_index do |item, idx| %>
+        <div class="calendar-multiple-header">
+          <div class="header-wrap">
+            <%= link_to gws_public_user_long_name(item.long_name), gws_schedule_user_plans_path(user: item.id), class: "calendar-name" %>
+            <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && item.id == @cur_user.id %>
+              <%= link_to t('gws/schedule.links.add_plan'), new_gws_schedule_user_plan_path(user: item.id), class: 'add-plan' %>
+            <% end %>
+            <%= render "gws/schedule/main/calendar_attr", user: item %>
+          </div>
+        </div>
+        <div class="calendar multiple" id="cal-<%= item.id %>"></div>
+
+        <%
+          calendar_options = {
+            tapMenu: item.id == @cur_user.id,
+            restUrl: gws_schedule_user_plans_path(user: item.id),
+            eventSources: [{ url: events_gws_schedule_user_plans_path(user: item.id, format: :json) }],
+            firstDay: @cur_site.schedule_first_day,
+            views: {
+              timelineDay: {
+                minTime: @cur_site.schedule_min_time,
+                maxTime: @cur_site.schedule_max_time
+              }
+            }
           }
-        }
-      }
-      init_options = params[:calendar] || {}
-    %>
-    <%= jquery do %>
-      $(document).on("gws:calendarInitialized", function() {
-        Gws_Schedule_Multiple_Calendar.render('#cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
-      });
-    <% end %>
-  <% end %>
+          init_options = params[:calendar] || {}
+        %>
+        <%= jquery do %>
+          $(document).on("gws:calendarInitialized", function() {
+            Gws_Schedule_Multiple_Calendar.render('#cal-<%= item.id %>', <%== calendar_options.to_json %>, <%== init_options.to_json %>);
+          });
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </section>


### PR DESCRIPTION
GWSスケジュールのスマホ表示対応（timelineDay view）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * スマホ向けにカレンダー表示をスクロールしやすいレイアウトへ最適化しました。
  * 複数カレンダー表示でヘッダー／操作バーが追従表示になり、タイムライン表示の幅も調整しました。
* **改善**
  * 予定・施設・グループ・検索・通知など各画面でカレンダーの表示構造を統一しました。
  * 印刷プレビューの見え方も含め、ビュー切替が安定するよう調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->