### PR TITLE
[modify] cms site_search sort_state

### DIFF
--- a/app/controllers/cms/agents/nodes/site_search_controller.rb
+++ b/app/controllers/cms/agents/nodes/site_search_controller.rb
@@ -78,6 +78,11 @@ class Cms::Agents::Nodes::SiteSearchController < ApplicationController
     end
 
     @s.sort = params[:sort]
+
+    if params[:sort].blank? && @cur_node.sort_type.present?
+      @s.sort = @cur_node.sort_type
+    end
+
     @s.field_name = %w(text_index content title)
     @s.from = (params[:page].to_i - 1) * @s.size if params[:page].present?
     @result = @s.search

--- a/app/models/concerns/cms/addon/site_search/setting.rb
+++ b/app/models/concerns/cms/addon/site_search/setting.rb
@@ -10,10 +10,12 @@ module Cms::Addon::SiteSearch
       field :category_state, type: String
       field :organization_state, type: String
       field :site_search_type, type: String
+      field :sort_state, type: String
+      field :sort_type, type: String
       embeds_ids :st_article_nodes, class_name: "Article::Node::Page"
       permit_params :link_target, :search_type_state,
         :article_node_state, :category_state, :organization_state,
-        :site_search_type, st_article_node_ids: []
+        :site_search_type, :sort_state, :sort_type, st_article_node_ids: []
     end
 
     def link_target_options
@@ -26,6 +28,7 @@ module Cms::Addon::SiteSearch
     def search_type_state_options
       %w(show hide).collect { |k| [I18n.t("ss.options.state.#{k}"), k == 'show' ? nil : k] }
     end
+    alias sort_state_options search_type_state_options
 
     def article_node_state_options
       %w(show hide).collect { |k| [I18n.t("ss.options.state.#{k}"), k == 'show' ? nil : k] }
@@ -41,6 +44,10 @@ module Cms::Addon::SiteSearch
 
     def site_search_type_options
       %w(page file all).collect { |k| [I18n.t("cms.options.site_search_type.#{k}"), k] }
+    end
+
+    def sort_type_options
+      %w(score released).collect { |k| [I18n.t("cms.search_sort_options.#{k}"), k] }
     end
   end
 end

--- a/app/views/cms/agents/addons/site_search/setting/_form.html.erb
+++ b/app/views/cms/agents/addons/site_search/setting/_form.html.erb
@@ -21,6 +21,12 @@
   <dt><%= @model.t :organization_state %><%= @model.tt :organization_state %></dt>
   <dd><%= f.select :organization_state, @item.organization_state_options %></dd>
 
+  <dt><%= @model.t :sort_state %><%= @model.tt :sort_state %></dt>
+  <dd><%= f.select :sort_state, @item.sort_state_options %></dd>
+
+  <dt><%= @model.t :sort_type %><%= @model.tt :sort_type %></dt>
+  <dd><%= f.select :sort_type, @item.sort_type_options %></dd>
+
   <dt><%= t("cms.node_config") %><%= @model.tt :st_article_node_ids %></dt>
   <dd class="wide" style="line-height: 2.5">
     <%= f.hidden_field "st_article_node_ids[]", value: "", class: "hidden-ids", id: nil %>

--- a/app/views/cms/agents/addons/site_search/setting/_show.html.erb
+++ b/app/views/cms/agents/addons/site_search/setting/_show.html.erb
@@ -17,6 +17,12 @@
   <dt><%= @model.t :organization_state %></dt>
   <dd><%= @item.label(:organization_state) %></dd>
 
+  <dt><%= @model.t :sort_state %></dt>
+  <dd><%= @item.label(:sort_state) %></dd>
+
+  <dt><%= @model.t :sort_type %></dt>
+  <dd><%= @item.label(:sort_type) %></dd>
+
   <dt><%= t("cms.node_config") %></dt>
   <dd><%=br @item.ordered_st_article_nodes.pluck(:name) %></dd>
 </dl>

