### PR TITLE
[modify][gws]閲覧一覧の削除ボタンを既読/未読の一括ボタンに置き換え

### DIFF
--- a/app/controllers/gws/board/topics_controller.rb
+++ b/app/controllers/gws/board/topics_controller.rb
@@ -114,6 +114,22 @@ class Gws::Board::TopicsController < ApplicationController
     render template: "print_#{@item.mode}", layout: 'ss/print'
   end
 
+  def set_browsed_all
+    set_selected_items
+    @items.each do |item|
+      item.set_browsed!(@cur_user) unless item.browsed?(@cur_user)
+    end
+    render_confirmed_all(true, notice: t("ss.notice.set_seen_all"))
+  end
+
+  def unset_browsed_all
+    set_selected_items
+    @items.each do |item|
+      item.unset_browsed!(@cur_user) if item.browsed?(@cur_user)
+    end
+    render_confirmed_all(true, notice: t("ss.notice.unset_seen_all"))
+  end
+
   def soft_delete
     set_item unless @item
     raise '403' unless @item.allowed?(:delete, @cur_user, site: @cur_site)

--- a/app/controllers/gws/board/topics_controller.rb
+++ b/app/controllers/gws/board/topics_controller.rb
@@ -69,7 +69,7 @@ class Gws::Board::TopicsController < ApplicationController
 
     params[:s] ||= {}
     params[:s][:user] = @cur_user
-    params[:s][:browsed_state] = (@mode == 'readable' ? 'unread' : 'both') if params[:s][:browsed_state].blank?
+    params[:s][:browsed_state] = 'both' if params[:s][:browsed_state].blank?
 
     set_items
     @items = @items.search(params[:s]).

--- a/app/controllers/gws/board/topics_controller.rb
+++ b/app/controllers/gws/board/topics_controller.rb
@@ -107,6 +107,18 @@ class Gws::Board::TopicsController < ApplicationController
     end
   end
 
+  def unread
+    set_item
+    raise '403' unless readable?
+
+    @item.unset_browsed!(@cur_user) if @item.browsed?(@cur_user)
+
+    respond_to do |format|
+      format.html { redirect_to({ action: :show, toggled: 1 }, { notice: t('ss.notice.saved') }) }
+      format.json { render json: { _id: @item.id }, content_type: json_content_type }
+    end
+  end
+
   def print
     set_item
     raise '403' unless readable?

--- a/app/controllers/gws/board/topics_controller.rb
+++ b/app/controllers/gws/board/topics_controller.rb
@@ -67,9 +67,9 @@ class Gws::Board::TopicsController < ApplicationController
       params[:s][:category] = @category.name
     end
 
-    if params[:s]
-      params[:s][:user] = @cur_user
-    end
+    params[:s] ||= {}
+    params[:s][:user] = @cur_user
+    params[:s][:browsed_state] = (@mode == 'readable' ? 'unread' : 'both') if params[:s][:browsed_state].blank?
 
     set_items
     @items = @items.search(params[:s]).

--- a/app/controllers/gws/faq/topics_controller.rb
+++ b/app/controllers/gws/faq/topics_controller.rb
@@ -51,7 +51,7 @@ class Gws::Faq::TopicsController < ApplicationController
 
     params[:s] ||= {}
     params[:s][:user] = @cur_user
-    params[:s][:browsed_state] = (@mode == 'readable' ? 'unread' : 'both') if params[:s][:browsed_state].blank?
+    params[:s][:browsed_state] = 'both' if params[:s][:browsed_state].blank?
 
     @items = items.search(params[:s]).
       custom_order(params.dig(:s, :sort) || 'updated_desc').

--- a/app/controllers/gws/faq/topics_controller.rb
+++ b/app/controllers/gws/faq/topics_controller.rb
@@ -82,4 +82,32 @@ class Gws::Faq::TopicsController < ApplicationController
       end
     end
   end
+
+  def unread
+    set_item
+    raise '403' unless readable?
+
+    @item.unset_browsed!(@cur_user) if @item.browsed?(@cur_user)
+
+    respond_to do |format|
+      format.html { redirect_to({ action: :show, toggled: 1 }, { notice: t('ss.notice.saved') }) }
+      format.json { render json: { _id: @item.id }, content_type: json_content_type }
+    end
+  end
+
+  def set_browsed_all
+    @items = items.in(id: params[:ids])
+    @items.each do |item|
+      item.set_browsed!(@cur_user) unless item.browsed?(@cur_user)
+    end
+    render_confirmed_all(true, notice: t("ss.notice.set_seen_all"))
+  end
+
+  def unset_browsed_all
+    @items = items.in(id: params[:ids])
+    @items.each do |item|
+      item.unset_browsed!(@cur_user) if item.browsed?(@cur_user)
+    end
+    render_confirmed_all(true, notice: t("ss.notice.unset_seen_all"))
+  end
 end

--- a/app/controllers/gws/faq/topics_controller.rb
+++ b/app/controllers/gws/faq/topics_controller.rb
@@ -49,6 +49,10 @@ class Gws::Faq::TopicsController < ApplicationController
       params[:s][:category] = @category.name
     end
 
+    params[:s] ||= {}
+    params[:s][:user] = @cur_user
+    params[:s][:browsed_state] = (@mode == 'readable' ? 'unread' : 'both') if params[:s][:browsed_state].blank?
+
     @items = items.search(params[:s]).
       custom_order(params.dig(:s, :sort) || 'updated_desc').
       page(params[:page]).per(50)

--- a/app/controllers/gws/notice/readable_filter.rb
+++ b/app/controllers/gws/notice/readable_filter.rb
@@ -93,26 +93,20 @@ module Gws::Notice::ReadableFilter
     render_update false, render: { template: :show, toggled: 1 }
   end
 
-  def toggle_browsed_all
-    ids = params[:ids]
-    if ids
-      ids = ids.map(&:to_i) rescue nil
-    end
-
-    @items = @items.in(id: ids)
+  def set_browsed_all
+    @items = @items.in(id: params[:ids])
     @items.each do |item|
-      next if item.browsed?(@cur_user)
-      begin
-        item.set_browsed!(@cur_user)
-      rescue => e
-        Rails.logger.error("#{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
-      end
+      item.set_browsed!(@cur_user) unless item.browsed?(@cur_user)
     end
+    redirect_to({ action: :index }, notice: t("ss.notice.set_seen_all"))
+  end
 
-    flash[:notice] = I18n.t("ss.notice.set_seen")
-    respond_to do |format|
-      format.html { redirect_to(action: :index) }
+  def unset_browsed_all
+    @items = @items.in(id: params[:ids])
+    @items.each do |item|
+      item.unset_browsed!(@cur_user) if item.browsed?(@cur_user)
     end
+    redirect_to({ action: :index }, notice: t("ss.notice.unset_seen_all"))
   end
 
   def print

--- a/app/controllers/gws/notice/readable_filter.rb
+++ b/app/controllers/gws/notice/readable_filter.rb
@@ -93,6 +93,28 @@ module Gws::Notice::ReadableFilter
     render_update false, render: { template: :show, toggled: 1 }
   end
 
+  def toggle_browsed_all
+    ids = params[:ids]
+    if ids
+      ids = ids.map(&:to_i) rescue nil
+    end
+
+    @items = @items.in(id: ids)
+    @items.each do |item|
+      next if item.browsed?(@cur_user)
+      begin
+        item.set_browsed!(@cur_user)
+      rescue => e
+        Rails.logger.error("#{e.class} (#{e.message}):\n  #{e.backtrace.join("\n  ")}")
+      end
+    end
+
+    flash[:notice] = I18n.t("ss.notice.set_seen")
+    respond_to do |format|
+      format.html { redirect_to(action: :index) }
+    end
+  end
+
   def print
     render template: "print", layout: 'ss/print'
   end

--- a/app/controllers/gws/qna/topics_controller.rb
+++ b/app/controllers/gws/qna/topics_controller.rb
@@ -51,7 +51,7 @@ class Gws::Qna::TopicsController < ApplicationController
 
     params[:s] ||= {}
     params[:s][:user] = @cur_user
-    params[:s][:browsed_state] = (@mode == 'readable' ? 'unread' : 'both') if params[:s][:browsed_state].blank?
+    params[:s][:browsed_state] = 'both' if params[:s][:browsed_state].blank?
 
     @items = items.search(params[:s]).
       custom_order(params.dig(:s, :sort) || 'updated_desc').

--- a/app/controllers/gws/qna/topics_controller.rb
+++ b/app/controllers/gws/qna/topics_controller.rb
@@ -83,6 +83,34 @@ class Gws::Qna::TopicsController < ApplicationController
     end
   end
 
+  def unread
+    set_item
+    raise '403' unless readable?
+
+    @item.unset_browsed!(@cur_user) if @item.browsed?(@cur_user)
+
+    respond_to do |format|
+      format.html { redirect_to({ action: :show, toggled: 1 }, { notice: t('ss.notice.saved') }) }
+      format.json { render json: { _id: @item.id }, content_type: json_content_type }
+    end
+  end
+
+  def set_browsed_all
+    @items = items.in(id: params[:ids])
+    @items.each do |item|
+      item.set_browsed!(@cur_user) unless item.browsed?(@cur_user)
+    end
+    render_confirmed_all(true, notice: t("ss.notice.set_seen_all"))
+  end
+
+  def unset_browsed_all
+    @items = items.in(id: params[:ids])
+    @items.each do |item|
+      item.unset_browsed!(@cur_user) if item.browsed?(@cur_user)
+    end
+    render_confirmed_all(true, notice: t("ss.notice.unset_seen_all"))
+  end
+
   def resolve
     set_item
     raise '403' unless @item.allowed?(:edit, @cur_user, site: @cur_site)

--- a/app/controllers/gws/qna/topics_controller.rb
+++ b/app/controllers/gws/qna/topics_controller.rb
@@ -49,6 +49,10 @@ class Gws::Qna::TopicsController < ApplicationController
       params[:s][:category] = @category.name
     end
 
+    params[:s] ||= {}
+    params[:s][:user] = @cur_user
+    params[:s][:browsed_state] = (@mode == 'readable' ? 'unread' : 'both') if params[:s][:browsed_state].blank?
+
     @items = items.search(params[:s]).
       custom_order(params.dig(:s, :sort) || 'updated_desc').
       page(params[:page]).per(50)

--- a/app/models/concerns/gws/board/browsing_state.rb
+++ b/app/models/concerns/gws/board/browsing_state.rb
@@ -36,7 +36,7 @@ module Gws::Board::BrowsingState
   end
 
   def browsed_state_options
-    %w(unread read).map { |m| [I18n.t("gws/board.options.browsed_state.#{m}"), m] }
+    %w(both unread).map { |m| [I18n.t("gws/board.options.browsed_state.#{m}"), m] }
   end
 
   def browsed_user_ids

--- a/app/models/concerns/gws/board/postable.rb
+++ b/app/models/concerns/gws/board/postable.rb
@@ -79,7 +79,7 @@ module Gws::Board::Postable
     end
 
     def search_browsed_state(params)
-      return all if params.blank? || params[:browsed_state].blank?
+      return all if params.blank? || params[:browsed_state].blank? || params[:browsed_state] == 'both'
 
       case params[:browsed_state]
       when 'read'
@@ -87,7 +87,7 @@ module Gws::Board::Postable
       when 'unread'
         all.exists("browsed_users_hash.#{params[:user].id}" => 0)
       else
-        none
+        all
       end
     end
   end

--- a/app/models/concerns/gws/faq/browsing_state.rb
+++ b/app/models/concerns/gws/faq/browsing_state.rb
@@ -23,4 +23,8 @@ module Gws::Faq::BrowsingState
     # be careful, you must not use `#set` method. this method update hash totally.
     persist_atomic_operations('$unset' => { "browsed_users_hash.#{user.id}" => '' })
   end
+
+  def browsed_state_options
+    %w(both unread).map { |m| [I18n.t("gws/faq.options.browsed_state.#{m}"), m] }
+  end
 end

--- a/app/models/concerns/gws/faq/browsing_state.rb
+++ b/app/models/concerns/gws/faq/browsing_state.rb
@@ -17,4 +17,10 @@ module Gws::Faq::BrowsingState
     # be careful, you must not use `#set` method. this method update hash totally.
     persist_atomic_operations('$set' => { "browsed_users_hash.#{user.id}" => Time.zone.now.utc })
   end
+
+  def unset_browsed!(user)
+    # to update hash partially, use `#persist_atomic_operations` method.
+    # be careful, you must not use `#set` method. this method update hash totally.
+    persist_atomic_operations('$unset' => { "browsed_users_hash.#{user.id}" => '' })
+  end
 end

--- a/app/models/concerns/gws/faq/postable.rb
+++ b/app/models/concerns/gws/faq/postable.rb
@@ -58,6 +58,9 @@ module Gws::Faq::Postable
         category_ids = Gws::Faq::Category.site(params[:site]).and_name_prefix(params[:category]).pluck(:id)
         criteria = criteria.in(category_ids: category_ids)
       end
+      if %w(read unread).include?(params[:browsed_state]) && params[:user].present?
+        criteria = criteria.exists("browsed_users_hash.#{params[:user].id}" => params[:browsed_state] == 'read')
+      end
       criteria
     }
   end

