### PR TITLE
[fixup][modify][gws] Add public links dropdown menu to GWS header [J090-622]

### DIFF
--- a/app/assets/stylesheets/gws/public_links/_menu.scss
+++ b/app/assets/stylesheets/gws/public_links/_menu.scss
@@ -11,6 +11,8 @@ $gws-public-links-link-row-height: 37px;
 .gws-public-links {
   display: inline-block;
   vertical-align: bottom;
+  // change_add
+  position: static;
 
   .gws-public-links-toggle {
     display: block;
@@ -52,10 +54,22 @@ $gws-public-links-link-row-height: 37px;
     // Follow the content instead: the boxes container caps itself at 4 columns
     // (see .gws-public-links-boxes max-width), and max-content lets the browser
     // add frame padding and border automatically, so 4 columns always fit.
-    width: max-content;
-    max-width: 90vw;
+
+    // change_disable
+    // width: max-content;
+    // max-width: 90vw;
+
+    // change_add
+    width: calc(100% - 210px);
+
     // leave a gap above for the speech-bubble pointer
-    margin-top: 10px;
+
+    // change_disable
+    // margin-top: 10px;
+
+    // change_add
+    margin-top: 1px;
+
     padding: 0;
     border: init.$border-gray4;
     background-color: init.$white;
@@ -68,7 +82,13 @@ $gws-public-links-link-row-height: 37px;
     &::after {
       content: "";
       position: absolute;
-      right: 18px;
+
+      // change_disable
+      // right: 18px;
+
+      // change_add
+      right: 374px;
+
       bottom: 100%;
       width: 12px;
       height: 12px;
@@ -79,6 +99,14 @@ $gws-public-links-link-row-height: 37px;
       // follow the panel border color so the contrast theme recolors it
       border-color: inherit;
       background-color: inherit;
+
+      // change_add ===========================
+      @media screen and (max-width: 407px) {
+        right: unset;
+        left: 20px;
+      }
+
+      // ======================================
     }
 
     // the lazy turbo-frame is inline by default; make it a block so its
@@ -148,23 +176,46 @@ $gws-public-links-link-row-height: 37px;
   flex-wrap: wrap;
   gap: $gws-public-links-box-gap;
   // cap the row at 4 boxes; the 5th wraps to the next line
-  max-width: $gws-public-links-box-width * 4 + $gws-public-links-box-gap * 3;
 
-  @include init.mb {
-    max-width: none;
-  }
+  // change_disable =============
+  // max-width: $gws-public-links-box-width * 4 + $gws-public-links-box-gap * 3;
+
+  // @include init.mb {
+  //   max-width: none;
+  // }
+  // ============================
 }
 
 .gws-public-links-box {
   display: flex;
   // box-sizing keeps the 1px borders inside the fixed width so 4 boxes fit the row
   box-sizing: border-box;
-  flex: 0 0 $gws-public-links-box-width;
+
+  // change_disable
+  // flex: 0 0 $gws-public-links-box-width;
+
   flex-direction: column;
-  width: $gws-public-links-box-width;
+
+  // change_disable
+  // width: $gws-public-links-box-width;
+
+  // change_add
+  width: calc((100% - 45px) / 4);
+
   overflow: hidden;
   border: 1px solid #e0e0e0;
   border-radius: 4px;
+
+  // change_add ================
+  @media screen and (max-width: 1280px) {
+    width: calc((100% - 30px) / 3);
+  }
+
+  @media screen and (max-width: 1024px) {
+    width: calc((100% - 15px) / 2);
+  }
+
+  // ===========================
 
   @include init.mb {
     flex-basis: 100%;
@@ -238,7 +289,7 @@ $gws-public-links-link-row-height: 37px;
 
 // the no-url case renders the name as a bare span directly in the list item
 // (scoped so it does NOT add extra padding to the name span inside a link)
-.gws-public-links-list-item > .gws-public-links-link-name {
+.gws-public-links-list-item>.gws-public-links-link-name {
   display: block;
   padding: 8px 12px;
   overflow: hidden;

--- a/app/assets/stylesheets/gws/public_links/_menu.scss
+++ b/app/assets/stylesheets/gws/public_links/_menu.scss
@@ -93,7 +93,12 @@ $gws-public-links-link-row-height: 37px;
       display: block;
     }
 
+    // The header wraps at this width, so the toggle no longer sits at the head's
+    // right edge. Stretch the panel across the whole head (left:0 + right:0) so
+    // the speech-bubble pointer on the toggle always lands on the panel, and so
+    // the panel does not shrink-to-fit (the boxes are sized in % of the panel).
     @include init.mb {
+      left: 0;
       width: auto;
       max-width: 100vw;
     }

--- a/app/assets/stylesheets/gws/public_links/_menu.scss
+++ b/app/assets/stylesheets/gws/public_links/_menu.scss
@@ -33,6 +33,7 @@ $gws-public-links-link-row-height: 37px;
       content: "";
       display: none;
       position: absolute;
+      z-index: 600;
       right: 18px;
       bottom: -2px;
       width: 12px;
@@ -43,7 +44,7 @@ $gws-public-links-link-row-height: 37px;
       border-left: 1px solid;
       // follow the panel border color so the contrast theme recolors it
       border-color: inherit;
-      background-color: #fff !important;
+      background-color: #fff;
     }
 
     &:hover {

--- a/app/assets/stylesheets/gws/public_links/_menu.scss
+++ b/app/assets/stylesheets/gws/public_links/_menu.scss
@@ -2,7 +2,6 @@
 // Public links dropdown (header menu)
 @use "ss/init";
 
-$gws-public-links-box-width: 230px;
 $gws-public-links-box-gap: 15px;
 $gws-public-links-frame-padding: 15px;
 // one link row ≈ 8px+8px padding + line + 1px divider; show up to 6, then scroll
@@ -10,12 +9,17 @@ $gws-public-links-link-row-height: 37px;
 
 .gws-public-links {
   display: inline-block;
-  vertical-align: bottom;
-  // change_add
   position: static;
+  vertical-align: bottom;
+
+  &:has(.gws-public-links-dropdown-menu.active) 
+  .gws-public-links-toggle::after {
+      display: block;
+    }
 
   .gws-public-links-toggle {
     display: block;
+    position: relative;
     margin: 0;
     padding: 12px;
     border: 0;
@@ -23,6 +27,24 @@ $gws-public-links-link-row-height: 37px;
     color: init.$white;
     line-height: 1;
     cursor: pointer;
+
+    // speech-bubble pointer aimed at the toggle icon (panel is right-aligned to it).
+    &::after {
+      content: "";
+      display: none;
+      position: absolute;
+      right: 18px;
+      bottom: -2px;
+      width: 12px;
+      height: 12px;
+      margin-bottom: -6px;
+      transform: rotate(45deg);
+      border-top: 1px solid;
+      border-left: 1px solid;
+      // follow the panel border color so the contrast theme recolors it
+      border-color: inherit;
+      background-color: #fff !important;
+    }
 
     &:hover {
       background-color: #424242;
@@ -53,21 +75,12 @@ $gws-public-links-link-row-height: 37px;
     // With absolute positioning + right:0, width:auto collapses to one box.
     // Follow the content instead: the boxes container caps itself at 4 columns
     // (see .gws-public-links-boxes max-width), and max-content lets the browser
-    // add frame padding and border automatically, so 4 columns always fit.
+    // add frame padding and border automatically, so 3 columns always fit.
 
-    // change_disable
-    // width: max-content;
-    // max-width: 90vw;
-
-    // change_add
     width: calc(100% - 210px);
 
     // leave a gap above for the speech-bubble pointer
 
-    // change_disable
-    // margin-top: 10px;
-
-    // change_add
     margin-top: 1px;
 
     padding: 0;
@@ -75,39 +88,6 @@ $gws-public-links-link-row-height: 37px;
     background-color: init.$white;
     box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
     color: init.$black;
-
-    // speech-bubble pointer aimed at the toggle icon (panel is right-aligned to it).
-    // Use a rotated square whose fill is background-color so it follows the
-    // contrast theme (which overrides background-color on `body *:after`).
-    &::after {
-      content: "";
-      position: absolute;
-
-      // change_disable
-      // right: 18px;
-
-      // change_add
-      right: 374px;
-
-      bottom: 100%;
-      width: 12px;
-      height: 12px;
-      margin-bottom: -6px;
-      transform: rotate(45deg);
-      border-top: 1px solid;
-      border-left: 1px solid;
-      // follow the panel border color so the contrast theme recolors it
-      border-color: inherit;
-      background-color: inherit;
-
-      // change_add ===========================
-      @media screen and (max-width: 407px) {
-        right: unset;
-        left: 20px;
-      }
-
-      // ======================================
-    }
 
     // the lazy turbo-frame is inline by default; make it a block so its
     // contents can lay out across the full panel width.
@@ -175,47 +155,20 @@ $gws-public-links-link-row-height: 37px;
   display: flex;
   flex-wrap: wrap;
   gap: $gws-public-links-box-gap;
-  // cap the row at 4 boxes; the 5th wraps to the next line
-
-  // change_disable =============
-  // max-width: $gws-public-links-box-width * 4 + $gws-public-links-box-gap * 3;
-
-  // @include init.mb {
-  //   max-width: none;
-  // }
-  // ============================
+  // cap the row at 3 boxes; the 4th wraps to the next line
 }
 
 .gws-public-links-box {
   display: flex;
-  // box-sizing keeps the 1px borders inside the fixed width so 4 boxes fit the row
+  // box-sizing keeps the 1px borders inside the fixed width so 3 boxes fit the row
   box-sizing: border-box;
-
-  // change_disable
-  // flex: 0 0 $gws-public-links-box-width;
-
   flex-direction: column;
 
-  // change_disable
-  // width: $gws-public-links-box-width;
-
-  // change_add
-  width: calc((100% - 45px) / 4);
+  width: calc((100% - $gws-public-links-box-gap * 2) / 3);
 
   overflow: hidden;
   border: 1px solid #e0e0e0;
   border-radius: 4px;
-
-  // change_add ================
-  @media screen and (max-width: 1280px) {
-    width: calc((100% - 30px) / 3);
-  }
-
-  @media screen and (max-width: 1024px) {
-    width: calc((100% - 15px) / 2);
-  }
-
-  // ===========================
 
   @include init.mb {
     flex-basis: 100%;

--- a/app/assets/stylesheets/gws/public_links/_menu.scss
+++ b/app/assets/stylesheets/gws/public_links/_menu.scss
@@ -12,10 +12,10 @@ $gws-public-links-link-row-height: 37px;
   position: static;
   vertical-align: bottom;
 
-  &:has(.gws-public-links-dropdown-menu.active) 
-  .gws-public-links-toggle::after {
-      display: block;
-    }
+  &:has(.gws-public-links-dropdown-menu.active)
+    .gws-public-links-toggle::after {
+    display: block;
+  }
 
   .gws-public-links-toggle {
     display: block;
@@ -74,14 +74,11 @@ $gws-public-links-link-row-height: 37px;
   .gws-public-links-dropdown-menu {
     right: 0;
     // With absolute positioning + right:0, width:auto collapses to one box.
-    // Follow the content instead: the boxes container caps itself at 4 columns
-    // (see .gws-public-links-boxes max-width), and max-content lets the browser
-    // add frame padding and border automatically, so 3 columns always fit.
-
+    // Reserve the toggle/icon area on the right (210px) so the 3-column box
+    // grid fits within the remaining panel width.
     width: calc(100% - 210px);
 
-    // leave a gap above for the speech-bubble pointer
-
+    // sit just below the toggle; the speech-bubble pointer lives on the toggle itself
     margin-top: 1px;
 
     padding: 0;
@@ -243,7 +240,7 @@ $gws-public-links-link-row-height: 37px;
 
 // the no-url case renders the name as a bare span directly in the list item
 // (scoped so it does NOT add extra padding to the name span inside a link)
-.gws-public-links-list-item>.gws-public-links-link-name {
+.gws-public-links-list-item > .gws-public-links-link-name {
   display: block;
   padding: 8px 12px;
   overflow: hidden;


### PR DESCRIPTION
## 概要
GWS リンク集のヘッダードロップダウンのスタイルを、調整（3カラム化・吹き出し位置変更）

## 変更内容
対象ファイルは `app/assets/stylesheets/gws/public_links/_menu.scss` の1ファイルのみ

- ドロップダウンのレイアウトを **固定幅4カラム → 可変幅3カラム**（`calc()` ベース）に変更
  - ボックス幅を `230px` 固定から `calc((100% - gap*2) / 3)` に
  - パネル幅を `max-content` から `calc(100% - 210px)` に
- 吹き出しポインタ（三角）を **パネル側 → トグルボタン側** へ移動し、`.active` 時に表示するよう `:has()` で制御

## 経緯

dev-seisaku（制作チーム）の以下3コミットを cherry-pick で取り込んでいます（履歴を保持）。

- `リンク集スタイルの調整（修正中） (#18)`
- `[fixup]制作チーム差分（リンク集）`
- `[fixup^2]制作チーム差分（リンク集）`

## 補足
- リンクブロックが一つで画面幅が狭くなった際に下記の状態になる表示を調整
https://github.com/shirasagi/shirasagi/pull/6163/changes/10c9b11145ec6300349949449a05612249346b65

**修正前**
<img width="706" height="828" alt="pr6163-706-before" src="https://github.com/user-attachments/assets/7975f804-a61f-4b17-a1ca-e76b0b6f6f77" />

**修正後**
<img width="706" height="828" alt="pr6163-706-fixed" src="https://github.com/user-attachments/assets/bf8cf421-3775-4774-bbca-63bb10c3dc8c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 公共リンクのドロップダウンで、開閉状態に応じて吹き出しポインタをトグル側に表示し、操作の意図がより分かりやすくなりました。
  * メニュー枠の余白・背景・影などの見た目と横幅の調整を行い、表示がより整いました（レスポンシブ対応も改善）。
  * リンクボックスの並びを4列上限から3列上限に変更し、画面幅に合わせて収まりやすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->