### PR TITLE
[fix][ss] ナビメニューの矢印グリフがドロップダウン内の項目にも表示される問題を修正

### DIFF
--- a/app/assets/stylesheets/ss/_pc_mb.scss
+++ b/app/assets/stylesheets/ss/_pc_mb.scss
@@ -1697,6 +1697,11 @@ _:future,
     a:not(.no-margin) {
       margin-right: 16px;
     }
+    // ドロップダウン内の項目には矢印グリフを表示しない
+    // （背景画像時代は webmail/_ss.scss の background-image: none で打ち消されていたが、::before グリフには効かないため）
+    .dropdown-menu a::before {
+      content: none;
+    }
     .dropdown-toggle {
       &::after {
         content: "";


### PR DESCRIPTION
## 概要
表示崩れの修正

## 変更内容
**修正前**
<img width="678" height="336" alt="スクリーンショット 2026-07-23 14 26 23" src="https://github.com/user-attachments/assets/06e8980e-3ea0-4f57-9ceb-18d79a954fb8" />

PR #6118 で #menu .nav-menu / .sns-nav-menu のリンク矢印を背景画像から ::before の Material Icons グリフに変更した際、配下のドロップダウン項目
(.dropdown-menu 内の a)にもグリフが付き、アイコンが文字に重なって表示が
崩れていた。

**修正後**
<img width="1904" height="651" alt="スクリーンショット 2026-07-29 13 10 00（2）" src="https://github.com/user-attachments/assets/9e6a8ac9-92db-42e9-b306-84974c940e54" />

背景画像時代は webmail/_ss.scss の
「#menu .nav-menu .dropdown .dropdown-menu a { background-image: none }」 が矢印を打ち消していたが、::before グリフには効かない。そのため
.dropdown-menu 内の a::before を content: none で打ち消すルールを追加し、 ドロップダウン項目には矢印を表示しないようにした。

refs J090-635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ドロップダウンメニュー内のリンクに表示されていた矢印アイコンを非表示にしました。
  * メニュー項目の表示がすっきりし、不要な矢印が表示されなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->