### PR TITLE
[modify][ss] 必須マークをスクリーンリーダー読み上げ対応

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -2134,6 +2134,31 @@ footer.send {
   font-weight: bold;
 }
 
+// 必須マーク: ホバー時に「必須入力」ツールチップを表示（読み上げは aria-label 側で対応）
+// 配色はコントラスト機能に追従させるため background/color は固定指定しない（境界は border のみ）
+.required-mark {
+  position: relative;
+}
+.required-mark .required-tooltip {
+  display: none;
+  position: absolute;
+  z-index: 100;
+  top: 100%;
+  left: 50%;
+  margin-top: 4px;
+  padding: 3px 8px;
+  transform: translateX(-50%);
+  border: 1px solid;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: normal;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.required-mark:hover .required-tooltip {
+  display: block;
+}
+
 // -------------------------------------------------------------------------------------------------
 // button
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -270,7 +270,9 @@ module ApplicationHelper
   end
 
   def required_mark
-    %(<span class="required" title="#{I18n.t('ss.required')}">*</span>).html_safe
+    label = I18n.t('ss.required')
+    tooltip = %(<span class="required-tooltip" aria-hidden="true">#{label}</span>)
+    %(<span class="required required-mark" role="img" aria-label="#{label}">*#{tooltip}</span>).html_safe
   end
 
   def sanitizer_status(item)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -271,8 +271,10 @@ module ApplicationHelper
 
   def required_mark
     label = I18n.t('ss.required')
-    tooltip = %(<span class="required-tooltip" aria-hidden="true">#{label}</span>)
-    %(<span class="required required-mark" role="img" aria-label="#{label}">*#{tooltip}</span>).html_safe
+    tooltip = tag.span(label, class: "required-tooltip", aria: { hidden: true })
+    tag.span(class: "required required-mark", role: "img", aria: { label: label }) do
+      safe_join([ "*", tooltip ])
+    end
   end
 
   def sanitizer_status(item)


### PR DESCRIPTION
関連PR
[modify][gws]: 必須項目のラベルに必須マークを追加 (J090-619)- #6103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **アクセシビリティ**
  * 必須マークの情報を見直し、補助技術に対して「必須」であることが正しく伝わるよう改善しました。
  * 読み上げ対象の内容を整理し、視覚的な「*」は非表示にして適切なラベルを付与しました。
* **UI（表示）**
  * 必須マークにホバー対応のツールチップを追加し、補足情報をその場で確認できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->