### PR TITLE
[fix][gws][schedule] invalid date in EN

### DIFF
--- a/app/controllers/concerns/gws/schedule/calendar_filter.rb
+++ b/app/controllers/concerns/gws/schedule/calendar_filter.rb
@@ -26,7 +26,7 @@ module Gws::Schedule::CalendarFilter
 
     def redirection_date
       if @item.present?
-        return I18n.l(@item.start_at.to_date, format: :picker)
+        return @item.start_at.to_date.iso8601
       end
 
       date = params.dig(:calendar, :date)
@@ -35,7 +35,7 @@ module Gws::Schedule::CalendarFilter
       end
 
       # Timecop で today / now が変更されている可能性があるので、現在年月日を明示する
-      I18n.l(Time.zone.today, format: :picker)
+      Time.zone.today.iso8601
     end
 
     def redirection_view_format

--- a/app/controllers/concerns/gws/schedule/calendar_filter.rb
+++ b/app/controllers/concerns/gws/schedule/calendar_filter.rb
@@ -26,7 +26,7 @@ module Gws::Schedule::CalendarFilter
 
     def redirection_date
       if @item.present?
-        return @item.start_at.to_date.to_s
+        return I18n.l(@item.start_at.to_date, format: :picker)
       end
 
       date = params.dig(:calendar, :date)
@@ -35,7 +35,7 @@ module Gws::Schedule::CalendarFilter
       end
 
       # Timecop で today / now が変更されている可能性があるので、現在年月日を明示する
-      I18n.l(Time.zone.today, format: :iso)
+      I18n.l(Time.zone.today, format: :picker)
     end
 
     def redirection_view_format


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

ユーザーのロケールが英語の時、date が MM-DD-YYYY となる。
MM-DD-YYYY 形式の日付は parse に失敗するので、動作が不正になる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * カレンダーのリダイレクト時に、予定の日付と今日の日付がISO 8601形式で正しく扱われるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->