### PR TITLE
[fix] cms column value free clone_files

### DIFF
--- a/app/models/cms/column/value/free.rb
+++ b/app/models/cms/column/value/free.rb
@@ -101,13 +101,20 @@ class Cms::Column::Value::Free < Cms::Column::Value::Base
 
       cloned_file_ids << clone_file.id
 
-      cloned_value = self.value.to_s
-      cloned_value.gsub!("=\"#{source_file.url}\"", "=\"#{clone_file.url}\"")
-      cloned_value.gsub!("=\"#{source_file.thumb_url}\"", "=\"#{clone_file.thumb_url}\"")
-      self.value = cloned_value
+      update_html_with_clone_file(source_file, clone_file)
     end
 
     self.file_ids = cloned_file_ids
+  end
+
+  def update_html_with_clone_file(old_file, new_file)
+    cloned_value = self.value.to_s
+
+    return if cloned_value.blank?
+
+    cloned_value.gsub!("=\"#{old_file.url}\"", "=\"#{new_file.url}\"")
+    cloned_value.gsub!("=\"#{old_file.thumb_url}\"", "=\"#{new_file.thumb_url}\"")
+    self.value = cloned_value
   end
 
   def save_files
@@ -172,7 +179,7 @@ class Cms::Column::Value::Free < Cms::Column::Value::Base
 
   def set_contains_urls
     if value.blank?
-      self.contains_urls.clear if self.contains_urls.present?
+      self.contains_urls.presence&.clear
     else
       begin
         self.contains_urls = value.scan(/(?:href|src)="(.*?)"/).flatten.uniq.compact.collect(&:strip)

--- a/app/models/cms/column/value/free.rb
+++ b/app/models/cms/column/value/free.rb
@@ -101,20 +101,10 @@ class Cms::Column::Value::Free < Cms::Column::Value::Base
 
       cloned_file_ids << clone_file.id
 
-      update_html_with_clone_file(source_file, clone_file)
+      update_value_with_clone_file(source_file, clone_file)
     end
 
     self.file_ids = cloned_file_ids
-  end
-
-  def update_html_with_clone_file(old_file, new_file)
-    cloned_value = self.value.to_s
-
-    return if cloned_value.blank?
-
-    cloned_value.gsub!("=\"#{old_file.url}\"", "=\"#{new_file.url}\"")
-    cloned_value.gsub!("=\"#{old_file.thumb_url}\"", "=\"#{new_file.thumb_url}\"")
-    self.value = cloned_value
   end
 
   def save_files
@@ -179,7 +169,8 @@ class Cms::Column::Value::Free < Cms::Column::Value::Base
 
   def set_contains_urls
     if value.blank?
-      self.contains_urls.presence&.clear
+      # self.contains_urls = self.fields['contains_urls'].default_val
+      self.contains_urls = []
     else
       begin
         self.contains_urls = value.scan(/(?:href|src)="(.*?)"/).flatten.uniq.compact.collect(&:strip)

--- a/spec/features/article/pages/clone_with_form_spec.rb
+++ b/spec/features/article/pages/clone_with_form_spec.rb
@@ -120,5 +120,126 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
         end
       end
     end
