### PR TITLE
[modify][cms] add canonical support to link check

### DIFF
--- a/app/controllers/cms/agents/tasks/links_controller.rb
+++ b/app/controllers/cms/agents/tasks/links_controller.rb
@@ -67,6 +67,7 @@ class Cms::Agents::Tasks::LinksController < ApplicationController
         status: source.status,
         elapsed: source.elapsed
       }
+      json[:canonical_url] = source.canonical_url.to_s if source.canonical_url
       io.puts(json.to_json)
     end
 
@@ -275,6 +276,17 @@ class Cms::Agents::Tasks::LinksController < ApplicationController
     extractor.each do |link|
       if IGNORE_LINK_TYPES.include?(link.type)
         @extraction_log.add(source, link)
+        next
+      end
+      if link.type == :canonical
+        if source.full_url != link.full_url
+          @extraction_log.add(source, link, :canonical)
+          source.canonical_url = link.full_url
+
+          # link_source = Cms::CheckLinks::Source.new(full_url: link.full_url)
+          # @full_url_to_source[link_source.full_url.to_s] = link_source
+          # @queue << link_source
+        end
         next
       end
       if link.href[0] == "#"

--- a/app/models/cms/check_links/link_extractor.rb
+++ b/app/models/cms/check_links/link_extractor.rb
@@ -5,6 +5,7 @@ class Cms::CheckLinks::LinkExtractor
 
   HYPERLINK_ELEMENT_TAG_NAMES = Set.new(%w(a area)).freeze
   IMAGE_ELEMENT_TAG_NAMES = Set.new(%w(img audio video source iframe)).freeze
+  CANONICAL_ELEMENT_TAG_NAMES = Set.new(%w(link)).freeze
 
   attr_accessor :cur_site, :base_url, :html
   attr_writer :fragment
@@ -17,6 +18,8 @@ class Cms::CheckLinks::LinkExtractor
         link = create_link_from_hyperlink(node, layout_yield)
       elsif image_element?(node)
         link = create_link_from_image(node, layout_yield)
+      elsif canonical_element?(node)
+        link = create_link_from_canonical(node, layout_yield)
       end
       next unless link
 
@@ -70,6 +73,12 @@ class Cms::CheckLinks::LinkExtractor
     IMAGE_ELEMENT_TAG_NAMES.include?(node.name)
   end
 
+  def canonical_element?(node)
+    return false if node["rel"].blank? || node["rel"] != "canonical"
+    return false if node["href"].blank?
+    CANONICAL_ELEMENT_TAG_NAMES.include?(node.name)
+  end
+
   def create_link_from_hyperlink(node, layout_yield)
     href = node["href"]
     rel = node["rel"].presence
@@ -121,5 +130,19 @@ class Cms::CheckLinks::LinkExtractor
 
     Cms::CheckLinks::Link.new(
       full_url: extracted_full_url, href: href, line: node.line, type: type, rel: nil, ss_rel: ss_rel)
+  end
+
+  def create_link_from_canonical(node, _layout_yield)
+    href = node["href"]
+    return if href.blank? || href == "#"
+
+    extracted_full_url = Addressable::URI.join(base_url, href) rescue nil
+    return unless extracted_full_url
+
+    extracted_full_url = extracted_full_url.normalize rescue nil
+    return unless extracted_full_url
+
+    Cms::CheckLinks::Link.new(
+      full_url: extracted_full_url, href: href, line: node.line, type: :canonical, rel: nil, ss_rel: nil)
   end
 end

--- a/app/models/cms/check_links/source.rb
+++ b/app/models/cms/check_links/source.rb
@@ -1,7 +1,7 @@
 class Cms::CheckLinks::Source
   include ActiveModel::Model
 
-  attr_accessor :full_url, :links, :referrers, :status, :elapsed
+  attr_accessor :full_url, :links, :referrers, :status, :elapsed, :canonical_url
   attr_reader :sequence
 
   def initialize(*args, **kwargs)