--- a/app/models/concerns/gws/qna/browsing_state.rb
+++ b/app/models/concerns/gws/qna/browsing_state.rb
@@ -23,4 +23,8 @@ module Gws::Qna::BrowsingState
     # be careful, you must not use `#set` method. this method update hash totally.
     persist_atomic_operations('$unset' => { "browsed_users_hash.#{user.id}" => '' })
   end
+
+  def browsed_state_options
+    %w(both unread).map { |m| [I18n.t("gws/qna.options.browsed_state.#{m}"), m] }
+  end
 end

--- a/app/models/concerns/gws/qna/browsing_state.rb
+++ b/app/models/concerns/gws/qna/browsing_state.rb
@@ -17,4 +17,10 @@ module Gws::Qna::BrowsingState
     # be careful, you must not use `#set` method. this method update hash totally.
     persist_atomic_operations('$set' => { "browsed_users_hash.#{user.id}" => Time.zone.now.utc })
   end
+
+  def unset_browsed!(user)
+    # to update hash partially, use `#persist_atomic_operations` method.
+    # be careful, you must not use `#set` method. this method update hash totally.
+    persist_atomic_operations('$unset' => { "browsed_users_hash.#{user.id}" => '' })
+  end
 end

--- a/app/models/concerns/gws/qna/postable.rb
+++ b/app/models/concerns/gws/qna/postable.rb
@@ -61,6 +61,9 @@ module Gws::Qna::Postable
       if params[:question_state].present?
         criteria = criteria.where(question_state: params[:question_state].to_s)
       end
+      if %w(read unread).include?(params[:browsed_state]) && params[:user].present?
+        criteria = criteria.exists("browsed_users_hash.#{params[:user].id}" => params[:browsed_state] == 'read')
+      end
       criteria
     }
   end

