### PR TITLE
[modify] able to disable LDAP tests in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,8 +41,8 @@ jobs:
         uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: 8.0
-      #- name: Prepare Ldap
-      #  run: docker pull osixia/openldap
+      - name: Prepare Ldap
+        run: docker pull osixia/openldap
       - name: Start Shirasagi Mail
         run: |
           docker pull ghcr.io/shirasagi/mail:latest
@@ -145,7 +145,7 @@ jobs:
           LANG: ja_JP.UTF-8
           LC_ALL: ja_JP.UTF-8
           allow_open_jtalk: 1
-          LDAP_TEST: disable
+          LDAP_TEST: enable
           ES_CONTAINER_ID: ${{ steps.elasticsearch.outputs.CONTAINER_ID }}
           CKAN_CONTAINER_ID: ${{ steps.ckan.outputs.CONTAINER_ID }}
           RUBYOPT: "-W:deprecated"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,8 +41,8 @@ jobs:
         uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: 8.0
-      - name: Prepare Ldap
-        run: docker pull osixia/openldap
+      #- name: Prepare Ldap
+      #  run: docker pull osixia/openldap
       - name: Start Shirasagi Mail
         run: |
           docker pull ghcr.io/shirasagi/mail:latest
@@ -145,7 +145,7 @@ jobs:
           LANG: ja_JP.UTF-8
           LC_ALL: ja_JP.UTF-8
           allow_open_jtalk: 1
-          LDAP_TEST: enable
+          LDAP_TEST: disable
           ES_CONTAINER_ID: ${{ steps.elasticsearch.outputs.CONTAINER_ID }}
           CKAN_CONTAINER_ID: ${{ steps.ckan.outputs.CONTAINER_ID }}
           RUBYOPT: "-W:deprecated"

--- a/spec/support/ldap/init.rb
+++ b/spec/support/ldap/init.rb
@@ -4,7 +4,7 @@ module SS::LdapSupport
   module_function
 
   def ldap_test_enabled?
-    ENV["LDAP_TEST"] == "enable" || ci?
+    ENV["LDAP_TEST"] == "enable"
   end
 
   def ldap_test_disabled?


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * Ruby 3.3 の継続的インテグレーション環境では、LDAP 準備処理と LDAP 関連テスト設定を無効化しました。
  * LDAP テストの有効/無効判定が見直され、環境変数の指定がない限り無効になります。
  * LDAP に依存しないテスト実行が安定して行えるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->