--- a/app/views/cms/agents/nodes/site_search/_result.html.erb
+++ b/app/views/cms/agents/nodes/site_search/_result.html.erb
@@ -39,18 +39,20 @@ document.addEventListener('DOMContentLoaded', () => {
     <%= I18n.t('gws/elasticsearch.format.search_results_count',
       count: count, from: @item.from + 1, to: @item.from + @item.size, took: @result['took'] / 1000.0) %>
   </div>
-  <div>
-    <%
-      sort_params = params.permit(:target, s: {})
-      options = %w(score released).map do |value|
-        name = t("cms.search_sort_options.#{value}")
-        [name, value, 'data-href': "#{@cur_node.url}?" + url_for(sort_params.merge(sort: value).to_query)]
-      end
-    %>
-    <%= t('cms.search_sort') %>
-    <%= select_tag 'sort', options_for_select(options, selected: params[:sort]), id: nil, "aria-label" => t('cms.search_sort'),
-      onchange: 'location.href = this.children[this.selectedIndex].getAttribute("data-href");' %>
-  </div>
+  <% if @cur_node.sort_state != 'hide' %>
+    <div>
+      <%
+        sort_params = params.permit(:target, s: {})
+        options = %w(score released).map do |value|
+          name = t("cms.search_sort_options.#{value}")
+          [name, value, 'data-href': "#{@cur_node.url}?" + url_for(sort_params.merge(sort: value).to_query)]
+        end
+      %>
+      <%= t('cms.search_sort') %>
+      <%= select_tag 'sort', options_for_select(options, selected: params[:sort].presence || @cur_node.sort_type), id: nil, "aria-label" => t('cms.search_sort'),
+        onchange: 'location.href = this.children[this.selectedIndex].getAttribute("data-href");' %>
+    </div>
+  <% end %>
 </div>
 
 <div class="cms-site-search-pages pages">

--- a/app/views/cms/agents/nodes/site_search/_result.html.erb
+++ b/app/views/cms/agents/nodes/site_search/_result.html.erb
@@ -43,9 +43,8 @@ document.addEventListener('DOMContentLoaded', () => {
     <div>
       <%
         sort_params = params.permit(:target, s: {})
-        options = %w(score released).map do |value|
-          name = t("cms.search_sort_options.#{value}")
-          [name, value, 'data-href': "#{@cur_node.url}?" + url_for(sort_params.merge(sort: value).to_query)]
+        options = @cur_node.sort_type_options.map do |k, v|
+          [k, v, 'data-href': "#{@cur_node.url}?" + url_for(sort_params.merge(sort: v).to_query)]
         end
       %>
       <%= t('cms.search_sort') %>

--- a/config/locales/cms/ja.yml
+++ b/config/locales/cms/ja.yml
@@ -1570,6 +1570,8 @@ ja:
         st_article_node_ids: 記事フォルダー
         site_search_type: 検索種類の初期値
         st_group_ids: 組織の設定
+        sort_state: 並び順の選択
+        sort_type: 並び順の初期値
       cms/form:
         name: 名前
         order: 並び順
@@ -3533,6 +3535,10 @@ ja:
         - サイト内検索の対象となる記事フォルダーを設定します。
       site_search_type:
         - 検索種類の初期値を設定します。
+      sort_state:
+        - 検索結果に並び順の選択を表示します。
+      sort_type:
+        - 並び順の初期値を設定します。
 
     cms/line/facility_search/category:
       name:

--- a/spec/features/cms/agents/nodes/site_search2_spec.rb
+++ b/spec/features/cms/agents/nodes/site_search2_spec.rb
@@ -55,7 +55,7 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
   context 'one site with hidden settings' do
     before do
       site_search_node.update search_type_state: 'hide',
-        article_node_state: 'hide', category_state: 'hide', organization_state: 'hide'
+        article_node_state: 'hide', category_state: 'hide', organization_state: 'hide', sort_state: 'hide'
     end
 
     it do
@@ -70,6 +70,9 @@ describe 'cms_agents_nodes_site_search', type: :feature, dbscope: :example, js: 
       within '.search-form' do
         fill_in 's[keyword]', with: 'page ()'
         click_button I18n.t('ss.buttons.search')
+      end
+      within '.search-stats' do
+        expect(page).not_to have_css("select[name='sort']")
       end
       within '.pages .item:nth-child(3)' do
         expect(page).to have_css('.title')


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

サイト内検索の並び順の初期値の設定。

## 変更内容

サイト内検索のフォルダー設定に並び順の初期値の項目を追加。

## その他

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * サイト検索結果の並び替え状態と並び替え種別を設定できるようになりました。
  * 検索結果をスコア順または公開日順で並べ替えられます。
  * 並び替えを指定しない場合は、設定された並び替え種別が適用されます。

* **改善**
  * 設定に応じて、検索結果の並び替え選択欄を表示・非表示できるようになりました。
  * 明示的に指定した並び替え条件が優先されます。
  * サイト検索設定画面で並び替え情報を確認できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->