--- a/app/views/gws/board/topics/_browsed.html.erb
+++ b/app/views/gws/board/topics/_browsed.html.erb
@@ -1,4 +1,4 @@
-<% if !@item.browsed?(@cur_user) %>
+<% if !@item.browsed?(@cur_user) && params[:toggled].blank? %>
   <%= jquery do %>
     var formatDate = function(browsedAt) {
       var disp = 'YYYY/MM/DD hh:mm';

--- a/app/views/gws/board/topics/_list_head.html.erb
+++ b/app/views/gws/board/topics/_list_head.html.erb
@@ -3,13 +3,18 @@
 
   <div class="list-head-action">
     <%= render template: "_list_head_tags" %>
-    <div class="list-head-action-destroy">
-      <% if @mode == 'trash' %>
-        <%= ss_button_to t("ss.links.delete"), "", class: "destroy-all btn btn-list-head-action", method: "delete", confirm: t('ss.confirm.hard_delete') %>
-      <% else %>
-        <%= ss_button_to t("ss.links.delete"), url_for(action: :soft_delete_all), class: "soft-delete-all btn btn-list-head-action", method: "post", confirm: t('ss.confirm.soft_delete') %>
-      <% end %>
-    </div>
+    <% if @mode == 'readable' %>
+      <%= ss_button_to t('gws/board.topic.unset_browsed'), url_for(action: :unset_browsed_all), class: "btn unset-browsed-all btn-list-head-action", method: "post", confirm: t('gws/board.confirm.unset_browsed_all') %>
+      <%= ss_button_to t('gws/board.topic.set_browsed'), url_for(action: :set_browsed_all), class: "btn set-browsed-all btn-list-head-action", method: "post", confirm: t('gws/board.confirm.set_browsed_all') %>
+    <% else %>
+      <div class="list-head-action-destroy">
+        <% if @mode == 'trash' %>
+          <%= ss_button_to t("ss.links.delete"), "", class: "destroy-all btn btn-list-head-action", method: "delete", confirm: t('ss.confirm.hard_delete') %>
+        <% else %>
+          <%= ss_button_to t("ss.links.delete"), url_for(action: :soft_delete_all), class: "soft-delete-all btn btn-list-head-action", method: "post", confirm: t('ss.confirm.soft_delete') %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 
   <%= render template: "_search" %>

--- a/app/views/gws/board/topics/_menu.html.erb
+++ b/app/views/gws/board/topics/_menu.html.erb
@@ -3,7 +3,7 @@
     <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'trash' %>
       <%= link_to t('ss.links.new'), action: :new %>
     <% end %>
-  <% elsif params[:action] =~ /new|create|lock|categories|destroy_all/ %>
+  <% elsif params[:action] =~ /new|create|lock|categories|destroy_all|browsed_all/ %>
     <%= link_to t('ss.links.back_to_index'), action: :index %>
   <% elsif params[:action] =~ /edit|update|delete|move|soft_delete/ %>
     <% if @item.allowed?(:read, @cur_user, site: @cur_site) %>
@@ -18,7 +18,7 @@
       <% if @mode == 'trash' %>
         <%= link_to t('ss.links.restore'), action: :undo_delete, id: @item %>
         <%= link_to t('ss.links.delete'), action: :delete, id: @item %>
-      <% else %>
+      <% elsif @mode != 'readable' %>
         <%= link_to t('ss.links.delete'), action: :soft_delete, id: @item %>
       <% end %>
     <% end %>

--- a/app/views/gws/board/topics/_menu.html.erb
+++ b/app/views/gws/board/topics/_menu.html.erb
@@ -11,7 +11,7 @@
     <% end %>
     <%= link_to t('ss.links.back_to_index'), action: :index %>
   <% else %>
-    <% if @item.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'trash' && @mode != 'readable' %>
+    <% if @item.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'trash' %>
       <%= link_to t('ss.links.edit'), action: :edit, id: @item %>
     <% end %>
     <% if @item.allowed?(:delete, @cur_user, site: @cur_site) %>

--- a/app/views/gws/board/topics/_menu.html.erb
+++ b/app/views/gws/board/topics/_menu.html.erb
@@ -11,7 +11,7 @@
     <% end %>
     <%= link_to t('ss.links.back_to_index'), action: :index %>
   <% else %>
-    <% if @item.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'trash' %>
+    <% if @item.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'trash' && @mode != 'readable' %>
       <%= link_to t('ss.links.edit'), action: :edit, id: @item %>
     <% end %>
     <% if @item.allowed?(:delete, @cur_user, site: @cur_site) %>

--- a/app/views/gws/board/topics/_menu.html.erb
+++ b/app/views/gws/board/topics/_menu.html.erb
@@ -1,6 +1,6 @@
 <nav class="nav-menu">
   <% if params[:action] =~ /index/ %>
-    <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'trash' %>
+    <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'trash' && @mode != 'readable' %>
       <%= link_to t('ss.links.new'), action: :new %>
     <% end %>
   <% elsif params[:action] =~ /new|create|lock|categories|destroy_all|browsed_all/ %>

--- a/app/views/gws/board/topics/_search.html.erb
+++ b/app/views/gws/board/topics/_search.html.erb
@@ -1,7 +1,7 @@
 <% @s ||= OpenStruct.new params[:s] %>
 <div class="list-head-search">
   <%= form_for :s, url: "", html: { class: "index-search", method: :get } do |f| %>
-    <%= f.select :browsed_state, @model.new.browsed_state_options, { include_blank: t('gws/board.topic.browsed_state') }, { data: { controller: "ss--submit-on-change" } } %>
+    <%= f.select :browsed_state, @model.new.browsed_state_options, {}, { data: { controller: "ss--submit-on-change" } } %>
     <%= f.text_field :keyword, style: "width: 240px;" %>
     <input type="submit" value="<%= t('ss.buttons.search') %>" class="btn" />
   <% end %>

--- a/app/views/gws/board/topics/_show_topic.html.erb
+++ b/app/views/gws/board/topics/_show_topic.html.erb
@@ -47,23 +47,20 @@
       </div>
     <% end %>
 
-    <%
-      show_comment_menu = @item.permit_comment? && (@item.allowed?(:edit, @cur_user, site: @cur_site) || @item.member_include?(@cur_user))
-      show_read_menu = !@item.browsed?(@cur_user)
-    %>
-    <% if show_comment_menu || show_read_menu %>
-      <div class="menu">
-        <% if show_comment_menu %>
-          <%= link_to new_gws_board_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary" do %>
-            <%= md_icons.outlined "reply", size: 15 %>
-            <span class="button-label"><%= t('gws/board.links.comment') %></span>
-          <% end %>
+    <% show_comment_menu = @item.permit_comment? && (@item.allowed?(:edit, @cur_user, site: @cur_site) || @item.member_include?(@cur_user)) %>
+    <div class="menu">
+      <% if show_comment_menu %>
+        <%= link_to new_gws_board_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary" do %>
+          <%= md_icons.outlined "reply", size: 15 %>
+          <span class="button-label"><%= t('gws/board.links.comment') %></span>
         <% end %>
-        <% if show_read_menu %>
-          <%= link_to tag.span(t('gws/board.topic.set_browsed'), class: "button-label"), { action: :read, id: @item }, method: :post, class: "btn" %>
-        <% end %>
-      </div>
-    <% end %>
+      <% end %>
+      <% if @item.browsed?(@cur_user) %>
+        <%= link_to tag.span(t('gws/board.topic.unset_browsed'), class: "button-label"), { action: :unread, id: @item }, method: :post, class: "btn gws-btn-pushed" %>
+      <% else %>
+        <%= link_to tag.span(t('gws/board.topic.set_browsed'), class: "button-label"), { action: :read, id: @item }, method: :post, class: "btn" %>
+      <% end %>
+    </div>
   </div>
 
   <%= yield if block_given? %>

--- a/app/views/gws/board/topics/_show_topic.html.erb
+++ b/app/views/gws/board/topics/_show_topic.html.erb
@@ -47,11 +47,20 @@
       </div>
     <% end %>
 
-    <% if @item.permit_comment? && (@item.allowed?(:edit, @cur_user, site: @cur_site) || @item.member_include?(@cur_user)) %>
+    <%
+      show_comment_menu = @item.permit_comment? && (@item.allowed?(:edit, @cur_user, site: @cur_site) || @item.member_include?(@cur_user))
+      show_read_menu = !@item.browsed?(@cur_user)
+    %>
+    <% if show_comment_menu || show_read_menu %>
       <div class="menu">
-        <%= link_to new_gws_board_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary" do %>
-          <%= md_icons.outlined "reply", size: 15 %>
-          <span class="button-label"><%= t('gws/board.links.comment') %></span>
+        <% if show_comment_menu %>
+          <%= link_to new_gws_board_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary" do %>
+            <%= md_icons.outlined "reply", size: 15 %>
+            <span class="button-label"><%= t('gws/board.links.comment') %></span>
+          <% end %>
+        <% end %>
+        <% if show_read_menu %>
+          <%= link_to tag.span(t('gws/board.topic.set_browsed'), class: "button-label"), { action: :read, id: @item }, method: :post, class: "btn" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/gws/board/topics/index.html.erb
+++ b/app/views/gws/board/topics/index.html.erb
@@ -19,7 +19,7 @@
     <% @items.each do |item| %>
     <%
       css_classes = %w(list-item)
-      css_classes << (item.browsed?(@cur_user) ? 'read' : 'unread')
+      css_classes << 'unread' unless item.browsed?(@cur_user)
       if item.severity.present?
         css_classes << item.severity
       end

--- a/app/views/gws/board/topics/index.html.erb
+++ b/app/views/gws/board/topics/index.html.erb
@@ -52,6 +52,7 @@
         <div class="meta">
           <span class="id">#<%= item.id %></span>
           <span class="datetime"><%= ss_time_tag item.descendants_updated %></span>
+          <span class="seen"><%= item.browsed?(@cur_user) ? t('gws/board.options.browsed_state.read') : t('gws/board.options.browsed_state.unread') %></span>
           <span class="user"><%= gws_public_user_long_name(item.contributor_name.presence || item.user_long_name) %></span>
           <span class="categories">
             <% item.categories.readable(@cur_user, site: @cur_site).each do |category| %>

--- a/app/views/gws/board/topics/index.html.erb
+++ b/app/views/gws/board/topics/index.html.erb
@@ -33,7 +33,7 @@
         <% if @mode == 'trash' %>
           <%= link_to t('ss.links.restore'), action: :undo_delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
           <%= link_to t('ss.links.delete'), action: :delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
-        <% else %>
+        <% elsif @mode != 'readable' %>
           <%= link_to t('ss.links.delete'), action: :soft_delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
         <% end %>
 

--- a/app/views/gws/discussion/forums/_list_head.html.erb
+++ b/app/views/gws/discussion/forums/_list_head.html.erb
@@ -1,5 +1,5 @@
 <div class="list-head">
-  <% if @model.allowed?(:delete, @cur_user, site: @cur_site) %>
+  <% if @model.allowed?(:delete, @cur_user, site: @cur_site) && @mode != 'readable' %>
   <label class="check"><input type="checkbox" /></label>
 
   <div class="list-head-action">

--- a/app/views/gws/discussion/forums/_menu.html.erb
+++ b/app/views/gws/discussion/forums/_menu.html.erb
@@ -1,6 +1,6 @@
 <nav class="nav-menu">
   <% if params[:action] =~ /index/ %>
-    <% if @model.allowed?(:edit, @cur_user, site: @cur_site) %>
+    <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'readable' %>
       <%= link_to t('ss.links.new'), action: :new %>
     <% end %>
   <% elsif params[:action] =~ /new|create|destroy_all/ %>

--- a/app/views/gws/discussion/forums/index.html.erb
+++ b/app/views/gws/discussion/forums/index.html.erb
@@ -7,7 +7,7 @@
   <%= link_to t('ss.links.show'), action: :show, id: item if item.allowed?(:read, @cur_user, site: @cur_site) %>
   <%= link_to t('ss.links.edit'), action: :edit, id: item if item.allowed?(:edit, @cur_user, site: @cur_site) %>
   <%= link_to t('ss.links.copy'), action: :copy, id: item  if item.allowed?(:edit, @cur_user, site: @cur_site) %>
-  <%= link_to t('ss.links.delete'), action: :soft_delete, id: item  if item.allowed?(:delete, @cur_user, site: @cur_site) %>
+  <%= link_to t('ss.links.delete'), action: :soft_delete, id: item  if item.allowed?(:delete, @cur_user, site: @cur_site) && @mode != 'readable' %>
 <% end %>
 
 <%= render template: 'gws/crud/index' %>

--- a/app/views/gws/discussion/forums/index.html.erb
+++ b/app/views/gws/discussion/forums/index.html.erb
@@ -10,4 +10,7 @@
   <%= link_to t('ss.links.delete'), action: :soft_delete, id: item  if item.allowed?(:delete, @cur_user, site: @cur_site) && @mode != 'readable' %>
 <% end %>
 
+<%# 閲覧一覧(readable)では一括操作が無いため行チェックボックスを表示しない %>
+<% @index_check = proc { |item| } if @mode == 'readable' %>
+
 <%= render template: 'gws/crud/index' %>

--- a/app/views/gws/faq/topics/_list_head.html.erb
+++ b/app/views/gws/faq/topics/_list_head.html.erb
@@ -1,7 +1,10 @@
 <% actions = [] %>
 
 <%
-  if @model.allowed?(:delete, @cur_user, site: @cur_site)
+  if @mode == 'readable'
+    actions << ss_button_to(t('gws/faq.topic.unset_browsed'), url_for(action: :unset_browsed_all), class: "btn unset-browsed-all btn-list-head-action", method: "post", confirm: t('gws/faq.confirm.unset_browsed_all'))
+    actions << ss_button_to(t('gws/faq.topic.set_browsed'), url_for(action: :set_browsed_all), class: "btn set-browsed-all btn-list-head-action", method: "post", confirm: t('gws/faq.confirm.set_browsed_all'))
+  elsif @model.allowed?(:delete, @cur_user, site: @cur_site)
     actions << tag.div(class: "list-head-action-destroy") do
       if @mode == 'trash'
         ss_button_to(t("ss.links.delete"), "", class: "destroy-all btn btn-red btn-list-head-action", method: "delete", confirm: t('ss.confirm.hard_delete'))

--- a/app/views/gws/faq/topics/_menu.html.erb
+++ b/app/views/gws/faq/topics/_menu.html.erb
@@ -1,9 +1,9 @@
 <nav class="nav-menu">
   <% if params[:action] =~ /index/ %>
-    <% if @model.allowed?(:edit, @cur_user, site: @cur_site) %>
+    <% if @model.allowed?(:edit, @cur_user, site: @cur_site) && @mode != 'readable' %>
       <%= link_to t('ss.links.new'), action: :new %>
     <% end %>
-  <% elsif params[:action] =~ /new|create|lock|categories|destroy_all/ %>
+  <% elsif params[:action] =~ /new|create|lock|categories|destroy_all|browsed_all/ %>
     <%= link_to t('ss.links.back_to_index'), action: :index %>
   <% elsif params[:action] =~ /edit|update|delete|move/ %>
     <% if @item.allowed?(:read, @cur_user, site: @cur_site) %>
@@ -20,7 +20,7 @@
       <% if @item.allowed?(:edit, @cur_user, site: @cur_site) %>
         <%= link_to t('ss.links.edit'), action: :edit, id: @item %>
       <% end %>
-      <% if @item.allowed?(:delete, @cur_user, site: @cur_site) %>
+      <% if @item.allowed?(:delete, @cur_user, site: @cur_site) && @mode != 'readable' %>
         <%= link_to t('ss.links.delete'), action: :soft_delete, id: @item %>
       <% end %>
     <% end %>

--- a/app/views/gws/faq/topics/_search.html.erb
+++ b/app/views/gws/faq/topics/_search.html.erb
@@ -2,6 +2,7 @@
 <div class="list-head-search">
   <%= form_for :s, url: "", html: { class: "index-search", method: :get } do |f| %>
     <%= f.select :sort, @model.new.sort_options, {}, { data: { controller: "ss--submit-on-change" } } %>
+    <%= f.select :browsed_state, @model.new.browsed_state_options, {}, { data: { controller: "ss--submit-on-change" } } %>
     <%= f.text_field :keyword, style: "width: 300px;" %>
     <input type="submit" value="<%= t('ss.buttons.search') %>" class="btn" />
   <% end %>

--- a/app/views/gws/faq/topics/_subscribed_users.html.erb
+++ b/app/views/gws/faq/topics/_subscribed_users.html.erb
@@ -37,7 +37,7 @@
   </div>
 </div>
 
-<% if subscribed_users.include?(@cur_user) && !@item.browsed?(@cur_user) %>
+<% if subscribed_users.include?(@cur_user) && !@item.browsed?(@cur_user) && params[:toggled].blank? %>
   <%= jquery do %>
     var formatDate = function(browsedAt) {
       var disp = 'YYYY/MM/DD hh:mm';

--- a/app/views/gws/faq/topics/index.html.erb
+++ b/app/views/gws/faq/topics/index.html.erb
@@ -34,7 +34,9 @@
           <%= link_to t('ss.links.delete'), action: :delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
         <% else %>
           <%= link_to t('ss.links.edit'), action: :edit, id: item if item.allowed?(:edit, @cur_user, site: @cur_site) %>
-          <%= link_to t('ss.links.delete'), action: :soft_delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
+          <% if @mode != 'readable' %>
+            <%= link_to t('ss.links.delete'), action: :soft_delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
+          <% end %>
         <% end %>
 
         <% if item.try(:image) %>
@@ -52,6 +54,7 @@
         <div class="meta">
           <span class="id">#<%= item.id %></span>
           <span class="datetime"><%= ss_time_tag item.descendants_updated %></span>
+          <span class="seen"><%= item.browsed?(@cur_user) ? t('gws/faq.options.browsed_state.read') : t('gws/faq.options.browsed_state.unread') %></span>
           <span class="user"><%= gws_public_user_long_name(item.contributor_name.presence || item.user_long_name) %></span>
           <span class="categories">
             <% item.categories.compact.each do |category| %>

--- a/app/views/gws/faq/topics/index.html.erb
+++ b/app/views/gws/faq/topics/index.html.erb
@@ -19,9 +19,7 @@
     <% @items.each do |item| %>
     <%
       css_classes = %w(list-item)
-      if item.subscribed_users.where(id: @cur_user.id).present?
-        css_classes << (item.browsed?(@cur_user) ? 'read' : 'unread')
-      end
+      css_classes << 'unread' unless item.browsed?(@cur_user)
       if item.severity.present?
         css_classes << item.severity
       end

--- a/app/views/gws/faq/topics/show_thread.html.erb
+++ b/app/views/gws/faq/topics/show_thread.html.erb
@@ -43,12 +43,18 @@
     </div>
     <% end %>
 
-    <% if @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
+    <% show_comment_menu = @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
     <div class="menu">
-      <%= link_to(t('gws/faq.links.comment'), new_gws_faq_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id),
-        class: "btn primary") %>
+      <% if show_comment_menu %>
+        <%= link_to(t('gws/faq.links.comment'), new_gws_faq_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id),
+          class: "btn primary") %>
+      <% end %>
+      <% if @item.browsed?(@cur_user) %>
+        <%= link_to tag.span(t('gws/faq.topic.unset_browsed'), class: "button-label"), { action: :unread, id: @item }, method: :post, class: "btn gws-btn-pushed" %>
+      <% else %>
+        <%= link_to tag.span(t('gws/faq.topic.set_browsed'), class: "button-label"), { action: :read, id: @item }, method: :post, class: "btn" %>
+      <% end %>
     </div>
-    <% end %>
   </article>
 
   <% if @item.children.present? %>

--- a/app/views/gws/faq/topics/show_tree.html.erb
+++ b/app/views/gws/faq/topics/show_tree.html.erb
@@ -41,12 +41,18 @@
     </div>
     <% end %>
 
-    <% if @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
+    <% show_comment_menu = @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
     <div class="menu">
