### PR TITLE
[modify][cms] ダウンロード通知に機能名/フォルダー名を追加

### DIFF
--- a/app/jobs/article/page/export_job.rb
+++ b/app/jobs/article/page/export_job.rb
@@ -36,6 +36,10 @@ class Article::Page::ExportJob < Cms::ApplicationJob
     Cms::PageExporter.new(mode: "article", site: site, truncate: truncate, criteria: criteria)
   end
 
+  def notification_subject
+    "[#{site.name}][#{node.name}] CSVダウンロード準備完了のお知らせ"
+  end
+
   def canonical_scheme
     site.mypage_scheme.presence || (site.https == "enabled" ? "https" : "http")
   end

--- a/app/jobs/cms/all_contents_export_job.rb
+++ b/app/jobs/cms/all_contents_export_job.rb
@@ -18,6 +18,10 @@ class Cms::AllContentsExportJob < Cms::ApplicationJob
     Cms::AllContent.new(site: site, truncate: truncate)
   end
 
+  def notification_subject
+    "[#{site.name}][#{I18n.t("cms.all_contents")} #{I18n.t("cms.all_content.download_tab")}] CSVダウンロード準備完了のお知らせ"
+  end
+
   def canonical_scheme
     site.mypage_scheme.presence || (site.https == "enabled" ? "https" : "http")
   end

--- a/app/jobs/concerns/ss/csv_export_base.rb
+++ b/app/jobs/concerns/ss/csv_export_base.rb
@@ -47,6 +47,10 @@ module SS::CsvExportBase
     SS.config.gws.canonical_domain
   end
 
+  def notification_subject
+    raise NotImplementedError, "サブクラスで実装してください"
+  end
+
   def send_notification!
     return unless respond_to?(:user)
     return unless user
@@ -58,11 +62,7 @@ module SS::CsvExportBase
     message.cur_user = user
     message.member_ids = [ user.id ]
     message.send_date = Time.zone.now
-    if respond_to?(:site) && site
-      message.subject = "[#{site.name}] CSVダウンロード準備完了のお知らせ"
-    else
-      message.subject = "CSVダウンロード準備完了のお知らせ"
-    end
+    message.subject = notification_subject
     message.format = 'text'
     message.text = <<~TEXT
       ダウンロードの準備が完了しました。

--- a/spec/features/article/pages/download_spec.rb
+++ b/spec/features/article/pages/download_spec.rb
@@ -54,7 +54,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
       expect(notification.group_id).to be_blank
       expect(notification.member_ids).to eq [ cms_user.id ]
       expect(notification.user_id).to eq cms_user.id
-      expect(notification.subject).to eq "[#{site.name}] CSVダウンロード準備完了のお知らせ"
+      expect(notification.subject).to eq "[#{site.name}][#{node.name}] CSVダウンロード準備完了のお知らせ"
       expect(notification.text).to be_present
       path = Rails.application.routes.url_helpers.sns_apis_file_gen_task_download_path(id: task)
       expect(notification.text).to include(path)
@@ -117,7 +117,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
       expect(notification.group_id).to be_blank
       expect(notification.member_ids).to eq [ cms_user.id ]
       expect(notification.user_id).to eq cms_user.id
-      expect(notification.subject).to eq "[#{site.name}] CSVダウンロード準備完了のお知らせ"
+      expect(notification.subject).to eq "[#{site.name}][#{node.name}] CSVダウンロード準備完了のお知らせ"
       expect(notification.text).to be_present
       path = Rails.application.routes.url_helpers.sns_apis_file_gen_task_download_path(id: task)
       expect(notification.text).to include(path)
@@ -180,7 +180,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
       expect(notification.group_id).to be_blank
       expect(notification.member_ids).to eq [ cms_user.id ]
       expect(notification.user_id).to eq cms_user.id
-      expect(notification.subject).to eq "[#{site.name}] CSVダウンロード準備完了のお知らせ"
+      expect(notification.subject).to eq "[#{site.name}][#{node.name}] CSVダウンロード準備完了のお知らせ"
       expect(notification.text).to be_present
       path = Rails.application.routes.url_helpers.sns_apis_file_gen_task_download_path(id: task)
       expect(notification.text).to include(path)
@@ -244,7 +244,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
       expect(notification.group_id).to be_blank
       expect(notification.member_ids).to eq [ cms_user.id ]
       expect(notification.user_id).to eq cms_user.id
-      expect(notification.subject).to eq "[#{site.name}] CSVダウンロード準備完了のお知らせ"
+      expect(notification.subject).to eq "[#{site.name}][#{node.name}] CSVダウンロード準備完了のお知らせ"
       expect(notification.text).to be_present
       path = Rails.application.routes.url_helpers.sns_apis_file_gen_task_download_path(id: task)
       expect(notification.text).to include(path)
@@ -324,7 +324,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
         expect(notification.group_id).to be_blank
         expect(notification.member_ids).to eq [ cms_user.id ]
         expect(notification.user_id).to eq cms_user.id
-        expect(notification.subject).to eq "[#{site.name}] CSVダウンロード準備完了のお知らせ"
+        expect(notification.subject).to eq "[#{site.name}][#{node.name}] CSVダウンロード準備完了のお知らせ"
         expect(notification.text).to be_present
         path = Rails.application.routes.url_helpers.sns_apis_file_gen_task_download_path(id: task)
         expect(notification.text).to include(path)
@@ -415,7 +415,7 @@ describe "article_pages", type: :feature, dbscope: :example, js: true do
         expect(notification.group_id).to be_blank
         expect(notification.member_ids).to eq [ cms_user.id ]
         expect(notification.user_id).to eq cms_user.id
-        expect(notification.subject).to eq "[#{site.name}] CSVダウンロード準備完了のお知らせ"
+        expect(notification.subject).to eq "[#{site.name}][#{node.name}] CSVダウンロード準備完了のお知らせ"
         expect(notification.text).to be_present
         path = Rails.application.routes.url_helpers.sns_apis_file_gen_task_download_path(id: task)
         expect(notification.text).to include(path)

--- a/spec/features/cms/all_contents/download_all_spec.rb
+++ b/spec/features/cms/all_contents/download_all_spec.rb
@@ -48,7 +48,8 @@ describe "cms_all_contents", type: :feature, dbscope: :example, js: true do
       expect(notification.group_id).to be_blank
       expect(notification.member_ids).to eq [ user.id ]
       expect(notification.user_id).to eq user.id
-      expect(notification.subject).to eq "[#{site.name}] CSVダウンロード準備完了のお知らせ"
+      subject = "[#{site.name}][#{I18n.t("cms.all_contents")} #{I18n.t("cms.all_content.download_tab")}] CSVダウンロード準備完了のお知らせ"
+      expect(notification.subject).to eq subject
       expect(notification.text).to be_present
       path = Rails.application.routes.url_helpers.sns_apis_file_gen_task_download_path(id: task)
       expect(notification.text).to include(path)


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * CSVダウンロード完了通知の件名に、対象のノード名を表示するようになりました。
  * 全コンテンツのダウンロード通知では、「全コンテンツ」「ダウンロード」の情報を件名に含めるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->