### PR TITLE
[fix][cms] ループHTMLを参照するフォルダーの複製に失敗する不具合を修正

### DIFF
--- a/app/jobs/concerns/job/cms/copy_nodes/cms_contents.rb
+++ b/app/jobs/concerns/job/cms/copy_nodes/cms_contents.rb
@@ -46,6 +46,11 @@ module Job::Cms::CopyNodes::CmsContents
     [:group, :user, :file, :layout].include?(type)
   end
 
+  def resolve_loop_setting_reference(id)
+    # 同一サイト内の複製なので、サイト共通のループHTML(共有)はそのまま参照する
+    id
+  end
+
   def update_html_strings(src_content, dest_content)
     from = "/" + src_content.filename.match(/(.*\/).*.part.html/)[1]
     to = "/" + dest_content.filename.match(/(.*\/).*.part.html/)[1]

--- a/spec/jobs/cms/node/copy_nodes_job/loop_setting_spec.rb
+++ b/spec/jobs/cms/node/copy_nodes_job/loop_setting_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Cms::Node::CopyNodesJob, dbscope: :example do
+  describe "copy node which refers shared loop setting" do
+    let(:site) { cms_site }
+    let(:layout) { create :cms_layout, cur_site: site }
+    let!(:loop_setting) { create :cms_loop_setting, cur_site: site }
+    let!(:node1) { create :cms_node, cur_site: site, layout: layout }
+    let!(:node2) do
+      create :article_node_page, cur_site: site, cur_node: node1, layout: layout, basename: "node2",
+        loop_setting_id: loop_setting.id
+    end
+
+    let(:target_node_name) { unique_id }
+    let(:target_node_index_name) { unique_id }
+    let(:target_node_filename) { unique_id }
+
+    before do
+      expect do
+        job = Cms::Node::CopyNodesJob.bind(site_id: site.id, node_id: node1.id)
+        job.perform_now(
+          target_node_name: target_node_name, target_node_index_name: target_node_index_name,
+          target_node_filename: target_node_filename)
+      end.to output(include(node2.filename)).to_stdout
+    end
+
+    it "copied node refers the same loop setting" do
+      expect(Job::Log.count).to eq 1
+      Job::Log.first.tap do |log|
+        expect(log.logs).to include(/INFO -- : .* Started Job/)
+        expect(log.logs).not_to include(include('コピーに失敗しました'))
+        expect(log.logs).to include(/INFO -- : .* Completed Job/)
+      end
+
+      copied_node = Cms::Node.site(site).where(filename: "#{target_node_filename}/node2").first
+      expect(copied_node).to be_present
+      expect(copied_node.loop_setting_id).to eq loop_setting.id
+    end
+  end
+end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

フォルダー複製（`Cms::Node::CopyNodesJob`）で、複製対象のフォルダー（配下含む）がループHTML(共有)（`Cms::LoopSetting`）を参照していると、`NoMethodError (undefined method 'resolve_loop_setting_reference')` が発生し「フォルダーのコピーに失敗しました。」となる不具合を修正します。

```
NoMethodError (undefined method 'resolve_loop_setting_reference' for an instance of Cms::Node::CopyNodesJob):
  app/jobs/concerns/ss/copy/cms_contents.rb:146:in 'SS::Copy::CmsContents#resolve_reference'
```

`resolve_loop_setting_reference` はサイト複製用の `Sys::SiteCopy::CmsLoopSettings` にのみ定義されており、フォルダー複製ジョブには定義がないことが原因です。エラーになったフォルダーは基本属性のみで作成され、`loop_setting_id` などの参照系属性が反映されない状態になっていました。

## 変更内容

- `Job::Cms::CopyNodes::CmsContents` に `resolve_loop_setting_reference` を追加。フォルダー複製は同一サイト内の複製のため、ループHTML(共有)は複製せず元の id をそのまま参照します（`resolve_node_reference` と同様のパターン）。
- 再現テスト `spec/jobs/cms/node/copy_nodes_job/loop_setting_spec.rb` を追加。ループHTML(共有)を設定した記事フォルダーを含むツリーを複製し、失敗ログが出ないこと・複製先が同じ `loop_setting_id` を参照することを検証します（修正前は失敗、修正後は成功することを確認済み）。

## 動作確認
1. ループHTMLリキッド形式のテンプレート作成

<img width="878" height="632" alt="スクリーンショット 2026-08-24 15 11 51（2）" src="https://github.com/user-attachments/assets/85ed25f5-a362-4db7-9d31-5436d3e348da" />

```
{% for page in pages %}
<article class="item-{{ page.css_class }} {% if page.new? %}new{% endif %} {% if page.current? %}current{% endif %}">
  <header>
    <time datetime="{{ page.date }}">{{ page.date | ss_date: "long" }}</time>
    <h2>ループHTMLテンプレート<a href="{{ page.url }}">{{ page.index_name | default: page.name }}</a></h2>
  </header>
  <p>{{ page.summary }}</p>
</article>
{% endfor %}
```

3. 記事フォルダに上記のテンプレート設定

**ジョブの結果**
<img width="1265" height="500" alt="スクリーンショット 2026-08-24 15 04 01（2）" src="https://github.com/user-attachments/assets/a0013e2b-200b-4752-a8fb-e4b800d371dc" />

**複製フォルダの確認**
<img width="822" height="844" alt="スクリーンショット 2026-08-24 15 04 41（2）" src="https://github.com/user-attachments/assets/5e22fa28-5318-42d1-a421-88fe0a0fd3a8" />

**公開画面**
<img width="666" height="372" alt="スクリーンショット 2026-08-24 15 08 46（2）" src="https://github.com/user-attachments/assets/879f5702-ace2-479e-a6c1-25241bb828d9" />


## その他

- `spec/jobs/cms/node/copy_nodes_job/` 配下の既存 spec（7 examples）がすべて成功することを確認済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ノードのコピー時、同一サイト内で共有されているループ設定への参照を正しく維持するようになりました。
  * コピー後も、元の共有ループ設定を引き続き利用できます。
* **テスト**
  * 共有ループ設定を参照するノードのコピー動作を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->