-      <%= link_to(t('gws/faq.links.comment'), new_gws_faq_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id),
-        class: "btn primary") %>
+      <% if show_comment_menu %>
+        <%= link_to(t('gws/faq.links.comment'), new_gws_faq_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id),
+          class: "btn primary") %>
+      <% end %>
+      <% if @item.browsed?(@cur_user) %>
+        <%= link_to tag.span(t('gws/faq.topic.unset_browsed'), class: "button-label"), { action: :unread, id: @item }, method: :post, class: "btn gws-btn-pushed" %>
+      <% else %>
+        <%= link_to tag.span(t('gws/faq.topic.set_browsed'), class: "button-label"), { action: :read, id: @item }, method: :post, class: "btn" %>
+      <% end %>
     </div>
-    <% end %>
   </article>
 
   <% if @item.children.present? %>

--- a/app/views/gws/notice/readables/_list_head.html.erb
+++ b/app/views/gws/notice/readables/_list_head.html.erb
@@ -1,11 +1,10 @@
 <div class="list-head">
+  <label class="check"><input type="checkbox" /></label>
+
   <div class="list-head-action">
     <%= render template: "_list_head_tags" %>
+    <%= ss_button_to t("gws/notice.links.set_seen"), { action: :toggle_browsed_all }, class: "set-seen-all btn btn-list-head-action", method: "post", confirm: t("gws/notice.confirm.set_seen") %>
   </div>
 
   <%= render template: "_search" %>
 </div>
-
-<%= jquery do %>
-  $('.list-items .list-item label.check').remove();
-<% end %>

--- a/app/views/gws/notice/readables/_list_head.html.erb
+++ b/app/views/gws/notice/readables/_list_head.html.erb
@@ -3,7 +3,8 @@
 
   <div class="list-head-action">
     <%= render template: "_list_head_tags" %>
-    <%= ss_button_to t("gws/notice.links.set_seen"), { action: :toggle_browsed_all }, class: "set-seen-all btn btn-list-head-action", method: "post", confirm: t("gws/notice.confirm.set_seen") %>
+    <%= ss_button_to t("gws/notice.links.unset_seen"), { action: :unset_browsed_all }, class: "unset-browsed-all btn btn-list-head-action", method: "post", confirm: t("gws/notice.confirm.unset_seen") %>
+    <%= ss_button_to t("gws/notice.links.set_seen"), { action: :set_browsed_all }, class: "set-browsed-all btn btn-list-head-action", method: "post", confirm: t("gws/notice.confirm.set_seen") %>
   </div>
 
   <%= render template: "_search" %>

--- a/app/views/gws/qna/topics/_list_head.html.erb
+++ b/app/views/gws/qna/topics/_list_head.html.erb
@@ -3,13 +3,18 @@
 
   <div class="list-head-action">
     <%= render template: "_list_head_tags" %>
-    <div class="list-head-action-destroy">
-      <% if @mode == 'trash' %>
-        <%= ss_button_to t("ss.links.delete"), "", class: "destroy-all btn btn-list-head-action", method: "delete", confirm: t('ss.confirm.hard_delete') %>
-      <% else %>
-        <%= ss_button_to t("ss.links.delete"), url_for(action: :soft_delete_all), class: "soft-delete-all btn btn-list-head-action", method: "post", confirm: t('ss.confirm.soft_delete') %>
-      <% end %>
-    </div>
+    <% if @mode == 'readable' %>
+      <%= ss_button_to t('gws/qna.topic.unset_browsed'), url_for(action: :unset_browsed_all), class: "btn unset-browsed-all btn-list-head-action", method: "post", confirm: t('gws/qna.confirm.unset_browsed_all') %>
+      <%= ss_button_to t('gws/qna.topic.set_browsed'), url_for(action: :set_browsed_all), class: "btn set-browsed-all btn-list-head-action", method: "post", confirm: t('gws/qna.confirm.set_browsed_all') %>
+    <% else %>
+      <div class="list-head-action-destroy">
+        <% if @mode == 'trash' %>
+          <%= ss_button_to t("ss.links.delete"), "", class: "destroy-all btn btn-list-head-action", method: "delete", confirm: t('ss.confirm.hard_delete') %>
+        <% else %>
+          <%= ss_button_to t("ss.links.delete"), url_for(action: :soft_delete_all), class: "soft-delete-all btn btn-list-head-action", method: "post", confirm: t('ss.confirm.soft_delete') %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 
   <%= render template: "_search" %>

--- a/app/views/gws/qna/topics/_menu.html.erb
+++ b/app/views/gws/qna/topics/_menu.html.erb
@@ -13,12 +13,12 @@
 <% end %>
 <nav class="nav-menu">
   <% if params[:action] =~ /index/ %>
-    <% if @mode != 'trash' %>
+    <% if @mode != 'trash' && @mode != 'readable' %>
       <% if @model.allowed?(:edit, @cur_user, site: @cur_site) %>
         <%= link_to t('ss.links.new'), action: :new %>
       <% end %>
     <% end %>
-  <% elsif params[:action] =~ /new|create|lock|categories|destroy_all/ %>
+  <% elsif params[:action] =~ /new|create|lock|categories|destroy_all|browsed_all/ %>
     <%= link_to t('ss.links.back_to_index'), action: :index %>
   <% elsif params[:action] =~ /edit|update|delete|move/ %>
     <% if @item.allowed?(:read, @cur_user, site: @cur_site) %>
@@ -35,7 +35,7 @@
       <% if @item.allowed?(:edit, @cur_user, site: @cur_site) %>
         <%= link_to t('ss.links.edit'), action: :edit, id: @item %>
       <% end %>
-      <% if @item.allowed?(:delete, @cur_user, site: @cur_site) %>
+      <% if @item.allowed?(:delete, @cur_user, site: @cur_site) && @mode != 'readable' %>
         <%= link_to t('ss.links.delete'), action: :soft_delete, id: @item %>
       <% end %>
       <% if @item.allowed?(:edit, @cur_user, site: @cur_site) %>

--- a/app/views/gws/qna/topics/_search.html.erb
+++ b/app/views/gws/qna/topics/_search.html.erb
@@ -2,6 +2,7 @@
 <div class="list-head-search">
   <%= form_for :s, url: "", html: { class: "index-search", method: :get } do |f| %>
     <%= f.select :sort, @model.new.sort_options, {}, { data: { controller: "ss--submit-on-change" } } %>
+    <%= f.select :browsed_state, @model.new.browsed_state_options, {}, { data: { controller: "ss--submit-on-change" } } %>
     <%= f.text_field :keyword, style: "width: 250px;" %>
     <%= f.select :question_state, @model.new.question_state_options, { include_blank: @model.t(:question_state) }, { data: { controller: "ss--submit-on-change" } } %>
     <input type="submit" value="<%= t('ss.buttons.search') %>" class="btn" />

--- a/app/views/gws/qna/topics/_subscribed_users.html.erb
+++ b/app/views/gws/qna/topics/_subscribed_users.html.erb
@@ -37,7 +37,7 @@
   </div>
 </div>
 
