### PR TITLE
Fix/cms loop setting reference

### DIFF
--- a/app/controllers/concerns/cms/column_filter2.rb
+++ b/app/controllers/concerns/cms/column_filter2.rb
@@ -18,6 +18,12 @@ module Cms::ColumnFilter2
 
   private
 
+  def set_items
+    raise SS::ForbiddenError unless cur_form.allowed?(:read, @cur_user, site: @cur_site)
+
+    @items ||= items
+  end
+
   def set_assets
     stylesheet "/assets/css/codemirror/codemirror.css"
     javascript "/assets/js/codemirror/codemirror.js"

--- a/app/helpers/cms/form_helper.rb
+++ b/app/helpers/cms/form_helper.rb
@@ -31,13 +31,16 @@ module Cms::FormHelper
     items
   end
 
-  def ancestral_loop_settings
-    items = []
-    settings = Cms::LoopSetting.site(@cur_site).shirasagi
-    settings.each do |item|
-      items << [item.name, item.id]
-    end
-    items
+  def ancestral_loop_settings(loop_setting = nil)
+    settings = Cms::LoopSetting.site(@cur_site).shirasagi.template_type
+    loop_setting = nil unless loop_setting&.html_format_shirasagi?
+    loop_template_options(settings, loop_setting)
+  end
+
+  def liquid_loop_template_options(loop_setting = nil)
+    settings = Cms::LoopSetting.site(@cur_site).liquid.template_type
+    loop_setting = nil unless loop_setting&.html_format_liquid?
+    loop_template_options(settings, loop_setting)
   end
 
   def ancestral_forms
@@ -51,5 +54,15 @@ module Cms::FormHelper
     st_forms = st_forms.and_public
     st_forms = st_forms.allow(:read, @cur_user, site: @cur_site)
     st_forms.order_by(update: 1)
+  end
+
+  private
+
+  def loop_template_options(settings, loop_setting)
+    options = settings.map { |setting| [setting.name, setting.id] }
+    if loop_setting && options.none? { |_name, id| id == loop_setting.id }
+      options << [loop_setting.name, loop_setting.id]
+    end
+    options
   end
 end

--- a/app/helpers/cms/form_helper.rb
+++ b/app/helpers/cms/form_helper.rb
@@ -33,12 +33,14 @@ module Cms::FormHelper
 
   def ancestral_loop_settings(loop_setting = nil)
     settings = Cms::LoopSetting.site(@cur_site).shirasagi.template_type
+    settings = settings.allow(:edit, @cur_user, site: @cur_site)
     loop_setting = nil unless loop_setting&.html_format_shirasagi?
     loop_template_options(settings, loop_setting)
   end
 
   def liquid_loop_template_options(loop_setting = nil)
     settings = Cms::LoopSetting.site(@cur_site).liquid.template_type
+    settings = settings.allow(:edit, @cur_user, site: @cur_site)
     loop_setting = nil unless loop_setting&.html_format_liquid?
     loop_template_options(settings, loop_setting)
   end

--- a/app/jobs/cms/node/copy_nodes_job.rb
+++ b/app/jobs/cms/node/copy_nodes_job.rb
@@ -4,6 +4,7 @@ class Cms::Node::CopyNodesJob < Cms::ApplicationJob
   include Job::Cms::CopyNodes::CmsForms
   include Job::Cms::CopyNodes::CmsColumns
   include Job::Cms::CopyNodes::CmsLayouts
+  include SS::Copy::CmsLoopSettings
   include Job::Cms::CopyNodes::CmsNodes
   include Job::Cms::CopyNodes::CmsParts
   include Job::Cms::CopyNodes::CmsPages

--- a/app/jobs/concerns/ss/copy/cms_loop_settings.rb
+++ b/app/jobs/concerns/ss/copy/cms_loop_settings.rb
@@ -1,0 +1,9 @@
+module SS::Copy::CmsLoopSettings
+  extend ActiveSupport::Concern
+
+  # ループHTML(共有)はサイト単位の共有リソースで、フォルダー複製は同一サイト内で行われる。
+  # そのため複製せず、複製先にも同じ設定を参照させる（レイアウト・定型フォームと同じ扱い）。
+  def resolve_loop_setting_reference(id)
+    id
+  end
+end

