### PR TITLE
[modify] ロケール（とタイムゾーン）を確実にリセット

### DIFF
--- a/app/controllers/concerns/cms/public_filter.rb
+++ b/app/controllers/concerns/cms/public_filter.rb
@@ -6,6 +6,7 @@ module Cms::PublicFilter
 
   included do
     rescue_from StandardError, with: :rescue_action
+    before_action :ensure_default_locale
     before_action :ensure_site_presence
     before_action :set_request_path
     #before_action :redirect_slash, if: ->{ request.env["REQUEST_PATH"] =~ /\/[^\.]+[^\/]$/ }
@@ -38,6 +39,10 @@ module Cms::PublicFilter
   end
 
   private
+
+  def ensure_default_locale
+    SS.reset_locale_and_timezone # cms and webmail are currently not supported.
+  end
 
   def ensure_site_presence
     return if @cur_site

--- a/app/controllers/concerns/ss/base_filter.rb
+++ b/app/controllers/concerns/ss/base_filter.rb
@@ -13,12 +13,12 @@ module SS::BaseFilter
     helper SS::EditorHelper
     helper SS::JbuilderHelper
     helper_method :logout_path
+    prepend_around_action :reset_locale_and_timezone
     before_action :set_model
     before_action :set_setting
     before_action :set_ss_assets
     before_action :logged_in?
     before_action :check_api_user
-    after_action :reset_locale_and_timezone
     rescue_from StandardError, with: :rescue_action
     layout "ss/base"
   end
@@ -199,7 +199,11 @@ module SS::BaseFilter
     raise "403"
   end
 
-  delegate :reset_locale_and_timezone, to: SS
+  def reset_locale_and_timezone
+    yield
+  ensure
+    SS.reset_locale_and_timezone
+  end
 
   def logout_path
     @logout_path ||= session[:logout_path].presence || sns_logout_path

--- a/app/controllers/concerns/ss/base_filter.rb
+++ b/app/controllers/concerns/ss/base_filter.rb
@@ -18,6 +18,7 @@ module SS::BaseFilter
     before_action :set_ss_assets
     before_action :logged_in?
     before_action :check_api_user
+    after_action :reset_locale_and_timezone
     rescue_from StandardError, with: :rescue_action
     layout "ss/base"
   end
@@ -197,6 +198,8 @@ module SS::BaseFilter
     # api user only allowd .json
     raise "403"
   end
+
+  delegate :reset_locale_and_timezone, to: SS
 
   def logout_path
     @logout_path ||= session[:logout_path].presence || sns_logout_path

--- a/spec/features/member/agents/nodes/bookmark_spec.rb
+++ b/spec/features/member/agents/nodes/bookmark_spec.rb
@@ -21,6 +21,14 @@ describe 'members/agents/nodes/bookmark', type: :feature, dbscope: :example, js:
   let!(:article_page) { create :article_page, cur_node: article_node, layout_id: layout1.id }
 
   describe 'without member login' do
+    before do
+      logout_member(site, login_node)
+    end
+
+    after do
+      logout_member(site, login_node)
+    end
+
     it do
       visit article_page.url
       within ".favorite" do
@@ -34,12 +42,12 @@ describe 'members/agents/nodes/bookmark', type: :feature, dbscope: :example, js:
       end
       expect(page).to have_css(".favorite", text: I18n.t("member.links.register_bookmark"))
       expect(current_path).to eq article_page.url
-      logout_member(site, login_node)
     end
   end
 
   describe 'with member login' do
     before do
+      logout_member(site, login_node)
       login_member(site, login_node)
     end
 

--- a/spec/features/workflow/pull_up_spec.rb
+++ b/spec/features/workflow/pull_up_spec.rb
@@ -120,15 +120,21 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
 
     context "intermediate user pulls up a request" do
       it do
-        login_cms_user
-        visit show_path
+        login_cms_user to: show_path
+        wait_for_all_turbo_frames
+        wait_for_all_ckeditors_ready
 
         #
         # admin: send request
         #
         within ".mod-workflow-request" do
+          expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
+
           select route_name, from: "workflow_route"
           click_on I18n.t("workflow.buttons.select")
+
+          wait_for_js_ready
+          expect(page).to have_css(".request-setting", text: route_name)
 
           fill_in "workflow[comment]", with: workflow_comment
           click_on I18n.t("workflow.buttons.request")
@@ -166,8 +172,12 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         # user2: pull up request
         #
         login_user user2, to: show_path
+        wait_for_all_turbo_frames
+        wait_for_all_ckeditors_ready
 
         within ".mod-workflow-approve" do