+
+    context 'with free' do
+      let!(:column3) { create(:cms_column_free, cur_site: site, cur_form: form, required: 'optional') }
+
+      it do
+        visit new_article_page_path(site: site, cid: node, form_id: form.id)
+        wait_for_all_ckeditors_ready
+        wait_for_all_turbo_frames
+
+        within 'form#item-form' do
+          fill_in 'item[name]', with: name
+          fill_in 'item[index_name]', with: index_name
+          within first(".column-value-cms-column-textfield") do
+            fill_in "item[column_values][][in_wrap][value]", with: column1_value
+          end
+          within first(".column-value-cms-column-free") do
+            fill_in_ckeditor "item[column_values][][in_wrap][value]", with: unique_id
+          end
+
+          ss_upload_file "#{Rails.root}/spec/fixtures/ss/logo.png", addon: ".column-value-cms-column-free"
+
+          expect(page).to have_css('.file-view', text: 'logo')
+          click_on I18n.t('ss.buttons.publish_save')
+        end
+
+        wait_for_notice I18n.t('ss.notice.saved')
+        wait_for_all_ckeditors_ready
+        wait_for_all_turbo_frames
+
+        expect(Article::Page.all.count).to eq 1
+        Article::Page.all.find_by(name: name).tap do |item|
+          expect(item.column_values.length).to eq 2
+          item.column_values.where(column_id: column3.id).first.tap do |column_value|
+            expect(column_value.file_ids).not_to be_nil
+          end
+        end
+
+        visit article_pages_path(site: site, cid: node)
+        click_on name
+        wait_for_all_ckeditors_ready
+        wait_for_all_turbo_frames
+
+        click_on I18n.t('ss.links.copy')
+
+        within 'form#item-form' do
+          click_on I18n.t('ss.buttons.save')
+        end
+        wait_for_notice I18n.t('ss.notice.saved')
+        expect(Article::Page.all.count).to eq 2
+
+        visit article_pages_path(site: site, cid: node)
+        click_on "[#{I18n.t('workflow.cloned_name_prefix')}] #{name}"
+        expect(page).to have_content(column1_value)
+
+        Article::Page.all.find_by(name: "[#{I18n.t('workflow.cloned_name_prefix')}] #{name}").tap do |item|
+          expect(item.index_name).to eq "[#{I18n.t('workflow.cloned_name_prefix')}] #{index_name}"
+          expect(item.column_values.length).to eq 2
+          item.column_values.where(column_id: column3.id).first.tap do |column_value|
+            expect(column_value.file_ids).not_to be_nil
+          end
+        end
+      end
+
+      context "when html is blank" do
+        it do
+          visit new_article_page_path(site: site, cid: node, form_id: form.id)
+          wait_for_all_ckeditors_ready
+          wait_for_all_turbo_frames
+
+          within 'form#item-form' do
+            fill_in 'item[name]', with: name
+            fill_in 'item[index_name]', with: index_name
+            within first(".column-value-cms-column-textfield") do
+              fill_in "item[column_values][][in_wrap][value]", with: column1_value
+            end
+
+            ss_upload_file "#{Rails.root}/spec/fixtures/ss/logo.png", addon: ".column-value-cms-column-free"
+
+            expect(page).to have_css('.file-view', text: 'logo')
+            click_on I18n.t('ss.buttons.publish_save')
+          end
+
+          wait_for_notice I18n.t('ss.notice.saved')
+          wait_for_all_ckeditors_ready
+          wait_for_all_turbo_frames
+
+          expect(Article::Page.all.count).to eq 1
+          Article::Page.all.find_by(name: name).tap do |item|
+            expect(item.column_values.length).to eq 2
+            item.column_values.where(column_id: column3.id).first.tap do |column_value|
+              expect(column_value.file_ids).not_to be_nil
+            end
+          end
+
+          visit article_pages_path(site: site, cid: node)
+          click_on name
+          wait_for_all_ckeditors_ready
+          wait_for_all_turbo_frames
+
+          click_on I18n.t('ss.links.copy')
+
+          within 'form#item-form' do
+            click_on I18n.t('ss.buttons.save')
+          end
+          wait_for_notice I18n.t('ss.notice.saved')
+          expect(Article::Page.all.count).to eq 2
+
+          visit article_pages_path(site: site, cid: node)
+          click_on "[#{I18n.t('workflow.cloned_name_prefix')}] #{name}"
+          expect(page).to have_content(column1_value)
+
+          Article::Page.all.find_by(name: "[#{I18n.t('workflow.cloned_name_prefix')}] #{name}").tap do |item|
+            expect(item.index_name).to eq "[#{I18n.t('workflow.cloned_name_prefix')}] #{index_name}"
+            expect(item.column_values.length).to eq 2
+            item.column_values.where(column_id: column3.id).first.tap do |column_value|
+              expect(column_value.file_ids).not_to be_nil
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/features/article/pages/clone_with_form_spec.rb
+++ b/spec/features/article/pages/clone_with_form_spec.rb
@@ -154,6 +154,7 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
           expect(item.column_values.length).to eq 2
           item.column_values.where(column_id: column3.id).first.tap do |column_value|
             expect(column_value.file_ids).not_to be_nil
+            @source_file_id = column_value.files.pick(:id)
           end
         end
 
@@ -179,6 +180,8 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
           expect(item.column_values.length).to eq 2
           item.column_values.where(column_id: column3.id).first.tap do |column_value|
             expect(column_value.file_ids).not_to be_nil
+            # cloned file has individual file id
+            expect(column_value.file_ids).not_to eq [ @source_file_id ]
           end
         end
       end
@@ -211,6 +214,7 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
             expect(item.column_values.length).to eq 2
             item.column_values.where(column_id: column3.id).first.tap do |column_value|
               expect(column_value.file_ids).not_to be_nil
+              @source_file_id = column_value.files.pick(:id)
             end
           end
 
@@ -236,6 +240,8 @@ describe 'article_pages', type: :feature, dbscope: :example, js: true do
             expect(item.column_values.length).to eq 2
             item.column_values.where(column_id: column3.id).first.tap do |column_value|
               expect(column_value.file_ids).not_to be_nil
+              # cloned file has individual file id
+              expect(column_value.file_ids).not_to eq [ @source_file_id ]
             end
           end
         end


### PR DESCRIPTION
- [x] 動作確認をしたか？
- [x] ドキュメントやコメントを書いたか？

## 概要

定型フォームの自由入力のHTMLが空かつファイルが添付されている場合にページを複製できない不具合の修正。

## 変更内容

複製の処理の修正。

## その他

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **不具合修正**
  * フォーム付き記事ページの複製時、フリー（CKEditor）カラム内の値とアップロードファイルが正しく引き継がれるようになりました。
  * HTMLが空でファイルのみ登録されている場合も、ファイル情報が保持されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->