--- a/app/models/cms/column/base.rb
+++ b/app/models/cms/column/base.rb
@@ -12,6 +12,16 @@ class Cms::Column::Base
         name: self.model_name.human
       }
     end
+
+    # カラム自体は権限を持たず、親フォームの権限に従う。
+    def allowed?(action, user, opts = {})
+      Cms::Form.allowed?(action, user, opts)
+    end
+  end
+
+  # カラム自体は権限を持たず、親フォームの権限に従う。
+  def allowed?(action, user, opts = {})
+    form ? form.allowed?(action, user, opts) : false
   end
 
   def alignment_options

--- a/app/models/cms/loop_setting.rb
+++ b/app/models/cms/loop_setting.rb
@@ -21,6 +21,7 @@ class Cms::LoopSetting
   validates :loop_html_setting_type, inclusion: { in: %w(template snippet), allow_blank: true }
   validates :state, inclusion: { in: %w(public closed), allow_blank: true }
   validates :html, liquid_format: true, if: ->{ html_format_liquid? }
+  before_validation :normalize_loop_html_setting_type
 
   default_scope -> { order_by(order: 1, name: 1) }
   scope :public_state, -> { where(:state.in => [nil, 'public']) }
@@ -84,5 +85,11 @@ class Cms::LoopSetting
     %w(template snippet).map do |v|
       [I18n.t("cms.options.loop_html_setting_type.#{v}"), v]
     end
+  end
+
+  private
+
+  def normalize_loop_html_setting_type
+    self.loop_html_setting_type = 'template' if loop_html_setting_type == 'snippet' && !html_format_liquid?
   end
 end

--- a/app/models/concerns/cms/addon/column/layout.rb
+++ b/app/models/concerns/cms/addon/column/layout.rb
@@ -1,11 +1,13 @@
 module Cms::Addon::Column::Layout
   extend ActiveSupport::Concern
   extend SS::Addon
+  include Cms::Addon::LoopSettingValidation
 
   included do
     field :layout, type: String
     belongs_to :loop_setting, class_name: 'Cms::LoopSetting'
     permit_params :layout, :loop_setting_id
     validates :layout, liquid_format: true
+    validate -> { validate_loop_setting_reference('liquid') }
   end
 end

--- a/app/models/concerns/cms/addon/layout_html.rb
+++ b/app/models/concerns/cms/addon/layout_html.rb
@@ -2,11 +2,13 @@ module Cms::Addon
   module LayoutHtml
     extend ActiveSupport::Concern
     extend SS::Addon
+    include Cms::Addon::LoopSettingValidation
 
     included do
       field :html, type: String
       belongs_to :loop_setting, class_name: 'Cms::LoopSetting'
       permit_params :html, :loop_setting_id
+      validate -> { validate_loop_setting_reference('liquid') }
     end
   end
 end

--- a/app/models/concerns/cms/addon/list.rb
+++ b/app/models/concerns/cms/addon/list.rb
@@ -2,6 +2,7 @@ module Cms::Addon::List
   module Model
     extend ActiveSupport::Concern
     extend SS::Translation
+    include Cms::Addon::LoopSettingValidation
 
     WELL_KONWN_CONDITION_HASH_OPTIONS = %i[site default_location request_dir category bind].freeze
 
@@ -49,6 +50,11 @@ module Cms::Addon::List
       validates :no_items_display_state, inclusion: { in: %w(show hide), allow_blank: true }
       validates :loop_format, inclusion: { in: %w(shirasagi liquid), allow_blank: true }
       validates :loop_liquid, liquid_format: true, if: ->{ loop_format_liquid? }
+      validate lambda {
+        validate_loop_setting_reference(
+          loop_format_liquid? ? 'liquid' : 'shirasagi',
+          changed: loop_setting_id_changed? || loop_format_changed?)
+      }
     end
 
     def sort_options

