### PR TITLE
[fix] unlock issue on firefox

### DIFF
--- a/app/assets/javascripts/cms/preview/main.js.erb
+++ b/app/assets/javascripts/cms/preview/main.js.erb
@@ -1251,28 +1251,16 @@ SS_Preview = (function () {
 
   EditLock.prototype.release = function() {
     if (!SS_Preview.lockPath) {
-      return $.Deferred().resolve().promise();
+      return;
     }
 
-    var self = this;
     var url = SS_Preview.lockPath;
     var token = $('meta[name="csrf-token"]').attr('content');
 
-    return $.ajax({
-      url: url,
-      type: "POST",
-      dataType: "json",
-      cache: false,
-      data: { _method: "delete", authenticity_token: token }
-    }).fail(function(xhr, status, error) {
-      if (self.container.notice) {
-        if (xhr.responseJSON) {
-          self.container.notice.show(xhr.responseJSON.join("\n"));
-        } else {
-          self.container.notice.show(error);
-        }
-      }
-    });
+    var data = new FormData();
+    data.append("authenticity_token", token);
+    data.append("_method", "delete");
+    navigator.sendBeacon(url, data)
   };
 
   EditLock.prototype.startRefreshLoop = function(failed) {
@@ -1394,10 +1382,11 @@ SS_Preview = (function () {
 
     if (dontCareLock) {
       afterReleased();
-      return $.Deferred().resolve().promise();
+      return;
     }
 
-    return this.editLock.release().always(afterReleased);
+    this.editLock.release();
+    afterReleased();
   };
 
   //

--- a/app/assets/javascripts/ss/lib/edit_lock.js
+++ b/app/assets/javascripts/ss/lib/edit_lock.js
@@ -59,15 +59,11 @@ this.SS_EditLock = (function () {
 
   SS_EditLock.prototype.releaseLock = function () {
     this.unloading = true;
-    $.ajax({
-      type: "POST",
-      url: this.unlock_url,
-      dataType: "json",
-      data: {
-        _method: "delete"
-      },
-      timeout: 5000
-    });
+    var token = $('meta[name="csrf-token"]').attr('content');
+    var data = new FormData();
+    data.append("authenticity_token", token);
+    data.append("_method", "delete");
+    navigator.sendBeacon(this.unlock_url, data)
   };
 
   SS_EditLock.prototype.releaseLockOnCancel = function () {

--- a/app/controllers/cms/node/max_file_sizes_controller.rb
+++ b/app/controllers/cms/node/max_file_sizes_controller.rb
@@ -71,7 +71,7 @@ class Cms::Node::MaxFileSizesController < ApplicationController
   def edit
     raise "403" unless @cur_node.allowed?(:edit, @cur_user, site: @cur_site)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/concerns/cms/crud_filter.rb
+++ b/app/controllers/concerns/cms/crud_filter.rb
@@ -156,7 +156,7 @@ module Cms::CrudFilter
   def edit
     raise "403" unless @item.allowed?(:edit, @cur_user, site: @cur_site, node: @cur_node)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/concerns/cms/lock_filter.rb
+++ b/app/controllers/concerns/cms/lock_filter.rb
@@ -20,7 +20,7 @@ module Cms::LockFilter
       return
     end
 
-    if @item.acquire_lock(force: params[:force].present?)
+    if @item.acquire_lock(user: @cur_user, force: params[:force].present?)
       render
     else
       respond_to do |format|
@@ -66,7 +66,7 @@ module Cms::LockFilter
       return
     end
 
-    if @item.release_lock(force: params[:force].present?)
+    if @item.release_lock(user: @cur_user, force: params[:force].present?)
       respond_to do |format|
         format.html { redirect_to(action: :edit) }
         format.json { head :no_content }

--- a/app/controllers/concerns/cms/page_filter.rb
+++ b/app/controllers/concerns/cms/page_filter.rb
@@ -89,7 +89,7 @@ module Cms::PageFilter
 
     if !result && @item.is_a?(Cms::Addon::EditLock)
       # So, edit lock must be held
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         location = { action: :lock }
       end
     end
@@ -112,7 +112,7 @@ module Cms::PageFilter
     # If page is failed to update, page is going to show in edit mode with update errors
     if !result && @item.is_a?(Cms::Addon::EditLock)
       # So, edit lock must be held
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         location = { action: :lock }
       end
     end

--- a/app/controllers/concerns/gws/crud_filter.rb
+++ b/app/controllers/concerns/gws/crud_filter.rb
@@ -77,7 +77,7 @@ module Gws::CrudFilter
 
   def edit
     raise "403" unless @item.allowed?(:edit, @cur_user, site: @cur_site)
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/concerns/gws/daily_report/report_filter.rb
+++ b/app/controllers/concerns/gws/daily_report/report_filter.rb
@@ -159,7 +159,7 @@ module Gws::DailyReport::ReportFilter
 
   def edit
     raise '403' unless @item.editable?(@cur_user, site: @cur_site)
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/concerns/sns/crud_filter.rb
+++ b/app/controllers/concerns/sns/crud_filter.rb
@@ -52,7 +52,7 @@ module Sns::CrudFilter
   def edit
     raise "403" unless @item.allowed?(:edit, @cur_user)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/concerns/webmail/imap_crud_filter.rb
+++ b/app/controllers/concerns/webmail/imap_crud_filter.rb
@@ -47,7 +47,7 @@ module Webmail::ImapCrudFilter
   def edit
     raise "403" unless @item.allowed?(:edit, @imap)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/gws/affair/duty_setting/holidays_controller.rb
+++ b/app/controllers/gws/affair/duty_setting/holidays_controller.rb
@@ -114,7 +114,7 @@ class Gws::Affair::DutySetting::HolidaysController < ApplicationController
 
   def edit
     raise "403" unless @holiday_calendar.allowed?(:edit, @cur_user, site: @cur_site)
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/gws/board/comments_controller.rb
+++ b/app/controllers/gws/board/comments_controller.rb
@@ -89,7 +89,7 @@ class Gws::Board::CommentsController < ApplicationController
   def edit
     raise "403" unless editable?
 
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/gws/daily_report/group_reports/comments_controller.rb
+++ b/app/controllers/gws/daily_report/group_reports/comments_controller.rb
@@ -63,7 +63,7 @@ class Gws::DailyReport::GroupReports::CommentsController < ApplicationController
 
   def edit
     raise "403" unless @item.allowed?(:edit, @cur_user, site: @cur_site)
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/gws/daily_report/reports_controller.rb
+++ b/app/controllers/gws/daily_report/reports_controller.rb
@@ -147,7 +147,7 @@ class Gws::DailyReport::ReportsController < ApplicationController
 
   def edit
     raise '403' unless @item.editable?(@cur_user, site: @cur_site)
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/gws/daily_report/user_reports/comments_controller.rb
+++ b/app/controllers/gws/daily_report/user_reports/comments_controller.rb
@@ -61,7 +61,7 @@ class Gws::DailyReport::UserReports::CommentsController < ApplicationController
 
   def edit
     raise "403" unless @item.allowed?(:edit, @cur_user, site: @cur_site)
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/gws/discussion/forums_controller.rb
+++ b/app/controllers/gws/discussion/forums_controller.rb
@@ -72,7 +72,7 @@ class Gws::Discussion::ForumsController < ApplicationController
   def edit
     raise "403" unless @item.allowed?(:edit, @cur_user, site: @cur_site)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/gws/notice/apis/comments_controller.rb
+++ b/app/controllers/gws/notice/apis/comments_controller.rb
@@ -51,7 +51,7 @@ class Gws::Notice::Apis::CommentsController < ApplicationController
   def edit
     raise '403' if @item.user_id != @cur_user.id && !@cur_notice.allowed?(:edit, @cur_user, site: @cur_site)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/gws/schedule/comments_controller.rb
+++ b/app/controllers/gws/schedule/comments_controller.rb
@@ -55,7 +55,7 @@ class Gws::Schedule::CommentsController < ApplicationController
   def edit
     raise '403' if @item.user_id != @cur_user.id && !@cur_schedule.allowed_for_managers?(:edit, @cur_user, site: @cur_site)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/gws/schedule/todo/apis/comments_controller.rb
+++ b/app/controllers/gws/schedule/todo/apis/comments_controller.rb
@@ -82,7 +82,7 @@ class Gws::Schedule::Todo::Apis::CommentsController < ApplicationController
     @cur_todo.errors.clear
 
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/gws/share/files_controller.rb
+++ b/app/controllers/gws/share/files_controller.rb
@@ -130,7 +130,7 @@ class Gws::Share::FilesController < ApplicationController
   def render_update(result, opts = {})
     unless result
       # if result is false, browser goes to edit form which requires to be locked.
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end
@@ -227,7 +227,7 @@ class Gws::Share::FilesController < ApplicationController
   def edit
     raise "403" unless @item.allowed?(:edit, @cur_user, site: @cur_site)
 
-    unless @item.acquire_lock
+    unless @item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end
@@ -261,7 +261,7 @@ class Gws::Share::FilesController < ApplicationController
   end
 
   def lock
-    if @item.acquire_lock(force: params[:force].present?)
+    if @item.acquire_lock(user: @cur_user, force: params[:force].present?)
       render
     else
       respond_to do |format|
@@ -300,7 +300,7 @@ class Gws::Share::FilesController < ApplicationController
       return
     end
 
-    if @item.release_lock(force: params[:force].present?)
+    if @item.release_lock(user: @cur_user, force: params[:force].present?)
       respond_to do |format|
         format.html { redirect_to url_for(action: :edit), notice: t("ss.notice.unlocked") }
         format.json { head :no_content }

--- a/app/controllers/gws/staff_record/public_duties_controller.rb
+++ b/app/controllers/gws/staff_record/public_duties_controller.rb
@@ -52,7 +52,7 @@ class Gws::StaffRecord::PublicDutiesController < ApplicationController
 
   def edit_charge
     if @item.is_a?(Cms::Addon::EditLock)
-      return redirect_to(action: :lock) unless @item.acquire_lock
+      return redirect_to(action: :lock) unless @item.acquire_lock(user: @cur_user)
     end
   end
 

--- a/app/controllers/gws/tabular/files_controller.rb
+++ b/app/controllers/gws/tabular/files_controller.rb
@@ -242,7 +242,7 @@ class Gws::Tabular::FilesController < ApplicationController
     raise "404" unless cur_view.authoring_allowed?("edit")
     raise "403" unless policy_class.edit?(@cur_site, @cur_user, @model, @item)
 
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/gws/workflow/files_controller.rb
+++ b/app/controllers/gws/workflow/files_controller.rb
@@ -125,7 +125,7 @@ class Gws::Workflow::FilesController < ApplicationController
   def edit
     raise '403' unless @item.editable?(@cur_user, site: @cur_site)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/controllers/gws/workflow2/files_controller.rb
+++ b/app/controllers/gws/workflow2/files_controller.rb
@@ -182,7 +182,7 @@ class Gws::Workflow2::FilesController < ApplicationController
       redirect_to url_for(action: :show), notice: I18n.t("gws/workflow2.notice.unable_to_edit_because_form_is_deleted")
       return
     end
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/gws/workflow2/routes_controller.rb
+++ b/app/controllers/gws/workflow2/routes_controller.rb
@@ -72,7 +72,7 @@ class Gws::Workflow2::RoutesController < ApplicationController
       end
     end
 
-    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock
+    if @item.is_a?(Cms::Addon::EditLock) && !@item.acquire_lock(user: @cur_user)
       redirect_to action: :lock
       return
     end

--- a/app/controllers/member/group_members_controller.rb
+++ b/app/controllers/member/group_members_controller.rb
@@ -72,7 +72,7 @@ class Member::GroupMembersController < ApplicationController
   def edit
     raise "403" unless @cur_member_group.allowed?(:edit, @cur_user, site: @cur_site, node: @cur_node)
     if @item.is_a?(Cms::Addon::EditLock)
-      unless @item.acquire_lock
+      unless @item.acquire_lock(user: @cur_user)
         redirect_to action: :lock
         return
       end

--- a/app/models/concerns/cms/addon/edit_lock.rb
+++ b/app/models/concerns/cms/addon/edit_lock.rb
@@ -15,7 +15,7 @@ module Cms::Addon::EditLock
     after_save :release_lock
   end
 
-  def acquire_lock(user: @cur_user, force: false)
+  def acquire_lock(user:, force: false)
     return if user.blank?
 
     lock_until = LOCK_INTERVAL.from_now.utc

--- a/app/models/concerns/gws/addon/edit_lock.rb
+++ b/app/models/concerns/gws/addon/edit_lock.rb
@@ -15,7 +15,7 @@ module Gws::Addon::EditLock
     after_save :release_lock
   end
 
-  def acquire_lock(user: @cur_user, force: false)
+  def acquire_lock(user:, force: false)
     return if user.blank?
 
     lock_until = LOCK_INTERVAL.from_now.utc

--- a/app/views/cms/agents/addons/edit_lock/_form.html.erb
+++ b/app/views/cms/agents/addons/edit_lock/_form.html.erb
@@ -6,7 +6,7 @@
       addon[:display_body] = "hide"
     %>
     <%= jquery do %>
-      var editLock = new SS_EditLock(".mod-cms-edit_lock", "<%= url_for action: :lock %>", "<%= url_for action: :unlock %>");
+      var editLock = new SS_EditLock(".mod-cms-edit_lock", "<%= url_for action: :lock, format: :json %>", "<%= url_for action: :unlock, format: :json %>");
     <% end %>
 
     <dl class="see mod-cms-edit_lock">

--- a/app/views/cms/preview/_tool.html.erb
+++ b/app/views/cms/preview/_tool.html.erb
@@ -71,7 +71,7 @@
         SS_Preview.inplaceFormPath.columnValue.moveAt = <%== move_at_cms_apis_preview_inplace_edit_page_column_value_path(site: @cur_site, preview_date: params[:preview_date], page_id: ":pageId", id: ":id").to_json %>;
         SS_Preview.inplaceFormPath.palette = <%== palette_cms_apis_preview_inplace_edit_form_path(site: @cur_site, preview_date: params[:preview_date], id: ":id").to_json %>;
         SS_Preview.publishPath = <%== publish_cms_apis_preview_page_path(site: @cur_site, preview_date: params[:preview_date], id: rendered[:page]).to_json %>;
-        SS_Preview.lockPath = <%== lock_cms_apis_preview_page_path(site: @cur_site, preview_date: params[:preview_date], id: rendered[:page]).to_json %>;
+        SS_Preview.lockPath = <%== lock_cms_apis_preview_page_path(site: @cur_site, preview_date: params[:preview_date], id: rendered[:page], format: :json).to_json %>;
       <% elsif %i[node].include?(rendered[:type]) %>
         SS_Preview.publishPath = <%== publish_cms_apis_preview_node_path(site: @cur_site, preview_date: params[:preview_date], cid: rendered[:node]).to_json %>;
       <% end %>

--- a/app/views/gws/agents/addons/edit_lock/_form.html.erb
+++ b/app/views/gws/agents/addons/edit_lock/_form.html.erb
@@ -6,7 +6,7 @@
       addon[:display_body] = "hide"
     %>
     <%= jquery do %>
-      var editLock = new SS_EditLock(".mod-gws-edit_lock", "<%= url_for action: :lock %>", "<%= url_for action: :unlock %>");
+      var editLock = new SS_EditLock(".mod-gws-edit_lock", "<%= url_for action: :lock, format: :json %>", "<%= url_for action: :unlock, format: :json %>");
     <% end %>
 
     <dl class="see mod-gws-edit_lock">


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

Firefox で記事ページの編集をキャンセルしてもロックされたままになる問題の修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 編集ロックの取得・解除時に利用者情報を正しく反映し、複数の編集画面でロック状態の管理を安定化しました。
  * プレビューや編集画面を離れる際、ロック解除処理を待たずに画面操作を完了できるよう改善しました。
  * ロック解除が通信状況の影響を受けにくくなり、不要なロックが残りにくくなりました。
  * ロック関連の通信形式を統一し、処理の信頼性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->