### PR TITLE
[modify] タブなどによるフォーカス移動時、sticky裏に回り込まないようにする変更

### DIFF
--- a/app/assets/stylesheets/ss/_sticky.scss
+++ b/app/assets/stylesheets/ss/_sticky.scss
@@ -13,6 +13,10 @@
   @media screen and (max-width: 768px) {
     margin: 0 auto;
   }
+
+  select, input, textarea, button {
+    scroll-margin-bottom: unset;
+  }
 }
 
 .ss-sticky {
@@ -38,4 +42,10 @@
 // footer.send の padding に負けないように
 footer.send.ss-sticky {
   @include ss-sticky;
+}
+
+body:has(.ss-sticky-bottom) {
+  a, button, input, select, textarea {
+    scroll-margin-bottom: 120px;
+  }
 }

--- a/app/assets/stylesheets/ss/_sticky.scss
+++ b/app/assets/stylesheets/ss/_sticky.scss
@@ -14,7 +14,7 @@
     margin: 0 auto;
   }
 
-  select, input, textarea, button {
+  a, button, input, select, textarea {
     scroll-margin-bottom: unset;
   }
 }


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 画面下部に固定表示される要素がある場合、リンクやフォーム要素へスクロールした際に、固定要素と重なりにくくなるよう表示位置を調整しました。
  - セレクトボックス、入力欄、テキストエリア、ボタンのスクロール位置も適切に処理されるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->