--- a/app/models/concerns/cms/addon/loop_setting_validation.rb
+++ b/app/models/concerns/cms/addon/loop_setting_validation.rb
@@ -1,0 +1,24 @@
+module Cms::Addon::LoopSettingValidation
+  extend ActiveSupport::Concern
+
+  private
+
+  def validate_loop_setting_reference(html_format, changed: loop_setting_id_changed?)
+    return unless changed && loop_setting_id.present?
+
+    setting = Cms::LoopSetting.where(id: loop_setting_id).first
+    unless setting
+      errors.add(:loop_setting_id, :invalid)
+      return
+    end
+
+    valid_site = setting.site_id == site_id
+    valid_type = [nil, 'template'].include?(setting.loop_html_setting_type)
+    valid_format = if html_format == 'liquid'
+                     setting.html_format == 'liquid'
+                   else
+                     [nil, 'shirasagi'].include?(setting.html_format)
+                   end
+    errors.add(:loop_setting_id, :invalid) unless valid_site && valid_type && valid_format
+  end
+end

--- a/app/views/cms/agents/addons/column/layout/_form.html.erb
+++ b/app/views/cms/agents/addons/column/layout/_form.html.erb
@@ -3,7 +3,11 @@
   loop_setting_select_id = "#{addon[:id]}_loop_setting_id"
   snippet_select_id = "#{addon[:id]}_loop_snippet_selector"
 
-  liquid_settings = Cms::LoopSetting.site(@cur_site).liquid
+  # ループHTML設定はサイト管理者専用。権限が無い場合は選択欄を disabled にして変更させない。
+  # disabled な select は送信されないため、既に紐付いている設定はそのまま保持される。
+  loop_setting_editable = Cms::LoopSetting.allowed?(:edit, @cur_user, site: @cur_site)
+
+  liquid_settings = Cms::LoopSetting.site(@cur_site).liquid.allow(:edit, @cur_user, site: @cur_site)
   template_options = liquid_loop_template_options(@item.loop_setting)
   snippet_options = liquid_settings.snippet_type.map { [_1.name, _1.id, { "data-snippet" => _1.html.to_s }] }
 %>
@@ -15,7 +19,7 @@
     <%=
       template_options = render SS::OptionsForSelectComponent.new(options: template_options, selected: @item.loop_setting_id)
       f.select :loop_setting_id, template_options, { include_blank: t('cms.input_directly') },
-               id: loop_setting_select_id, class: 'loop-setting-selector'
+               id: loop_setting_select_id, class: 'loop-setting-selector', disabled: !loop_setting_editable
     %>
     <%= tt("cms.labels.loop_html") %>
   </dd>

--- a/app/views/cms/agents/addons/column/layout/_form.html.erb
+++ b/app/views/cms/agents/addons/column/layout/_form.html.erb
@@ -4,22 +4,21 @@
   snippet_select_id = "#{addon[:id]}_loop_snippet_selector"
 
   liquid_settings = Cms::LoopSetting.site(@cur_site).liquid
-  template_options = liquid_settings.template_type.map { [_1.name, _1.id] }
+  template_options = liquid_loop_template_options(@item.loop_setting)
   snippet_options = liquid_settings.snippet_type.map { [_1.name, _1.id, { "data-snippet" => _1.html.to_s }] }
 %>
 <%= code_editor "##{addon[:id]} .html", mode: :html %>
 
 <dl class="see">
   <dt>HTML<%= @model.tt :layout %></dt>
-  <% if template_options.present? %>
-    <dd>
-      <%=
-        template_options = render SS::OptionsForSelectComponent.new(options: template_options, selected: @item.loop_setting_id)
-        f.select :loop_setting_id, template_options, { include_blank: t('cms.input_directly') }, id: loop_setting_select_id, class: 'loop-setting-selector'
-      %>
-      <%= tt("cms.labels.loop_html") %>
-    </dd>
-  <% end %>
+  <dd>
+    <%=
+      template_options = render SS::OptionsForSelectComponent.new(options: template_options, selected: @item.loop_setting_id)
+      f.select :loop_setting_id, template_options, { include_blank: t('cms.input_directly') },
+               id: loop_setting_select_id, class: 'loop-setting-selector'
+    %>
+    <%= tt("cms.labels.loop_html") %>
+  </dd>
   <dd>
     <%= f.text_area :layout, style: "height: 400px", class: "html" %>
   </dd>