+          expect(page).to have_content(I18n.t("ss.options.state.public"))
+
           fill_in "remand[comment]", with: approve_comment2
           click_on I18n.t("workflow.buttons.pull_up")
         end
@@ -208,15 +218,21 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
 
     context "last user pulls up a request. this is most usual case" do
       it do
-        login_cms_user
-        visit show_path
+        login_cms_user to: show_path
+        wait_for_all_turbo_frames
+        wait_for_all_ckeditors_ready
 
         #
         # admin: send request
         #
         within ".mod-workflow-request" do
+          expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
+
           select route_name, from: "workflow_route"
           click_on I18n.t("workflow.buttons.select")
+
+          wait_for_js_ready
+          expect(page).to have_css(".request-setting", text: route_name)
 
           fill_in "workflow[comment]", with: workflow_comment
           click_on I18n.t("workflow.buttons.request")
@@ -254,8 +270,12 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         # user3: pull up request, he is the last one
         #
         login_user user3, to: show_path
+        wait_for_all_turbo_frames
+        wait_for_all_ckeditors_ready
 
         within ".mod-workflow-approve" do
+          expect(page).to have_content(I18n.t("ss.options.state.public"))
+
           fill_in "remand[comment]", with: approve_comment3
           click_on I18n.t("workflow.buttons.pull_up")
         end
@@ -291,13 +311,16 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
 
     context "intermediate user pulls up a request" do
       it do
-        login_cms_user
-        visit show_path
+        login_cms_user to: show_path
+        wait_for_all_turbo_frames
+        wait_for_all_ckeditors_ready
 
         #
         # admin: send request
         #
         within ".mod-workflow-request" do
+          expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
+
           select route_name, from: "workflow_route"
           click_on I18n.t("workflow.buttons.select")
 
@@ -337,8 +360,12 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         # user2: pull up request
         #
         login_user user2, to: show_path
+        wait_for_all_turbo_frames
+        wait_for_all_ckeditors_ready
 
         within ".mod-workflow-approve" do
+          expect(page).to have_content(I18n.t("ss.options.state.public"))
+
           fill_in "remand[comment]", with: approve_comment2
           click_on I18n.t("workflow.buttons.pull_up")
         end

--- a/spec/features/workflow/pull_up_spec.rb
+++ b/spec/features/workflow/pull_up_spec.rb
@@ -44,8 +44,13 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
         # admin: send request
         #
         within ".mod-workflow-request" do
+          expect(page).to have_css("#workflow_route", text: I18n.t("mongoid.attributes.workflow/model/route.my_group"))
+
           select route_name, from: "workflow_route"
           click_on I18n.t("workflow.buttons.select")
+
+          wait_for_js_ready
+          expect(page).to have_css(".request-setting", text: route_name)
 
           fill_in "workflow[comment]", with: workflow_comment
           click_on I18n.t("workflow.buttons.request")
@@ -323,6 +328,9 @@ describe "pull_up", type: :feature, dbscope: :example, js: true do
 
           select route_name, from: "workflow_route"
           click_on I18n.t("workflow.buttons.select")
+
+          wait_for_js_ready
+          expect(page).to have_css(".request-setting", text: route_name)
 
           fill_in "workflow[comment]", with: workflow_comment
           click_on I18n.t("workflow.buttons.request")

--- a/spec/support/cms/member.rb
+++ b/spec/support/cms/member.rb
@@ -12,7 +12,7 @@ def login_member(site, node, member = cms_member(site: site))
   within 'form.form-login' do
     fill_in 'item[email]', with: member.email
     fill_in 'item[password]', with: member.in_password
-    click_button 'ログイン'
+    click_button I18n.t("ss.login")
   end
   expect(page).to have_no_css('.member-login-box [name="item[password]"]')
 rescue => e


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

公開画面のテストが失敗することがたまにある。
どうやら英語ロケールで公開画面が描画されているようだ。

原因は不明だけど、管理画面に英語に設定されているユーザーがログインすると、
シラサギ内部が英語のままとなることが分かった。

確実に既定のロケールへリセットされるようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ページ表示後に言語・タイムゾーン設定が意図せず残る問題を修正しました。
  - 例外発生時も設定が適切にリセットされるよう改善しました。
  - ログイン状態や承認操作に関連する表示・動作の安定性を改善しました。

- **テスト**
  - 未ログイン時のブックマーク操作に関する検証を強化しました。
  - ワークフローの承認操作、グループ表示、選択内容の確認を追加しました。
  - 多言語環境でのログイン操作に対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->