-<% if subscribed_users.include?(@cur_user) && !@item.browsed?(@cur_user) %>
+<% if subscribed_users.include?(@cur_user) && !@item.browsed?(@cur_user) && params[:toggled].blank? %>
   <%= jquery do %>
     var formatDate = function(browsedAt) {
       var disp = 'YYYY/MM/DD hh:mm';

--- a/app/views/gws/qna/topics/index.html.erb
+++ b/app/views/gws/qna/topics/index.html.erb
@@ -34,7 +34,9 @@
           <%= link_to t('ss.links.delete'), action: :delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
         <% else %>
           <%= link_to t('ss.links.edit'), action: :edit, id: item if item.allowed?(:edit, @cur_user, site: @cur_site) %>
-          <%= link_to t('ss.links.delete'), action: :soft_delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
+          <% if @mode != 'readable' %>
+            <%= link_to t('ss.links.delete'), action: :soft_delete, id: item if item.allowed?(:delete, @cur_user, site: @cur_site) %>
+          <% end %>
         <% end %>
 
         <% if item.try(:image) %>
@@ -52,6 +54,7 @@
         <div class="meta">
           <span class="id">#<%= item.id %></span>
           <span class="datetime"><%= ss_time_tag item.descendants_updated %></span>
+          <span class="seen"><%= item.browsed?(@cur_user) ? t('gws/qna.options.browsed_state.read') : t('gws/qna.options.browsed_state.unread') %></span>
           <span class="user"><%= gws_public_user_long_name(item.contributor_name.presence || item.user_long_name) %></span>
           <span class="categories">
             <% item.categories.compact.each do |category| %>

--- a/app/views/gws/qna/topics/index.html.erb
+++ b/app/views/gws/qna/topics/index.html.erb
@@ -19,9 +19,7 @@
     <% @items.each do |item| %>
     <%
       css_classes = %w(list-item)
-      if item.subscribed_users.where(id: @cur_user.id).present?
-        css_classes << (item.browsed?(@cur_user) ? 'read' : 'unread')
-      end
+      css_classes << 'unread' unless item.browsed?(@cur_user)
       if item.severity.present?
         css_classes << item.severity
       end

--- a/app/views/gws/qna/topics/show_thread.html.erb
+++ b/app/views/gws/qna/topics/show_thread.html.erb
@@ -46,14 +46,20 @@
     </div>
     <% end %>
 
-    <% if !@item.resolved? && @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
+    <% show_comment_menu = !@item.resolved? && @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
     <div class="menu">
-      <%= link_to(new_gws_qna_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary") do %>
-        <%= md_icons.outlined "reply", size: 15 %>
-        <span class="button-label"><%= t('gws/qna.links.comment') %></span>
+      <% if show_comment_menu %>
+        <%= link_to(new_gws_qna_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary") do %>
+          <%= md_icons.outlined "reply", size: 15 %>
+          <span class="button-label"><%= t('gws/qna.links.comment') %></span>
+        <% end %>
+      <% end %>
+      <% if @item.browsed?(@cur_user) %>
+        <%= link_to tag.span(t('gws/qna.topic.unset_browsed'), class: "button-label"), { action: :unread, id: @item }, method: :post, class: "btn gws-btn-pushed" %>
+      <% else %>
+        <%= link_to tag.span(t('gws/qna.topic.set_browsed'), class: "button-label"), { action: :read, id: @item }, method: :post, class: "btn" %>
       <% end %>
     </div>
-    <% end %>
 
     <% if @item.children.present? %>
       <div class="comments">

--- a/app/views/gws/qna/topics/show_tree.html.erb
+++ b/app/views/gws/qna/topics/show_tree.html.erb
@@ -44,14 +44,20 @@
     </div>
     <% end %>
 
-    <% if !@item.resolved? && @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
+    <% show_comment_menu = !@item.resolved? && @item.permit_comment? && @model.allowed?(:edit, @cur_user, site: @cur_site) %>
     <div class="menu">
-      <%= link_to(new_gws_qna_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary") do %>
-        <%= md_icons.outlined "reply", size: 15 %>
-        <span class="button-label"><%= t('gws/qna.links.comment') %></span>
+      <% if show_comment_menu %>
+        <%= link_to(new_gws_qna_topic_parent_comment_path(topic_id: @item.id, parent_id: @item.id), class: "btn primary") do %>
+          <%= md_icons.outlined "reply", size: 15 %>
+          <span class="button-label"><%= t('gws/qna.links.comment') %></span>
+        <% end %>
+      <% end %>
+      <% if @item.browsed?(@cur_user) %>
+        <%= link_to tag.span(t('gws/qna.topic.unset_browsed'), class: "button-label"), { action: :unread, id: @item }, method: :post, class: "btn gws-btn-pushed" %>
+      <% else %>
+        <%= link_to tag.span(t('gws/qna.topic.set_browsed'), class: "button-label"), { action: :read, id: @item }, method: :post, class: "btn" %>
       <% end %>
     </div>
-    <% end %>
 
     <% if @item.children.present? %>
       <div class="comments">

--- a/config/locales/gws/board/en.yml
+++ b/config/locales/gws/board/en.yml
@@ -4,6 +4,9 @@ en:
     #descendants_num: No. of comments
     #descendants_updated: Time and date updated
     no_authority: You do not have permission.
+    confirm:
+      set_browsed_all: Do you want to mark all selected items as read?
+      unset_browsed_all: Do you want to return all selected items to unread?
     topic:
       comment: Comments
       new: Create new
@@ -14,6 +17,8 @@ en:
       browsing_state: Notification destination
       browsed_state: Status
       browsed: View
+      set_browsed: Mark as read
+      unset_browsed: Mark as unread
       list: To topic list
       confirm: Do you want to delete this?
       browsed_user_info:

--- a/config/locales/gws/board/ja.yml
+++ b/config/locales/gws/board/ja.yml
@@ -4,6 +4,9 @@ ja:
     #descendants_num: コメント数
     #descendants_updated: 更新日時
     no_authority: 権限がありません
+    confirm:
+      set_browsed_all: 選択した項目を全て既読にしますか？
+      unset_browsed_all: 選択した項目を全て未読に戻しますか？
     topic:
       comment: コメント
       new: 新規作成
@@ -14,6 +17,8 @@ ja:
       browsing_state: 通知先
       browsed_state: 状態
       browsed: 閲覧
+      set_browsed: 既読にする
+      unset_browsed: 未読にする
       list: トピック一覧へ
       confirm: 削除しますか？
       browsed_user_info:

--- a/config/locales/gws/faq/en.yml
+++ b/config/locales/gws/faq/en.yml
@@ -4,6 +4,9 @@ en:
     #descendants_num: No. of comments
     #descendants_updated: Time and date updated
     no_authority: You do not have permission.
+    confirm:
+      set_browsed_all: Do you want to mark all selected items as read?
+      unset_browsed_all: Do you want to return all selected items to unread?
     topic:
       comment: Comments
       new: Create new
@@ -13,6 +16,8 @@ en:
       delete: Delete
       browsing_state: Notification destination
       browsed: View
+      set_browsed: Mark as read
+      unset_browsed: Mark as unread
       list: To topic list
       confirm: Do you want to delete this?
       notice:

--- a/config/locales/gws/faq/en.yml
+++ b/config/locales/gws/faq/en.yml
@@ -47,6 +47,7 @@ en:
       browsed_state:
         read: Read
         unread: Unread
+        both: All
       severity:
         normal: Normal
         important: Important

--- a/config/locales/gws/faq/ja.yml
+++ b/config/locales/gws/faq/ja.yml
@@ -4,6 +4,9 @@ ja:
     #descendants_num: コメント数
     #descendants_updated: 更新日時
     no_authority: 権限がありません
+    confirm:
+      set_browsed_all: 選択した項目を全て既読にしますか？
+      unset_browsed_all: 選択した項目を全て未読に戻しますか？
     topic:
       comment: コメント
       new: 新規作成
@@ -13,6 +16,8 @@ ja:
       delete: 削除
       browsing_state: 通知先
       browsed: 閲覧
+      set_browsed: 既読にする
+      unset_browsed: 未読にする
       list: トピック一覧へ
       confirm: 削除しますか？
       notice:

--- a/config/locales/gws/faq/ja.yml
+++ b/config/locales/gws/faq/ja.yml
@@ -47,6 +47,7 @@ ja:
       browsed_state:
         read: 既読
         unread: 未読
+        both: 全て表示
       severity:
         normal: 通常
         important: 重要

--- a/config/locales/gws/qna/en.yml
+++ b/config/locales/gws/qna/en.yml
@@ -44,6 +44,7 @@ en:
       browsed_state:
         read: Read
         unread: Unread
+        both: All
       severity:
         normal: Normal
         important: Important

--- a/config/locales/gws/qna/en.yml
+++ b/config/locales/gws/qna/en.yml
@@ -13,6 +13,8 @@ en:
       delete: Delete
       browsing_state: Notification destination
       browsed: View
+      set_browsed: Mark as read
+      unset_browsed: Mark as unread
       list: To topic list
       confirm: Do you want to delete this?
       notice:
@@ -57,6 +59,8 @@ en:
     confirm:
       resolve: Are you sure you want to mark it as resolved?
       unresolve: Are you sure you want to revert it to unresolved?
+      set_browsed_all: Do you want to mark all selected items as read?
+      unset_browsed_all: Do you want to return all selected items to unread?
     errors:
       denied_comment: You are not allowed to post comments.
 

--- a/config/locales/gws/qna/ja.yml
+++ b/config/locales/gws/qna/ja.yml
@@ -44,6 +44,7 @@ ja:
       browsed_state:
         read: 既読
         unread: 未読
+        both: 全て表示
       severity:
         normal: 通常
         important: 重要

--- a/config/locales/gws/qna/ja.yml
+++ b/config/locales/gws/qna/ja.yml
@@ -13,6 +13,8 @@ ja:
       delete: 削除
       browsing_state: 通知先
       browsed: 閲覧
+      set_browsed: 既読にする
+      unset_browsed: 未読にする
       list: トピック一覧へ
       confirm: 削除しますか？
       notice:
@@ -57,6 +59,8 @@ ja:
     confirm:
       resolve: 解決済みにしてよろしいですか？
       unresolve: 未解決に戻してよろしいですか？
+      set_browsed_all: 選択した項目を全て既読にしますか？
+      unset_browsed_all: 選択した項目を全て未読に戻しますか？
     errors:
       denied_comment: コメントの投稿は許可されていません。
 

--- a/config/routes/gws/board/routes.rb
+++ b/config/routes/gws/board/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
         match :soft_delete, on: :member, via: %i[get post]
         match :undo_delete, on: :member, via: %i[get post]
         post :soft_delete_all, on: :collection
+        post :set_browsed_all, on: :collection
+        post :unset_browsed_all, on: :collection
       end
     end
 

--- a/config/routes/gws/board/routes.rb
+++ b/config/routes/gws/board/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         get :categories, on: :collection
         get :print, on: :member
         post :read, on: :member
+        post :unread, on: :member
         match :soft_delete, on: :member, via: %i[get post]
         match :undo_delete, on: :member, via: %i[get post]
         post :soft_delete_all, on: :collection

--- a/config/routes/gws/faq/routes.rb
+++ b/config/routes/gws/faq/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
         end
         get :categories, on: :collection
         post :read, on: :member
+        post :unread, on: :member
+        post :set_browsed_all, on: :collection
+        post :unset_browsed_all, on: :collection
         match :soft_delete, on: :member, via: %i[get post]
         match :undo_delete, on: :member, via: %i[get post]
         post :soft_delete_all, on: :collection

--- a/config/routes/gws/notice/routes.rb
+++ b/config/routes/gws/notice/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     scope path: ':folder_id/:category_id' do
       resources :readables, only: [:index, :show] do
         post :toggle_browsed, on: :member
+        post :toggle_browsed_all, on: :collection
         get :print, on: :member
       end
       resources :back_numbers, only: [:index, :show] do

--- a/config/routes/gws/notice/routes.rb
+++ b/config/routes/gws/notice/routes.rb
@@ -17,7 +17,8 @@ Rails.application.routes.draw do
     scope path: ':folder_id/:category_id' do
       resources :readables, only: [:index, :show] do
         post :toggle_browsed, on: :member
-        post :toggle_browsed_all, on: :collection
+        post :set_browsed_all, on: :collection
+        post :unset_browsed_all, on: :collection
         get :print, on: :member
       end
       resources :back_numbers, only: [:index, :show] do

--- a/config/routes/gws/notice/routes.rb
+++ b/config/routes/gws/notice/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
       end
       resources :back_numbers, only: [:index, :show] do
         post :toggle_browsed, on: :member
+        post :set_browsed_all, on: :collection
+        post :unset_browsed_all, on: :collection
         get :print, on: :member
       end
       resources :calendars, only: [:index, :show] do

--- a/config/routes/gws/qna/routes.rb
+++ b/config/routes/gws/qna/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
         end
         get :categories, on: :collection
         post :read, on: :member
+        post :unread, on: :member
+        post :set_browsed_all, on: :collection
+        post :unset_browsed_all, on: :collection
         get :resolve, on: :member, to: ->(_) { [200, {}, ['']] }
         post :resolve, on: :member
         get :unresolve, on: :member, to: ->(_) { [200, {}, ['']] }

--- a/spec/features/gws/board/topics/basic_crud_spec.rb
+++ b/spec/features/gws/board/topics/basic_crud_spec.rb
@@ -142,7 +142,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
 
       describe "#soft_delete" do
         it do
-          visit index_path
+          # 削除ボタンは閲覧一覧(readable)から除去したため、管理一覧(editable)で操作する
+          visit gws_board_topics_path(site, 'editable', '-')
           click_on item.name
           within ".nav-menu" do
             click_on I18n.t("ss.links.delete")

--- a/spec/features/gws/board/topics/basic_crud_spec.rb
+++ b/spec/features/gws/board/topics/basic_crud_spec.rb
@@ -28,7 +28,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
     describe "#new" do
       it do
         Timecop.freeze(now) do
-          visit index_path
+          # 新規作成は閲覧一覧(readable)から除去したため、管理一覧(editable)で作成する
+          visit gws_board_topics_path(site, 'editable', '-')
           click_on I18n.t("ss.links.new")
           wait_for_cbox_opened { click_on I18n.t("gws.apis.categories.index") }
           within_cbox do

--- a/spec/features/gws/board/topics/basic_crud_spec.rb
+++ b/spec/features/gws/board/topics/basic_crud_spec.rb
@@ -270,7 +270,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example do
 
       describe "#soft_delete_all" do
         it do
-          visit index_path
+          # 削除ボタンは閲覧一覧(readable)から除去したため、管理一覧(editable)で操作する
+          visit gws_board_topics_path(site, 'editable', '-')
           within ".list-items" do
             first("input[value='#{item.id}']").click
           end

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -33,6 +33,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       within ".list-head" do
         expect(page).to have_css(".soft-delete-all")
         expect(page).to have_no_css(".set-browsed-all")
+        expect(page).to have_no_css(".unset-browsed-all")
       end
     end
   end

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -83,6 +83,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
 
       within ".nav-menu" do
         expect(page).to have_no_link I18n.t("ss.links.delete")
+        expect(page).to have_no_link I18n.t("ss.links.edit")
       end
       expect(page).to have_link I18n.t("gws/board.topic.set_browsed")
 
@@ -96,6 +97,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       click_on item.name
       within ".nav-menu" do
         expect(page).to have_link I18n.t("ss.links.delete")
+        expect(page).to have_link I18n.t("ss.links.edit")
       end
     end
   end

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
+  let(:site) { gws_site }
+  let!(:category) { create :gws_board_category }
+  let!(:item) { create :gws_board_topic, category_ids: [ category.id ] }
+  let(:readable_path) { gws_board_topics_path site, '-', '-' }
+  let(:editable_path) { gws_board_topics_path site, 'editable', '-' }
+
+  before { login_gws_user }
+
+  context "閲覧一覧(readable)" do
+    it "削除ボタンを表示せず、既読/未読の一括ボタンを表示する" do
+      visit readable_path
+      within ".list-head" do
+        expect(page).to have_no_css(".soft-delete-all")
+        expect(page).to have_css(".set-browsed-all")
+        expect(page).to have_css(".unset-browsed-all")
+      end
+      within ".list-items" do
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+      end
+    end
+  end
+
+  context "管理一覧(editable)" do
+    it "従来どおり削除ボタンを表示し、既読/未読ボタンは表示しない" do
+      visit editable_path
+      within ".list-head" do
+        expect(page).to have_css(".soft-delete-all")
+        expect(page).to have_no_css(".set-browsed-all")
+      end
+    end
+  end
+
+  context "#set_browsed_all / #unset_browsed_all" do
+    it "選択した項目を一括で既読/未読にできる" do
+      visit readable_path
+      expect(item.browsed?(gws_user)).to be_falsey
+
+      within ".list-items" do
+        first("input[value='#{item.id}']").click
+      end
+      within ".list-head" do
+        page.accept_confirm do
+          click_on I18n.t("gws/board.topic.set_browsed")
+        end
+      end
+      wait_for_notice I18n.t("ss.notice.set_seen_all")
+      expect(item.reload.browsed?(gws_user)).to be_truthy
+
+      within ".list-items" do
+        first("input[value='#{item.id}']").click
+      end
+      within ".list-head" do
+        page.accept_confirm do
+          click_on I18n.t("gws/board.topic.unset_browsed")
+        end
+      end
+      wait_for_notice I18n.t("ss.notice.unset_seen_all")
+      expect(item.reload.browsed?(gws_user)).to be_falsey
+    end
+  end
+end

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -76,12 +76,12 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
   end
 
   context "未読/全て表示フィルタ" do
-    it "既定は未読のみ表示。既読にすると既定一覧から消え、全て表示で再表示される" do
+    it "既定は全て表示。未読で絞り込むと既読は消える" do
       item.set_browsed!(gws_user)
       visit readable_path
-      expect(page).to have_no_css(".list-item")
-      visit "#{readable_path}?s[browsed_state]=both"
       expect(page).to have_css(".list-item", text: item.name)
+      visit "#{readable_path}?s[browsed_state]=unread"
+      expect(page).to have_no_css(".list-item")
     end
   end
 

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -19,6 +19,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       end
       within ".list-items" do
         expect(page).to have_no_link I18n.t("ss.links.delete")
+        # メタ情報に既読/未読ラベルを表示する（初期状態は未読）
+        expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/board.options.browsed_state.unread"))
       end
     end
   end
@@ -48,6 +50,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t("ss.notice.set_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_truthy
+      within ".list-items" do
+        expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/board.options.browsed_state.read"))
+      end
 
       within ".list-items" do
         first("input[value='#{item.id}']").click
@@ -59,6 +64,39 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t("ss.notice.unset_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_falsey
+      within ".list-items" do
+        expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/board.options.browsed_state.unread"))
+      end
+    end
+  end
+
+  context "詳細画面(show)" do
+    before do
+      # 自動既読タイマーがテスト中に発火しないよう遅延を大きくする
+      site.set(board_browsed_delay: 3600)
+    end
+
+    it "閲覧一覧経由の詳細に既読ボタンがあり削除ボタンが無い。既読にできる" do
+      expect(item.browsed?(gws_user)).to be_falsey
+      visit readable_path
+      click_on item.name
+
+      within ".nav-menu" do
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+      end
+      expect(page).to have_link I18n.t("gws/board.topic.set_browsed")
+
+      click_on I18n.t("gws/board.topic.set_browsed")
+      wait_for_notice I18n.t("ss.notice.saved")
+      expect(item.reload.browsed?(gws_user)).to be_truthy
+    end
+
+    it "管理一覧経由の詳細には削除ボタンがある" do
+      visit editable_path
+      click_on item.name
+      within ".nav-menu" do
+        expect(page).to have_link I18n.t("ss.links.delete")
+      end
     end
   end
 end

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -76,7 +76,7 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       site.set(board_browsed_delay: 3600)
     end
 
-    it "閲覧一覧経由の詳細は削除ボタンが無く編集ボタンは残る。既読ボタンで既読にできる" do
+    it "閲覧一覧経由の詳細は削除ボタンが無く編集ボタンは残る。既読/未読を切り替えられる" do
       expect(item.browsed?(gws_user)).to be_falsey
       visit readable_path
       click_on item.name
@@ -85,11 +85,19 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
         expect(page).to have_no_link I18n.t("ss.links.delete")
         expect(page).to have_link I18n.t("ss.links.edit")
       end
-      expect(page).to have_link I18n.t("gws/board.topic.set_browsed")
 
+      # 未読 → 「既読にする」を押すと既読になる
+      expect(page).to have_link I18n.t("gws/board.topic.set_browsed")
       click_on I18n.t("gws/board.topic.set_browsed")
       wait_for_notice I18n.t("ss.notice.saved")
       expect(item.reload.browsed?(gws_user)).to be_truthy
+
+      # 既読 → ボタンが「未読にする」に変わり、押すと未読に戻る（トグル）
+      expect(page).to have_link I18n.t("gws/board.topic.unset_browsed")
+      click_on I18n.t("gws/board.topic.unset_browsed")
+      wait_for_notice I18n.t("ss.notice.saved")
+      expect(item.reload.browsed?(gws_user)).to be_falsey
+      expect(page).to have_link I18n.t("gws/board.topic.set_browsed")
     end
 
     it "管理一覧経由の詳細には削除ボタンがある" do

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -76,14 +76,14 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       site.set(board_browsed_delay: 3600)
     end
 
-    it "閲覧一覧経由の詳細に既読ボタンがあり削除ボタンが無い。既読にできる" do
+    it "閲覧一覧経由の詳細は削除ボタンが無く編集ボタンは残る。既読ボタンで既読にできる" do
       expect(item.browsed?(gws_user)).to be_falsey
       visit readable_path
       click_on item.name
 
       within ".nav-menu" do
         expect(page).to have_no_link I18n.t("ss.links.delete")
-        expect(page).to have_no_link I18n.t("ss.links.edit")
+        expect(page).to have_link I18n.t("ss.links.edit")
       end
       expect(page).to have_link I18n.t("gws/board.topic.set_browsed")
 
@@ -97,7 +97,6 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       click_on item.name
       within ".nav-menu" do
         expect(page).to have_link I18n.t("ss.links.delete")
-        expect(page).to have_link I18n.t("ss.links.edit")
       end
     end
   end

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -37,7 +37,9 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
 
   context "#set_browsed_all / #unset_browsed_all" do
     it "選択した項目を一括で既読/未読にできる" do
-      visit readable_path
+      # 既定は未読のみ表示。既読済みも扱うため全て表示で開く
+      both_path = "#{readable_path}?s[browsed_state]=both"
+      visit both_path
       expect(item.browsed?(gws_user)).to be_falsey
 
       within ".list-items" do
@@ -50,11 +52,10 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t("ss.notice.set_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_truthy
+
+      visit both_path
       within ".list-items" do
         expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/board.options.browsed_state.read"))
-      end
-
-      within ".list-items" do
         first("input[value='#{item.id}']").click
       end
       within ".list-head" do
@@ -64,9 +65,21 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t("ss.notice.unset_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_falsey
+
+      visit both_path
       within ".list-items" do
         expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/board.options.browsed_state.unread"))
       end
+    end
+  end
+
+  context "未読/全て表示フィルタ" do
+    it "既定は未読のみ表示。既読にすると既定一覧から消え、全て表示で再表示される" do
+      item.set_browsed!(gws_user)
+      visit readable_path
+      expect(page).to have_no_css(".list-item")
+      visit "#{readable_path}?s[browsed_state]=both"
+      expect(page).to have_css(".list-item", text: item.name)
     end
   end
 

--- a/spec/features/gws/board/topics/browsed_all_spec.rb
+++ b/spec/features/gws/board/topics/browsed_all_spec.rb
@@ -19,6 +19,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
       end
       within ".list-items" do
         expect(page).to have_no_link I18n.t("ss.links.delete")
+        # 未読の項目には unread クラスが付く
+        expect(page).to have_css(".list-item.unread")
         # メタ情報に既読/未読ラベルを表示する（初期状態は未読）
         expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/board.options.browsed_state.unread"))
       end

--- a/spec/features/gws/board/topics/delete_notification_spec.rb
+++ b/spec/features/gws/board/topics/delete_notification_spec.rb
@@ -21,7 +21,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
   context "soft_delete" do
     it do
       login_user(user)
-      visit gws_board_topic_path(site: site, mode: '-', category: '-', id: item2)
+      # 削除ボタンは閲覧一覧(readable)から除去したため、管理一覧(editable)で操作する
+      visit gws_board_topic_path(site: site, mode: 'editable', category: '-', id: item2)
 
       within "#menu" do
         expect(page).to have_link I18n.t("ss.links.edit")
@@ -57,7 +58,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
   context "soft_delete_all" do
     it do
       login_user(user)
-      visit gws_board_topics_path(site: site, mode: '-', category: '-')
+      # 削除ボタンは閲覧一覧(readable)から除去したため、管理一覧(editable)で操作する
+      visit gws_board_topics_path(site: site, mode: 'editable', category: '-')
 
       # check menu link
       within ".list-items" do
@@ -110,7 +112,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
   context "soft_delete_all with no permission case" do
     it do
       login_user(user1)
-      visit gws_board_topics_path(site: site, mode: '-', category: '-')
+      # 削除ボタンは閲覧一覧(readable)から除去したため、管理一覧(editable)で操作する
+      visit gws_board_topics_path(site: site, mode: 'editable', category: '-')
 
       # check menu link
       within ".list-items" do

--- a/spec/features/gws/board/topics/with_release_spec.rb
+++ b/spec/features/gws/board/topics/with_release_spec.rb
@@ -28,7 +28,8 @@ describe "gws_board_topics", type: :feature, dbscope: :example, js: true do
     let(:close_date) { release_date + 1.day }
 
     it do
-      visit gws_board_topics_path(site: site, mode: '-', category: '-')
+      # 新規作成は閲覧一覧(readable)から除去したため、管理一覧(editable)で作成する
+      visit gws_board_topics_path(site: site, mode: 'editable', category: '-')
       within ".nav-menu" do
         click_on I18n.t("ss.links.new")
       end

--- a/spec/features/gws/discussion/forums/delete_button_visibility_spec.rb
+++ b/spec/features/gws/discussion/forums/delete_button_visibility_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe "gws_discussion_forums", type: :feature, dbscope: :example, js: true do
+  let!(:site) { gws_site }
+  let!(:forum) { create :gws_discussion_forum }
+  let(:readable_path) { gws_discussion_forums_path(mode: '-', site: site) }
+  let(:editable_path) { gws_discussion_forums_path(mode: 'editable', site: site) }
+
+  before { login_gws_user }
+
+  it "閲覧一覧(readable)では一括削除ボタンを表示しない" do
+    visit readable_path
+    expect(current_path).not_to eq sns_login_path
+    expect(page).to have_no_css(".soft-delete-all")
+  end
+
+  it "管理一覧(editable)では一括削除ボタンを表示する" do
+    visit editable_path
+    expect(current_path).not_to eq sns_login_path
+    expect(page).to have_css(".soft-delete-all")
+  end
+end

--- a/spec/features/gws/discussion/forums/delete_button_visibility_spec.rb
+++ b/spec/features/gws/discussion/forums/delete_button_visibility_spec.rb
@@ -8,15 +8,25 @@ describe "gws_discussion_forums", type: :feature, dbscope: :example, js: true do
 
   before { login_gws_user }
 
-  it "閲覧一覧(readable)では一括削除ボタンを表示しない" do
+  it "閲覧一覧(readable)では削除ボタン・新規作成・チェックボックスを表示しない" do
     visit readable_path
     expect(current_path).not_to eq sns_login_path
+    expect(page).to have_css(".list-item", text: forum.name)
     expect(page).to have_no_css(".soft-delete-all")
+    within ".nav-menu" do
+      expect(page).to have_no_link I18n.t("ss.links.new")
+    end
+    expect(page).to have_no_css(".list-items .list-item label.check")
   end
 
-  it "管理一覧(editable)では一括削除ボタンを表示する" do
+  it "管理一覧(editable)では削除ボタン・新規作成・チェックボックスを表示する" do
     visit editable_path
     expect(current_path).not_to eq sns_login_path
+    expect(page).to have_css(".list-item", text: forum.name)
     expect(page).to have_css(".soft-delete-all")
+    within ".nav-menu" do
+      expect(page).to have_link I18n.t("ss.links.new")
+    end
+    expect(page).to have_css(".list-items .list-item label.check")
   end
 end

--- a/spec/features/gws/faq/topics/basic_crud_spec.rb
+++ b/spec/features/gws/faq/topics/basic_crud_spec.rb
@@ -14,7 +14,8 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
     let(:text) { Array.new(2) { "text-#{unique_id}" } }
 
     it do
-      visit gws_faq_topics_path(site: site, mode: '-', category: '-')
+      # 新規作成は閲覧一覧(readable)から除去したため、管理一覧(editable)で作成する
+      visit gws_faq_topics_path(site: site, mode: 'editable', category: '-')
       wait_for_js_ready
 
       Timecop.freeze(now) do
@@ -74,7 +75,8 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
       expect(item.name).to eq name2
       expect(item.category_ids).to include(category1.id, category2.id)
 
-      visit gws_faq_topics_path(site: site, mode: '-', category: '-')
+      # 削除ボタンは閲覧一覧(readable)から除去したため、管理一覧(editable)で操作する
+      visit gws_faq_topics_path(site: site, mode: 'editable', category: '-')
       click_on item.name
       within ".nav-menu" do
         click_on I18n.t("ss.links.delete")

--- a/spec/features/gws/faq/topics/browsed_all_spec.rb
+++ b/spec/features/gws/faq/topics/browsed_all_spec.rb
@@ -36,7 +36,9 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
 
   context "#set_browsed_all / #unset_browsed_all" do
     it "選択した項目を一括で既読/未読にできる" do
-      visit readable_path
+      # 既定は未読のみ表示。既読済みも扱うため全て表示で開く
+      both_path = "#{readable_path}?s[browsed_state]=both"
+      visit both_path
       expect(item.browsed?(gws_user)).to be_falsey
 
       within ".list-items" do
@@ -50,6 +52,7 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
       wait_for_notice I18n.t("ss.notice.set_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_truthy
 
+      visit both_path
       within ".list-items" do
         first("input[value='#{item.id}']").click
       end
@@ -60,6 +63,16 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t("ss.notice.unset_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_falsey
+    end
+  end
+
+  context "未読/全て表示フィルタ" do
+    it "既定は未読のみ表示。既読にすると既定一覧から消え、全て表示で再表示される" do
+      item.set_browsed!(gws_user)
+      visit readable_path
+      expect(page).to have_no_css(".list-item")
+      visit "#{readable_path}?s[browsed_state]=both"
+      expect(page).to have_css(".list-item", text: item.name)
     end
   end
 

--- a/spec/features/gws/faq/topics/browsed_all_spec.rb
+++ b/spec/features/gws/faq/topics/browsed_all_spec.rb
@@ -19,6 +19,7 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
       end
       within ".list-items" do
         expect(page).to have_no_link I18n.t("ss.links.delete")
+        expect(page).to have_css(".list-item.unread")
         expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/faq.options.browsed_state.unread"))
       end
     end

--- a/spec/features/gws/faq/topics/browsed_all_spec.rb
+++ b/spec/features/gws/faq/topics/browsed_all_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
+  let(:site) { gws_site }
+  let!(:category) { create :gws_faq_category }
+  let!(:item) { create :gws_faq_topic, category_ids: [ category.id ] }
+  let(:readable_path) { gws_faq_topics_path site, '-', '-' }
+  let(:editable_path) { gws_faq_topics_path site, 'editable', '-' }
+
+  before { login_gws_user }
+
+  context "閲覧一覧(readable)" do
+    it "削除ボタンを表示せず、既読/未読の一括ボタンを表示する" do
+      visit readable_path
+      within ".list-head" do
+        expect(page).to have_no_css(".soft-delete-all")
+        expect(page).to have_css(".set-browsed-all")
+        expect(page).to have_css(".unset-browsed-all")
+      end
+      within ".list-items" do
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+        expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/faq.options.browsed_state.unread"))
+      end
+    end
+  end
+
+  context "管理一覧(editable)" do
+    it "従来どおり削除ボタンを表示し、既読/未読ボタンは表示しない" do
+      visit editable_path
+      within ".list-head" do
+        expect(page).to have_css(".soft-delete-all")
+        expect(page).to have_no_css(".set-browsed-all")
+      end
+    end
+  end
+
+  context "#set_browsed_all / #unset_browsed_all" do
+    it "選択した項目を一括で既読/未読にできる" do
+      visit readable_path
+      expect(item.browsed?(gws_user)).to be_falsey
+
+      within ".list-items" do
+        first("input[value='#{item.id}']").click
+      end
+      within ".list-head" do
+        page.accept_confirm do
+          click_on I18n.t("gws/faq.topic.set_browsed")
+        end
+      end
+      wait_for_notice I18n.t("ss.notice.set_seen_all")
+      expect(item.reload.browsed?(gws_user)).to be_truthy
+
+      within ".list-items" do
+        first("input[value='#{item.id}']").click
+      end
+      within ".list-head" do
+        page.accept_confirm do
+          click_on I18n.t("gws/faq.topic.unset_browsed")
+        end
+      end
+      wait_for_notice I18n.t("ss.notice.unset_seen_all")
+      expect(item.reload.browsed?(gws_user)).to be_falsey
+    end
+  end
+
+  context "詳細画面(show)" do
+    before do
+      # 自動既読タイマーがテスト中に発火しないよう遅延を大きくする
+      site.set(faq_browsed_delay: 3600)
+    end
+
+    it "閲覧一覧経由の詳細は削除ボタンが無く編集ボタンは残る。既読/未読を切り替えられる" do
+      expect(item.browsed?(gws_user)).to be_falsey
+      visit readable_path
+      click_on item.name
+
+      within ".nav-menu" do
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+        expect(page).to have_link I18n.t("ss.links.edit")
+      end
+
+      expect(page).to have_link I18n.t("gws/faq.topic.set_browsed")
+      click_on I18n.t("gws/faq.topic.set_browsed")
+      wait_for_notice I18n.t("ss.notice.saved")
+      expect(item.reload.browsed?(gws_user)).to be_truthy
+
+      expect(page).to have_link I18n.t("gws/faq.topic.unset_browsed")
+      click_on I18n.t("gws/faq.topic.unset_browsed")
+      wait_for_notice I18n.t("ss.notice.saved")
+      expect(item.reload.browsed?(gws_user)).to be_falsey
+      expect(page).to have_link I18n.t("gws/faq.topic.set_browsed")
+    end
+  end
+end

--- a/spec/features/gws/faq/topics/browsed_all_spec.rb
+++ b/spec/features/gws/faq/topics/browsed_all_spec.rb
@@ -31,6 +31,7 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
       within ".list-head" do
         expect(page).to have_css(".soft-delete-all")
         expect(page).to have_no_css(".set-browsed-all")
+        expect(page).to have_no_css(".unset-browsed-all")
       end
     end
   end

--- a/spec/features/gws/faq/topics/browsed_all_spec.rb
+++ b/spec/features/gws/faq/topics/browsed_all_spec.rb
@@ -68,12 +68,12 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
   end
 
   context "未読/全て表示フィルタ" do
-    it "既定は未読のみ表示。既読にすると既定一覧から消え、全て表示で再表示される" do
+    it "既定は全て表示。未読で絞り込むと既読は消える" do
       item.set_browsed!(gws_user)
       visit readable_path
-      expect(page).to have_no_css(".list-item")
-      visit "#{readable_path}?s[browsed_state]=both"
       expect(page).to have_css(".list-item", text: item.name)
+      visit "#{readable_path}?s[browsed_state]=unread"
+      expect(page).to have_no_css(".list-item")
     end
   end
 

--- a/spec/features/gws/faq/topics/disable_all_spec.rb
+++ b/spec/features/gws/faq/topics/disable_all_spec.rb
@@ -9,7 +9,8 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
 
   context "disable (soft delete) all" do
     it do
-      login_user user, to: gws_faq_topics_path(site: site, mode: '-', category: '-')
+      # 一括削除は閲覧一覧(readable)から除去したため、管理一覧(editable)で操作する
+      login_user user, to: gws_faq_topics_path(site: site, mode: 'editable', category: '-')
       wait_for_event_fired("ss:checked-all-list-items") { find('.list-head label.check input').set(true) }
       page.accept_confirm(I18n.t("ss.confirm.delete")) do
         within ".list-head-action" do
@@ -46,7 +47,8 @@ describe "gws_faq_topics", type: :feature, dbscope: :example, js: true do
     end
 
     it do
-      login_user user, to: gws_faq_topics_path(site: site, mode: '-', category: '-')
+      # 削除権限が無い場合、管理一覧(editable)でも一括削除ボタンは出ない
+      login_user user, to: gws_faq_topics_path(site: site, mode: 'editable', category: '-')
       expect(page).to have_css(".list-item", text: topic.name)
       expect(page).to have_no_css(".list-head-action")
     end

--- a/spec/features/gws/notices/browsed_all_spec.rb
+++ b/spec/features/gws/notices/browsed_all_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe "gws_notice_readables", type: :feature, dbscope: :example, js: true do
+  let(:site) { gws_site }
+  let(:folder) { create(:gws_notice_folder) }
+  let!(:item) { create :gws_notice_post, folder: folder, readable_member_ids: [ gws_user.id ] }
+  let(:index_path) { gws_notice_readables_path(site: site, folder_id: '-', category_id: '-') }
+
+  before { login_gws_user }
+
+  it "一覧に既読にするボタンがあり、選択した項目を一括で既読にできる" do
+    expect(item.browsed?(gws_user)).to be_falsey
+
+    visit index_path
+    within ".list-head" do
+      expect(page).to have_css(".set-seen-all")
+    end
+
+    within ".list-items" do
+      first("input[value='#{item.id}']").click
+    end
+    within ".list-head" do
+      page.accept_confirm do
+        click_on I18n.t("gws/notice.links.set_seen")
+      end
+    end
+    wait_for_notice I18n.t("ss.notice.set_seen")
+
+    expect(item.reload.browsed?(gws_user)).to be_truthy
+  end
+end

--- a/spec/features/gws/notices/browsed_all_spec.rb
+++ b/spec/features/gws/notices/browsed_all_spec.rb
@@ -8,14 +8,16 @@ describe "gws_notice_readables", type: :feature, dbscope: :example, js: true do
 
   before { login_gws_user }
 
-  it "一覧に既読にするボタンがあり、選択した項目を一括で既読にできる" do
+  it "一覧の既読/未読ボタンで選択した項目を一括で既読/未読にできる" do
     expect(item.browsed?(gws_user)).to be_falsey
 
     visit index_path
     within ".list-head" do
-      expect(page).to have_css(".set-seen-all")
+      expect(page).to have_css(".set-browsed-all")
+      expect(page).to have_css(".unset-browsed-all")
     end
 
+    # 一括既読
     within ".list-items" do
       first("input[value='#{item.id}']").click
     end
@@ -24,8 +26,19 @@ describe "gws_notice_readables", type: :feature, dbscope: :example, js: true do
         click_on I18n.t("gws/notice.links.set_seen")
       end
     end
-    wait_for_notice I18n.t("ss.notice.set_seen")
-
+    wait_for_notice I18n.t("ss.notice.set_seen_all")
     expect(item.reload.browsed?(gws_user)).to be_truthy
+
+    # 一括未読
+    within ".list-items" do
+      first("input[value='#{item.id}']").click
+    end
+    within ".list-head" do
+      page.accept_confirm do
+        click_on I18n.t("gws/notice.links.unset_seen")
+      end
+    end
+    wait_for_notice I18n.t("ss.notice.unset_seen_all")
+    expect(item.reload.browsed?(gws_user)).to be_falsey
   end
 end

--- a/spec/features/gws/qna/topics/browsed_all_spec.rb
+++ b/spec/features/gws/qna/topics/browsed_all_spec.rb
@@ -36,7 +36,9 @@ describe "gws_qna_topics", type: :feature, dbscope: :example, js: true do
 
   context "#set_browsed_all / #unset_browsed_all" do
     it "選択した項目を一括で既読/未読にできる" do
-      visit readable_path
+      # 既定は未読のみ表示。既読済みも扱うため全て表示で開く
+      both_path = "#{readable_path}?s[browsed_state]=both"
+      visit both_path
       expect(item.browsed?(gws_user)).to be_falsey
 
       within ".list-items" do
@@ -50,6 +52,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example, js: true do
       wait_for_notice I18n.t("ss.notice.set_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_truthy
 
+      visit both_path
       within ".list-items" do
         first("input[value='#{item.id}']").click
       end
@@ -60,6 +63,16 @@ describe "gws_qna_topics", type: :feature, dbscope: :example, js: true do
       end
       wait_for_notice I18n.t("ss.notice.unset_seen_all")
       expect(item.reload.browsed?(gws_user)).to be_falsey
+    end
+  end
+
+  context "未読/全て表示フィルタ" do
+    it "既定は未読のみ表示。既読にすると既定一覧から消え、全て表示で再表示される" do
+      item.set_browsed!(gws_user)
+      visit readable_path
+      expect(page).to have_no_css(".list-item")
+      visit "#{readable_path}?s[browsed_state]=both"
+      expect(page).to have_css(".list-item", text: item.name)
     end
   end
 

--- a/spec/features/gws/qna/topics/browsed_all_spec.rb
+++ b/spec/features/gws/qna/topics/browsed_all_spec.rb
@@ -68,12 +68,12 @@ describe "gws_qna_topics", type: :feature, dbscope: :example, js: true do
   end
 
   context "未読/全て表示フィルタ" do
-    it "既定は未読のみ表示。既読にすると既定一覧から消え、全て表示で再表示される" do
+    it "既定は全て表示。未読で絞り込むと既読は消える" do
       item.set_browsed!(gws_user)
       visit readable_path
-      expect(page).to have_no_css(".list-item")
-      visit "#{readable_path}?s[browsed_state]=both"
       expect(page).to have_css(".list-item", text: item.name)
+      visit "#{readable_path}?s[browsed_state]=unread"
+      expect(page).to have_no_css(".list-item")
     end
   end
 

--- a/spec/features/gws/qna/topics/browsed_all_spec.rb
+++ b/spec/features/gws/qna/topics/browsed_all_spec.rb
@@ -31,6 +31,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example, js: true do
       within ".list-head" do
         expect(page).to have_css(".soft-delete-all")
         expect(page).to have_no_css(".set-browsed-all")
+        expect(page).to have_no_css(".unset-browsed-all")
       end
     end
   end

--- a/spec/features/gws/qna/topics/browsed_all_spec.rb
+++ b/spec/features/gws/qna/topics/browsed_all_spec.rb
@@ -19,6 +19,7 @@ describe "gws_qna_topics", type: :feature, dbscope: :example, js: true do
       end
       within ".list-items" do
         expect(page).to have_no_link I18n.t("ss.links.delete")
+        expect(page).to have_css(".list-item.unread")
         expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/qna.options.browsed_state.unread"))
       end
     end

--- a/spec/features/gws/qna/topics/browsed_all_spec.rb
+++ b/spec/features/gws/qna/topics/browsed_all_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe "gws_qna_topics", type: :feature, dbscope: :example, js: true do
+  let(:site) { gws_site }
+  let!(:category) { create :gws_qna_category }
+  let!(:item) { create :gws_qna_topic, category_ids: [ category.id ] }
+  let(:readable_path) { gws_qna_topics_path site, '-', '-' }
+  let(:editable_path) { gws_qna_topics_path site, 'editable', '-' }
+
+  before { login_gws_user }
+
+  context "閲覧一覧(readable)" do
+    it "削除ボタンを表示せず、既読/未読の一括ボタンを表示する" do
+      visit readable_path
+      within ".list-head" do
+        expect(page).to have_no_css(".soft-delete-all")
+        expect(page).to have_css(".set-browsed-all")
+        expect(page).to have_css(".unset-browsed-all")
+      end
+      within ".list-items" do
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+        expect(page).to have_css(".list-item .meta .seen", text: I18n.t("gws/qna.options.browsed_state.unread"))
+      end
+    end
+  end
+
+  context "管理一覧(editable)" do
+    it "従来どおり削除ボタンを表示し、既読/未読ボタンは表示しない" do
+      visit editable_path
+      within ".list-head" do
+        expect(page).to have_css(".soft-delete-all")
+        expect(page).to have_no_css(".set-browsed-all")
+      end
+    end
+  end
+
+  context "#set_browsed_all / #unset_browsed_all" do
+    it "選択した項目を一括で既読/未読にできる" do
+      visit readable_path
+      expect(item.browsed?(gws_user)).to be_falsey
+
+      within ".list-items" do
+        first("input[value='#{item.id}']").click
+      end
+      within ".list-head" do
+        page.accept_confirm do
+          click_on I18n.t("gws/qna.topic.set_browsed")
+        end
+      end
+      wait_for_notice I18n.t("ss.notice.set_seen_all")
+      expect(item.reload.browsed?(gws_user)).to be_truthy
+
+      within ".list-items" do
+        first("input[value='#{item.id}']").click
+      end
+      within ".list-head" do
+        page.accept_confirm do
+          click_on I18n.t("gws/qna.topic.unset_browsed")
+        end
+      end
+      wait_for_notice I18n.t("ss.notice.unset_seen_all")
+      expect(item.reload.browsed?(gws_user)).to be_falsey
+    end
+  end
+
+  context "詳細画面(show)" do
+    before do
+      # 自動既読タイマーがテスト中に発火しないよう遅延を大きくする
+      site.set(qna_browsed_delay: 3600)
+    end
+
+    it "閲覧一覧経由の詳細は削除ボタンが無く編集ボタンは残る。既読/未読を切り替えられる" do
+      expect(item.browsed?(gws_user)).to be_falsey
+      visit readable_path
+      click_on item.name
+
+      within ".nav-menu" do
+        expect(page).to have_no_link I18n.t("ss.links.delete")
+        expect(page).to have_link I18n.t("ss.links.edit")
+      end
+
+      expect(page).to have_link I18n.t("gws/qna.topic.set_browsed")
+      click_on I18n.t("gws/qna.topic.set_browsed")
+      wait_for_notice I18n.t("ss.notice.saved")
+      expect(item.reload.browsed?(gws_user)).to be_truthy
+
+      expect(page).to have_link I18n.t("gws/qna.topic.unset_browsed")
+      click_on I18n.t("gws/qna.topic.unset_browsed")
+      wait_for_notice I18n.t("ss.notice.saved")
+      expect(item.reload.browsed?(gws_user)).to be_falsey
+      expect(page).to have_link I18n.t("gws/qna.topic.set_browsed")
+    end
+  end
+end


### PR DESCRIPTION
## 概要

GWS の各機能の**閲覧一覧（readable）**を、既存の**回覧板**の型に合わせて整理・機能追加します。共通の狙いは次の2点です。

- **閲覧一覧は「閲覧」に専念**：削除・新規作成など管理系の導線を閲覧一覧から外し、管理一覧（editable）に集約する。
- **回覧板と同じ既読/未読操作を横展開**：一覧でまとめて既読/未読にできるボタン、未読での絞り込み、詳細画面の既読/未読トグルを追加する。

対象は **掲示板 / よくある質問 / Q&A / お知らせ / 電子会議室** の5機能です。

## 対象機能と主な変更

| 機能 | 閲覧一覧(readable) | 詳細画面 | 管理一覧(editable) |
|---|---|---|---|
| 掲示板 (board) | 削除・新規作成を非表示／一括既読・未読ボタン／既読・未読ラベル／未読時に `unread` クラス／未読・全て表示フィルタ | 既読/未読トグル・削除は非表示（編集は表示） | 従来どおり（削除・新規作成あり） |
| よくある質問 (faq) | 同上 | 同上 | 従来どおり |
| Q&A (qna) | 同上 | 同上 | 従来どおり |
| お知らせ (notice) | 一括既読・未読ボタン（バックナンバーも対応） | （既存の toggle_browsed を維持） | ― |
| 電子会議室 (discussion) | 削除ボタン・チェックボックス・新規作成を非表示 | ― | 従来どおり |

## 主な機能

- **一括既読/未読**：閲覧一覧で項目を選択し、「既読にする」「未読にする」でまとめて切り替え。
- **未読/全て表示フィルタ**：閲覧一覧に絞り込みセレクトを追加（既定は「全て表示」）。
- **既読/未読の可視化**：一覧メタに既読/未読ラベル、未読の行に `unread` クラス（既読は素の表示。SCSS も `.unread` のみ定義）。
- **詳細の既読/未読トグル**：掲示板・FAQ・Q&A の詳細で手動切り替え（回覧板に合わせる）。
- **管理系の非表示**：閲覧一覧では削除・新規作成を出さず、管理一覧へ集約。

## 実装メモ（レビューの要点）

- **既読状態の共有**：既読/未読は `Gws::Board::BrowsingState` concern を共有（お知らせ notice も流用）。FAQ/Q&A の concern には `unset_browsed!` が無かったため追加。
- **一括処理**：掲示板は `set_selected_items` / `render_confirmed_all` を利用。FAQ/Q&A/お知らせはモード対応の `items.in(id: params[:ids])` で選択項目を絞り込み。
- **自動既読との衝突回避**：詳細を開いてN秒後に自動既読にする既存機能（`board/faq/qna_browsed_delay`・既定2秒）と手動トグルが衝突しないよう、`params[:toggled]` があるときは自動既読タイマーをスキップするガードを追加。
- **削除通知の回帰を回避**：一括処理のために `before_action :set_selected_items` を追加登録すると、`Gws::CrudFilter` の同メソッドとの兼ね合いでコールバック順序が変わり、既存の `soft_delete_all` の削除通知（`Gws::Memo::NotificationFilter`）が発火しなくなる回帰を確認。**アクション内で呼ぶ形**にして回避。
- **共有パーシャル起因の修正**：お知らせのバックナンバー(back_numbers)は閲覧一覧の `_list_head` を共有描画するため、一括ボタンの action に対応するルートが無く一覧がエラー化 → back_numbers にも collection ルートを追加。
- **絞り込みの既定**：`browsed_state` フィルタの既定は `both`（全て表示）。未読は明示選択時のみ絞り込み。

## テスト

各機能に feature spec（実ブラウザ）を追加/更新し、以下を検証しています。

- 閲覧一覧：削除ボタン（各行・一括）が非表示、一括で既読/未読に切り替え可能、未読フィルタで絞り込み可能、未読行に `unread` クラスが付く。
- 詳細画面：削除ボタンが非表示（編集は表示）、既読/未読トグルが機能する。
- 管理一覧：従来どおり削除・新規作成ボタンが表示され、既存の削除通知も維持される。
- 電子会議室：閲覧一覧で削除・新規作成・チェックボックスが出ず、管理一覧では出る。

ローカルでは GWS 関連 spec は全てグリーンです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 閲覧一覧で全トピックの既読/未読を一括切り替えできるボタン（既読設定・解除）を追加しました。
  * 既読/未読の切替（未読化/既読化）と、閲覧状態に応じた反映を追加しました。
* **改善**
  * 閲覧一覧では削除系の導線を非表示にし、一覧に「見た/未見」表示を追加しました。
  * 詳細画面のメニュー表示を既読状態に応じて調整しました。
* **テスト**
  * 既読/未読の表示・操作と導線をE2Eで検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