--- a/app/views/cms/agents/addons/layout_html/_form.html.erb
+++ b/app/views/cms/agents/addons/layout_html/_form.html.erb
@@ -6,8 +6,13 @@
 
   # Liquid のスニペット/テンプレート選択は Cms::Form でのみ意味がある (Cms::Form#render_html が loop_setting.html を参照)。
   # Cms::Layout は html を直接レンダリングするため、これらの UI は表示しない。
+
+  # ループHTML設定はサイト管理者専用。権限が無い場合は選択欄を disabled にして変更させない。
+  # disabled な select は送信されないため、既に紐付いている設定はそのまま保持される。
+  loop_setting_editable = Cms::LoopSetting.allowed?(:edit, @cur_user, site: @cur_site)
+
   if show_loop_setting_ui
-    liquid_settings = Cms::LoopSetting.site(@cur_site).liquid
+    liquid_settings = Cms::LoopSetting.site(@cur_site).liquid.allow(:edit, @cur_user, site: @cur_site)
     template_options = liquid_loop_template_options(@item.loop_setting)
     snippet_options = liquid_settings.snippet_type.map { [_1.name, _1.id, { "data-snippet" => _1.html.to_s }] }
   else
@@ -28,7 +33,8 @@
                  template_options,
                  { include_blank: t('cms.input_directly') },
                  id: loop_setting_select_id,
-                 class: 'loop-setting-selector'
+                 class: 'loop-setting-selector',
+                 disabled: !loop_setting_editable
       %>
       <%= tt("cms.labels.loop_html") %>
     </dd>

--- a/app/views/cms/agents/addons/layout_html/_form.html.erb
+++ b/app/views/cms/agents/addons/layout_html/_form.html.erb
@@ -2,12 +2,13 @@
   addon ||= local_assigns.fetch(:addon, {})
   snippet_select_id = "#{addon[:id]}_loop_snippet_selector"
   loop_setting_select_id = "#{addon[:id]}_loop_setting_id"
+  show_loop_setting_ui = @item.is_a?(Cms::Form)
 
   # Liquid のスニペット/テンプレート選択は Cms::Form でのみ意味がある (Cms::Form#render_html が loop_setting.html を参照)。
   # Cms::Layout は html を直接レンダリングするため、これらの UI は表示しない。
-  if @item.is_a?(Cms::Form)
+  if show_loop_setting_ui
     liquid_settings = Cms::LoopSetting.site(@cur_site).liquid
-    template_options = liquid_settings.template_type.map { [_1.name, _1.id] }
+    template_options = liquid_loop_template_options(@item.loop_setting)
     snippet_options = liquid_settings.snippet_type.map { [_1.name, _1.id, { "data-snippet" => _1.html.to_s }] }
   else
     template_options = []
@@ -19,7 +20,7 @@
 
 <dl class="see">
   <dt><%= @model.t :html %><%= @model.tt :html %></dt>
-  <% if template_options.present? %>
+  <% if show_loop_setting_ui %>
     <dd>
       <%=
         template_options = render SS::OptionsForSelectComponent.new(options: template_options, selected: @item.loop_setting_id)

--- a/app/views/cms/agents/addons/page_list/_form.html.erb
+++ b/app/views/cms/agents/addons/page_list/_form.html.erb
@@ -1,5 +1,8 @@
 <% addon ||= local_assigns.fetch(:addon, {}) %>
 <% snippet_select_id = "#{addon[:id]}_loop_snippet_selector" %>
+<%# ループHTML設定はサイト管理者専用。権限が無い場合は選択欄を disabled にして変更させない。 %>
+<%# disabled な select は送信されないため、既に紐付いている設定はそのまま保持される。 %>
+<% loop_setting_editable = Cms::LoopSetting.allowed?(:edit, @cur_user, site: @cur_site) %>
 
 <%= code_editor "##{addon[:id]} .html", mode: :html %>
 <%= jquery do %>
@@ -12,6 +15,7 @@
     <% if @model.use_liquid %>
     var $loopSettingSelectShirasagi = $('#item_loop_setting_id');
     var $loopSettingSelectLiquid = $('#item_loop_setting_id_liquid');