--- a/app/models/cms/content_link_checker.rb
+++ b/app/models/cms/content_link_checker.rb
@@ -52,6 +52,7 @@ class Cms::ContentLinkChecker
     extractor = Cms::CheckLinks::LinkExtractor.new(
       cur_site: cur_site, base_url: root_full_url, fragment: document)
     extractor.each do |link|
+      next if link.type == :canonical
       next if link.href == "#"
       next if extracted_urls[link.href]
 

--- a/app/models/cms/link_checker.rb
+++ b/app/models/cms/link_checker.rb
@@ -192,7 +192,7 @@ class Cms::LinkChecker
     path = File.join(path, "index.html") if Fs.directory?(path)
     return path if Fs.file?(path)
 
-    path = Addressable::URI.unencode(path)
+    path = Addressable::URI.unencode(path).to_s
     return path if Fs.file?(path)
 
     nil

--- a/app/models/cms/link_checker.rb
+++ b/app/models/cms/link_checker.rb
@@ -229,7 +229,7 @@ class Cms::LinkChecker
     content_type = contents_headers["content-type"]
     content = nil
     if fetch_content && content_type.include?(TEXT_HTML_MIME_TYPE)
-      content = ""
+      content = +""
       contents_body.each { content += _1 }
     end
     Result.success(

--- a/spec/jobs/cms/check_links_job/basic_spec.rb
+++ b/spec/jobs/cms/check_links_job/basic_spec.rb
@@ -550,7 +550,7 @@ describe Cms::CheckLinksJob, dbscope: :example do
         url_log_path = task.log_file_path.sub(".log", "") + "-extraction-log.json.gz"
         url_logs = Zlib::GzipReader.open(url_log_path) { _1.readlines }.map { JSON.parse(_1.chomp) }
         # puts url_logs.map { _1["full_url"] }.join("\n")
-        expect(url_logs.length).to eq 26
+        expect(url_logs.length).to eq 27
 
         next_month_url = "#{calendar.full_url}#{Time.zone.today.next_month.strftime("%Y%m")}/"
         expect(url_logs.select { _1["full_url"].start_with?(next_month_url) }.map { _1["type"] }.uniq).to eq %w(nofollow)
@@ -564,7 +564,15 @@ describe Cms::CheckLinksJob, dbscope: :example do
         expect(url_logs.select { _1["full_url"] == page1.full_url }.map { _1["type"] }.uniq).to eq %w(inner_yield)
 
         list_url = "#{calendar.full_url}#{Time.zone.today.strftime("%Y%m")}/list.html"
-        expect(url_logs.select { _1["full_url"] == list_url }.map { _1["type"] }.uniq).to eq %w(inner_yield)
+        url_logs.select { _1["full_url"] == list_url }.tap do |logs|
+          expect(logs).to have(3).items
+          expect(logs[0]["source"]).to eq calendar.full_url
+          expect(logs[0]["type"]).to eq "canonical"
+          expect(logs[1]["source"]).to eq calendar.full_url
+          expect(logs[1]["type"]).to eq "inner_yield"
+          expect(logs[2]["source"]).to eq list_url
+          expect(logs[2]["type"]).to eq "inner_yield"
+        end
 
         list_ics_url = "#{calendar.full_url}#{Time.zone.today.strftime("%Y%m")}/list.ics"
         expect(url_logs.select { _1["full_url"] == list_ics_url }.map { _1["type"] }.uniq).to eq %w(nofollow)

--- a/spec/models/cms/check_links/link_extractor_spec.rb
+++ b/spec/models/cms/check_links/link_extractor_spec.rb
@@ -199,8 +199,17 @@ describe Cms::CheckLinks::LinkExtractor, type: :model, dbscope: :example do
       extractor = described_class.new(cur_site: site, base_url: node.full_url, html: html)
       links = extractor.to_a
       # puts links.map(&:href).join("\n")
-      expect(links).to have(6).items
+      expect(links).to have(7).items
       links[0].tap do |link|
+        path = "#{today.strftime("%Y%m")}/list.html"
+        expect(link.full_url).to eq Addressable::URI.parse("#{node.full_url}#{path}")
+        expect(link.href).to eq link.full_url.to_s
+        expect(link.line).to be < 30
+        expect(link.type).to eq :canonical
+        expect(link.rel).to be_blank
+        expect(link.ss_rel).to be_blank
+      end
+      links[1].tap do |link|
         path = "#{today.strftime("%Y%m")}/list.html"
         expect(link.full_url).to eq Addressable::URI.parse("#{node.full_url}#{path}")
         expect(link.href).to eq "#{node.url}#{path}"
@@ -209,7 +218,7 @@ describe Cms::CheckLinks::LinkExtractor, type: :model, dbscope: :example do
         expect(link.rel).to be_blank
         expect(link.ss_rel).to be_blank
       end
-      links[1].tap do |link|
+      links[2].tap do |link|
         path = "#{today.strftime("%Y%m")}/list.ics"
         expect(link.full_url).to eq Addressable::URI.parse("#{node.full_url}#{path}")
         expect(link.href).to eq "#{node.url}#{path}"
@@ -218,7 +227,7 @@ describe Cms::CheckLinks::LinkExtractor, type: :model, dbscope: :example do
         expect(link.rel).to be_blank
         expect(link.ss_rel).to eq "nofollow"
       end
-      links[2].tap do |link|
+      links[3].tap do |link|
         path = "#{today.prev_month.strftime("%Y%m")}/index.html"
         expect(link.full_url).to eq Addressable::URI.parse("#{node.full_url}#{path}")
         expect(link.href).to eq "#{node.url}#{path}"
@@ -227,7 +236,7 @@ describe Cms::CheckLinks::LinkExtractor, type: :model, dbscope: :example do
         expect(link.rel).to be_blank
         expect(link.ss_rel).to eq "nofollow"
       end
-      links[3].tap do |link|
+      links[4].tap do |link|
         path = "#{today.next_month.strftime("%Y%m")}/index.html"
         expect(link.full_url).to eq Addressable::URI.parse("#{node.full_url}#{path}")
         expect(link.href).to eq "#{node.url}#{path}"
@@ -236,12 +245,36 @@ describe Cms::CheckLinks::LinkExtractor, type: :model, dbscope: :example do
         expect(link.rel).to be_blank
         expect(link.ss_rel).to eq "nofollow"
       end
-      links[4].tap do |link|
+      links[5].tap do |link|
         path = "#{today.strftime("%Y%m%d")}/"
         expect(link.full_url).to eq Addressable::URI.parse("#{node.full_url}#{path}")
         expect(link.href).to eq "#{node.url}#{path}"
         expect(link.line).to be > 30
         expect(link.type).to eq :inner_yield
+        expect(link.rel).to be_blank
+        expect(link.ss_rel).to be_blank
+      end
+    end
+  end
+
+  context "with canonical" do
+    let(:canonical_url) { unique_url }
+
+    it do
+      html = <<~HTML
+        <link rel="canonical" href="#{canonical_url}"/>
+      HTML
+
+      extractor = described_class.new(cur_site: site, base_url: site.full_url, html: html)
+      links = extractor.to_a
+      expect(links).to have(1).items
+
+      links[0].tap do |link|
+        expect(link.full_url).to be_a(Addressable::URI)
+        expect(link.full_url).to eq Addressable::URI.parse(canonical_url)
+        expect(link.href).to eq canonical_url
+        expect(link.line).to eq 1
+        expect(link.type).to eq :canonical
         expect(link.rel).to be_blank
         expect(link.ss_rel).to be_blank
       end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - HTMLのcanonicalリンクを自動検出し、ページの正規URLとして記録できるようになりました。
  - canonicalリンクを通常のリンク検査から除外し、重複した検証や誤検知を防止します。
  - リンク抽出ログにcanonicalリンクの情報が表示されるようになりました。

- **不具合修正**
  - URL処理の安定性を改善し、生成ファイルやHTMLコンテンツの取得時に一貫して扱えるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->