+    var loopSettingEditable = <%= loop_setting_editable %>;
 
     // 設定が0件でも select は常に描画され、未選択（空）なら直接入力として編集可能になる。 i18n-ok
     if ($loopSettingSelectLiquid.length) {
@@ -25,8 +29,8 @@
       $addon.find(".loop-format-shirasagi").toggleClass("hide", isLiquid);
       $addon.find(".loop-format-liquid").toggleClass("hide", !isLiquid);
 
-      $loopSettingSelectShirasagi.prop('disabled', isLiquid);
-      $loopSettingSelectLiquid.prop('disabled', !isLiquid);
+      $loopSettingSelectShirasagi.prop('disabled', isLiquid || !loopSettingEditable);
+      $loopSettingSelectLiquid.prop('disabled', !isLiquid || !loopSettingEditable);
     };
 
     changeLoopFormat();
@@ -99,7 +103,7 @@
       <dd>
         <%= f.select :loop_setting_id, ancestral_loop_settings(@item.loop_setting),
                      { include_blank: t('cms.input_directly') },
-                     disabled: (@item.loop_format == 'liquid') %>
+                     disabled: (@item.loop_format == 'liquid' || !loop_setting_editable) %>
       </dd>
       <dd><%= f.text_area :loop_html, class: :html, style: "height: 100px;" %></dd>
     <% end %>
@@ -123,7 +127,7 @@
 
 <% if @model.use_loop_settings && @model.use_liquid %>
   <%
-    liquid_settings = Cms::LoopSetting.site(@cur_site).liquid
+    liquid_settings = Cms::LoopSetting.site(@cur_site).liquid.allow(:edit, @cur_user, site: @cur_site)
     liquid_snippet_options = liquid_settings.snippet_type.map { [_1.name, _1.id, { "data-snippet" => _1.html.to_s }] }
     liquid_template_options = liquid_loop_template_options(@item.loop_setting)
   %>
@@ -139,7 +143,7 @@
           include_blank: t('cms.input_directly'),
           id: 'item_loop_setting_id_liquid',
           name: 'item[loop_setting_id]',
-          disabled: (@item.loop_format != 'liquid')
+          disabled: (@item.loop_format != 'liquid' || !loop_setting_editable)
         )
       %>
       <%= tt("cms.labels.loop_html") %>

--- a/app/views/cms/agents/addons/page_list/_form.html.erb
+++ b/app/views/cms/agents/addons/page_list/_form.html.erb
@@ -13,8 +13,7 @@
     var $loopSettingSelectShirasagi = $('#item_loop_setting_id');
     var $loopSettingSelectLiquid = $('#item_loop_setting_id_liquid');
 
-    // liquid のループ設定が無いと select 自体が描画されない。
-    // 存在する時だけロックする（無い場合は直接入力で編集可のままにする）。
+    // 設定が0件でも select は常に描画され、未選択（空）なら直接入力として編集可能になる。 i18n-ok
     if ($loopSettingSelectLiquid.length) {
       Cms_Editor_CodeMirror.lock('#item_loop_setting_id_liquid', '#item_loop_liquid');
     }
@@ -97,7 +96,11 @@
 
     <% if @model.use_loop_html %>
       <dt><%= t("cms.loop_html") %><%= @model.tt :loop_html %></dt>
-      <dd><%= f.select :loop_setting_id, ancestral_loop_settings, { include_blank: t('cms.input_directly') }, disabled: (@item.loop_format == 'liquid') %></dd>
+      <dd>
+        <%= f.select :loop_setting_id, ancestral_loop_settings(@item.loop_setting),
+                     { include_blank: t('cms.input_directly') },
+                     disabled: (@item.loop_format == 'liquid') %>
+      </dd>
       <dd><%= f.text_area :loop_html, class: :html, style: "height: 100px;" %></dd>
     <% end %>
 
@@ -122,14 +125,14 @@
   <%
     liquid_settings = Cms::LoopSetting.site(@cur_site).liquid
     liquid_snippet_options = liquid_settings.snippet_type.map { [_1.name, _1.id, { "data-snippet" => _1.html.to_s }] }
-    liquid_template_options = liquid_settings.template_type.map { [_1.name, _1.id] }
+    liquid_template_options = liquid_loop_template_options(@item.loop_setting)
   %>
   <dl class="see loop-format-liquid">
     <dt><%= @model.t :loop_liquid %><%= @model.tt :loop_liquid %></dt>
-    <% if liquid_template_options.present? %>
     <dd>
       <%=
-        liquid_template_options = render SS::OptionsForSelectComponent.new(options: liquid_template_options, selected: @item.loop_setting_id)
+        liquid_template_options = render SS::OptionsForSelectComponent.new(
+          options: liquid_template_options, selected: @item.loop_setting_id)
         select_tag(
           'item[loop_setting_id]',
           liquid_template_options,
@@ -141,7 +144,6 @@
       %>
       <%= tt("cms.labels.loop_html") %>
     </dd>
-    <% end %>
     <dd><%= f.text_area :loop_liquid, class: :html, style: "height: 300px;" %></dd>
     <% if liquid_snippet_options.present? %>
       <dd>

--- a/spec/helpers/cms/form_helper_spec.rb
+++ b/spec/helpers/cms/form_helper_spec.rb
@@ -86,6 +86,31 @@ describe Cms::FormHelper, type: :helper, dbscope: :example do
 
       expect(settings).not_to include([liquid_setting.name, liquid_setting.id])
     end
+
+    # ループHTML設定はサイト管理者専用。権限の無いユーザーには選択肢を出さない。
+    context "with a user who has no permission on loop settings" do
+      let!(:restricted_role) { create(:cms_role, name: unique_id) }
+      let!(:restricted_user) do
+        create(:cms_user, name: unique_id, email: "#{unique_id}@example.jp", in_password: ss_pass,
+          group_ids: [cms_group.id], cms_role_ids: [restricted_role.id])
+      end
+
+      before do
+        @cur_user = restricted_user
+      end
+
+      it "returns no options" do
+        expect(helper.ancestral_loop_settings).to eq []
+      end
+
+      # 現在適用中の設定だけは補完する。補完しないと select が空になり、
+      # 保存時に既存の紐付けが意図せず解除されてしまう。
+      it "supplements only the currently selected setting" do
+        settings = helper.ancestral_loop_settings(shirasagi_setting)
+
+        expect(settings).to eq [[shirasagi_setting.name, shirasagi_setting.id]]
+      end
+    end
   end
 
   describe "#liquid_loop_template_options" do
@@ -123,6 +148,31 @@ describe Cms::FormHelper, type: :helper, dbscope: :example do
       settings = helper.liquid_loop_template_options
 
       expect(settings).to include([liquid_setting.name, liquid_setting.id])
+    end
+
+    # ループHTML設定はサイト管理者専用。権限の無いユーザーには選択肢を出さない。
+    context "with a user who has no permission on loop settings" do
+      let!(:restricted_role) { create(:cms_role, name: unique_id) }
+      let!(:restricted_user) do
+        create(:cms_user, name: unique_id, email: "#{unique_id}@example.jp", in_password: ss_pass,
+          group_ids: [cms_group.id], cms_role_ids: [restricted_role.id])
+      end
+
+      before do
+        @cur_user = restricted_user
+      end
+
+      it "returns no options" do
+        expect(helper.liquid_loop_template_options).to eq []
+      end
+
+      # 現在適用中の設定だけは補完する。補完しないと select が空になり、
+      # 保存時に既存の紐付けが意図せず解除されてしまう。
+      it "supplements only the currently selected setting" do
+        settings = helper.liquid_loop_template_options(liquid_setting)
+
+        expect(settings).to eq [[liquid_setting.name, liquid_setting.id]]
+      end
     end
   end
 

--- a/spec/helpers/cms/form_helper_spec.rb
+++ b/spec/helpers/cms/form_helper_spec.rb
@@ -74,6 +74,56 @@ describe Cms::FormHelper, type: :helper, dbscope: :example do
       closed_names = settings.map { |name, _id| name }
       expect(closed_names).not_to include(closed_setting.name)
     end
+
+    it "supplements a closed shirasagi setting" do
+      settings = helper.ancestral_loop_settings(closed_setting)
+
+      expect(settings).to include([closed_setting.name, closed_setting.id])
+    end
+
+    it "does not supplement a liquid setting" do
+      settings = helper.ancestral_loop_settings(liquid_setting)
+
+      expect(settings).not_to include([liquid_setting.name, liquid_setting.id])
+    end
+  end
+
+  describe "#liquid_loop_template_options" do
+    let!(:user) { cms_user }
+    let!(:site) { cms_site }
+    let!(:liquid_setting) { create(:cms_loop_setting, :liquid, :template_type, site: site) }
+    let!(:shirasagi_setting) { create(:cms_loop_setting, :shirasagi, :template_type, site: site) }
+    let!(:closed_setting) { create(:cms_loop_setting, :liquid, :template_type, site: site, state: "closed") }
+    let!(:snippet_setting) { create(:cms_loop_setting, :liquid, :snippet_type, site: site) }
+
+    before do
+      @cur_site = site
+      @cur_user = user
+    end
+
+    it "does not supplement a shirasagi setting" do
+      settings = helper.liquid_loop_template_options(shirasagi_setting)
+
+      expect(settings).not_to include([shirasagi_setting.name, shirasagi_setting.id])
+    end
+
+    it "supplements a closed liquid setting" do
+      settings = helper.liquid_loop_template_options(closed_setting)
+
+      expect(settings).to include([closed_setting.name, closed_setting.id])
+    end
+
+    it "supplements a liquid snippet setting" do
+      settings = helper.liquid_loop_template_options(snippet_setting)
+
+      expect(settings).to include([snippet_setting.name, snippet_setting.id])
+    end
+
+    it "includes a public liquid template setting" do
+      settings = helper.liquid_loop_template_options
+
+      expect(settings).to include([liquid_setting.name, liquid_setting.id])
+    end
   end
 
   describe "snippet insertion helper functionality" do

--- a/spec/models/cms/addon/loop_setting_validation_spec.rb
+++ b/spec/models/cms/addon/loop_setting_validation_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'loop setting reference validation' do
+  let!(:other_site) { create(:cms_site_unique) }
+  let!(:valid_setting) do
+    create(:cms_loop_setting, :liquid, :template_type, cur_site: site)
+  end
+  let!(:other_site_setting) do
+    create(:cms_loop_setting, :liquid, :template_type, cur_site: other_site)
+  end
+  let!(:snippet_setting) do
+    create(:cms_loop_setting, :liquid, :snippet_type, cur_site: site)
+  end
+  let!(:shirasagi_setting) do
+    create(:cms_loop_setting, :shirasagi, :template_type, cur_site: site)
+  end
+
+  it 'rejects a loop setting from another site' do
+    item.loop_setting_id = other_site_setting.id
+
+    expect(item).not_to be_valid
+    expect(item.errors[:loop_setting_id]).to be_present
+  end
+
+  it 'rejects a snippet setting' do
+    item.loop_setting_id = snippet_setting.id
+
+    expect(item).not_to be_valid
+    expect(item.errors[:loop_setting_id]).to be_present
+  end
+
+  it 'rejects a loop setting whose format does not match' do
+    item.loop_setting_id = shirasagi_setting.id
+
+    expect(item).not_to be_valid
+    expect(item.errors[:loop_setting_id]).to be_present
+  end
+
+  it 'accepts a template setting with the same site and format' do
+    item.reload
+    item.loop_setting_id = valid_setting.id
+
+    expect(item).to be_valid
+    expect(item.errors[:loop_setting_id]).to be_blank
+  end
+
+  it 'does not validate an unchanged invalid loop setting reference' do
+    item.set(loop_setting_id: snippet_setting.id)
+    item.reload
+    item.name = "updated-#{unique_id}"
+
+    expect(item.save).to be true
+    expect(item.errors[:loop_setting_id]).to be_blank
+  end
+end
+
+describe Cms::Addon::LoopSettingValidation, type: :model, dbscope: :example do
+  let!(:site) { cms_site }
+
+  context 'with Cms::Addon::List' do
+    let!(:item) { create(:article_node_page, cur_site: site, loop_format: 'liquid') }
+
+    it_behaves_like 'loop setting reference validation'
+
+    it 'accepts a shirasagi setting when loop_format is shirasagi' do
+      setting = create(:cms_loop_setting, :shirasagi, :template_type, cur_site: site)
+      item.loop_format = 'shirasagi'
+      item.loop_setting_id = setting.id
+
+      expect(item).to be_valid
+      expect(item.errors[:loop_setting_id]).to be_blank
+    end
+
+    it 'rejects changing only loop_format to shirasagi with a liquid setting' do
+      setting = create(:cms_loop_setting, :liquid, :template_type, cur_site: site)
+      item.update!(loop_setting_id: setting.id)
+
+      item.loop_format = 'shirasagi'
+
+      expect(item.save).to be false
+      expect(item.errors[:loop_setting_id]).to be_present
+    end
+
+    it 'rejects changing only loop_format to liquid with a shirasagi setting' do
+      setting = create(:cms_loop_setting, :shirasagi, :template_type, cur_site: site)
+      item.update!(loop_format: 'shirasagi', loop_setting_id: setting.id)
+
+      item.loop_format = 'liquid'
+
+      expect(item.save).to be false
+      expect(item.errors[:loop_setting_id]).to be_present
+    end
+  end
+
+  context 'with Cms::Addon::LayoutHtml' do
+    let!(:item) { create(:cms_form, cur_site: site) }
+
+    it_behaves_like 'loop setting reference validation'
+  end
+
+  context 'with Cms::Addon::Column::Layout' do
+    let!(:form) { create(:cms_form, cur_site: site) }
+    let!(:item) { create(:cms_column_free, cur_site: site, cur_form: form) }
+
+    it_behaves_like 'loop setting reference validation'
+  end
+end

--- a/spec/models/cms/loop_setting_spec.rb
+++ b/spec/models/cms/loop_setting_spec.rb
@@ -275,9 +275,16 @@ describe Cms::LoopSetting, dbscope: :example do
       expect(loop_setting).to be_valid
     end
 
-    it "accepts snippet" do
-      loop_setting = build(:cms_loop_setting, site: site, loop_html_setting_type: "snippet")
+    it "accepts snippet for liquid format" do
+      loop_setting = build(:cms_loop_setting, site: site, html_format: "liquid", loop_html_setting_type: "snippet")
       expect(loop_setting).to be_valid
+      expect(loop_setting.loop_html_setting_type).to eq "snippet"
+    end
+
+    it "normalizes snippet to template for non-liquid format" do
+      loop_setting = build(:cms_loop_setting, site: site, html_format: "shirasagi", loop_html_setting_type: "snippet")
+      expect(loop_setting).to be_valid
+      expect(loop_setting.loop_html_setting_type).to eq "template"
     end
 
     it "accepts blank (backward compatibility)" do
@@ -289,6 +296,24 @@ describe Cms::LoopSetting, dbscope: :example do
       loop_setting = build(:cms_loop_setting, site: site, loop_html_setting_type: "invalid")
       expect(loop_setting).not_to be_valid
       expect(loop_setting.errors[:loop_html_setting_type]).to include(I18n.t('errors.messages.inclusion'))
+    end
+
+    it "normalizes an inconsistent shirasagi snippet record on the next save" do
+      loop_setting = create(:cms_loop_setting, :shirasagi, :template_type, site: site)
+
+      # コールバックを迂回し、既存DBに存在し得る矛盾データを再現する
+      loop_setting.set(loop_html_setting_type: "snippet")
+      loop_setting.reload
+
+      expect(loop_setting.loop_html_setting_type).to eq "snippet"
+      expect(described_class.site(site).snippet_type).to include(loop_setting)
+
+      loop_setting.save!
+      loop_setting.reload
+
+      expect(loop_setting.loop_html_setting_type).to eq "template"
+      expect(described_class.site(site).snippet_type).not_to include(loop_setting)
+      expect(described_class.site(site).template_type).to include(loop_setting)
     end
   end
 


### PR DESCRIPTION
- [ ] 動作確認をしたか？
- [ ] ドキュメントやコメントを書いたか？

## 概要

## 変更内容

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ループ設定の選択肢が、編集権限や形式に応じて適切に絞り込まれるようになりました。
  - 権限がない場合も、既存のループ設定との紐付けは保持され、選択欄は無効化されます。
  - Shirasagi形式とLiquid形式の設定を正しく選択・管理できるようになりました。

- **不具合修正**
  - 別サイトの設定や形式が一致しない設定の参照を保存時に検出します。
  - Shirasagi形式で不適切な設定種別が自動的に正規化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->